### PR TITLE
Remove link to GitHub repo from sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Generate and serve the documentation at `localhost:1313`:
 hugo server -b localhost:1313 -w
 ```
 
-For further information please have a look at our contribution guide [here](https://docs.kubermatic.io/contributing/contributing/).
+For further information please have a look at our contribution guide [here](/content/contributing).

--- a/config.toml
+++ b/config.toml
@@ -49,12 +49,6 @@ weight = 2
 languageName = "German"
 
 [[menu.shortcuts]]
-name = "<i class='fab fa-github'></i> Github"
-identifier = "ds"
-url = "https://github.com/kubermatic/docs"
-weight = 10
-
-[[menu.shortcuts]]
 name = "<i class='fa fa-globe'></i> Kubermatic.io"
 url = "https://kubermatic.io"
 weight = 15


### PR DESCRIPTION
This PR:

- Removes a link to this (private) repo from the sidebar.
- Fixes link to the contributing guide in the README.