### PR TITLE
begin 2.12 upgrade notes with cert-manager 0.9

### DIFF
--- a/content/upgrading/2.11_to_2.12/_index.en.md
+++ b/content/upgrading/2.11_to_2.12/_index.en.md
@@ -20,7 +20,7 @@ re-installs the CRDs):
 
 ```bash
 $ helm --tiller-namespace kubermatic-installer delete --purge cert-manager
-$ kubectl get crd | awk '{ print $1 }' | grep certmanager | xargs kubectl delete crd
+$ kubectl get crd | awk '/certmanager/ {print $1}' | xargs kubectl delete crd
 
 $ cd kubermatic-installer/charts/cert-manager
 $ helm --tiller-namespace kubermatic-installer upgrade --install --namespace cert-manager --values YOUR_VALUES_YAML_HERE cert-manager .


### PR DESCRIPTION
The new cert-manager requires manual upgrade steps. This documents these steps. @thz you seemed like you recently walked through the upgrade nodes for 2.11 and may know if this PR is helpful enough.