### PR TITLE
Replaced AWS policy with a new cleaned up version.

### DIFF
--- a/content/requirements/cloud_provider/_aws.en.md
+++ b/content/requirements/cloud_provider/_aws.en.md
@@ -17,22 +17,22 @@ pre = "<b></b>"
         {
             "Effect": "Allow",
             "Action": [
-                "iam:ListInstanceProfiles",
-                "iam:GetInstanceProfile"
+                "iam:GetInstanceProfile",
+                "iam:ListInstanceProfiles"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/*"
         },
         {
             "Effect": "Allow",
             "Action": [
-                "iam:GetRole",
-                "iam:PutRolePolicy",
-                "iam:PassRole",
-                "iam:ListRolePolicies",
-                "iam:ListAttachedRolePolicies",
-                "iam:DeleteRolePolicy",
                 "iam:CreateRole",
-                "iam:DeleteRole"
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "iam:PassRole",
+                "iam:PutRolePolicy"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"
         },
@@ -40,10 +40,10 @@ pre = "<b></b>"
             "Effect": "Allow",
             "Action": [
                 "iam:AddRoleToInstanceProfile",
-                "iam:RemoveRoleFromInstanceProfile",
-                "iam:GetInstanceProfile",
                 "iam:CreateInstanceProfile",
-                "iam:DeleteInstanceProfile"
+                "iam:DeleteInstanceProfile",
+                "iam:GetInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/kubernetes-*"
         },


### PR DESCRIPTION
This policy has been tested on Kubermatic against AWS both in the cases where we don't specify an instance profile and in the case we do. Cluster creation was successful, deletion also.

**Without specifying an instance profile**

![Screenshot from 2019-09-17 15-19-10](https://user-images.githubusercontent.com/4869961/65320948-4da01600-dba3-11e9-9e3c-2d1991d46d1a.png)

**Specifying an instance profile**

The instance profile we used has the following minimal AWS role attached:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "ec2:DescribeInstances",
                "ec2:DescribeRegions"
            ],
            "Resource": [
                "*"
            ]
        }
    ]
}
```

![Screenshot from 2019-09-17 17-07-19](https://user-images.githubusercontent.com/4869961/65321126-b091ad00-dba3-11e9-9bcf-2aa78cda3d7d.png)

Both cases show positive results while checking cluster status via CLI:

```
➜ kubectl --kubeconfig kubeconfig-admin-r57szlnpvc get nodes
NAME                                            STATUS   ROLES    AGE     VERSION
ip-xxx-xx-x-xxx.eu-central-1.compute.internal   Ready    <none>   3m20s   v1.14.6
➜ kubectl --kubeconfig kubeconfig-admin-r57szlnpvc get pod -A
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   canal-nkz57                             2/2     Running   0          3m44s
kube-system   coredns-fdb754d8d-8fkkt                 1/1     Running   0          7m3s
kube-system   coredns-fdb754d8d-br7hr                 1/1     Running   0          7m3s
kube-system   kube-proxy-62r4c                        1/1     Running   0          3m44s
kube-system   kubernetes-dashboard-57dcd9448b-4qssq   1/1     Running   0          7m3s
kube-system   node-exporter-clz55                     2/2     Running   0          3m44s
kube-system   node-local-dns-lpzk6                    1/1     Running   0          3m14s
kube-system   openvpn-client-67d8b4755f-bqg5m         2/2     Running   0          7m3s
```