### PR TITLE
Described the case in which we use an instance profile

### DIFF
--- a/content/requirements/cloud_provider/_aws.en.md
+++ b/content/requirements/cloud_provider/_aws.en.md
@@ -117,6 +117,11 @@ Ensure that the user used to create clusters via Kubermatic has (atleast) the fo
         },
         {
             "Effect": "Allow",
+            "Action": "iam:PassRole",
+            "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_WORKER_INSTANCE_PROFILE_NAME"
+        },
+        {
+            "Effect": "Allow",
             "Action": [
                 "ec2:*",
                 "elasticloadbalancing:CreateListener",
@@ -150,7 +155,7 @@ Ensure that the user used to create clusters via Kubermatic has (atleast) the fo
 }
 ```
 
-The instance profile for the worker nodes must have at least the following IAM permissions:
+The instance profile for the worker (referenced above as `YOUR_WORKER_INSTANCE_PROFILE_NAME`) nodes must have at least the following IAM permissions:
 
 ```json
 {

--- a/content/requirements/cloud_provider/_aws.en.md
+++ b/content/requirements/cloud_provider/_aws.en.md
@@ -7,14 +7,15 @@ pre = "<b></b>"
 
 ## AWS
 
-A valid user with specific IAM permissions is required if we want to create cluster via Kubermatic. The permissions of this user can be more or less restrictive, this depends if we specify an instance profile or not for the worker nodes.
+A valid user with specific IAM permissions is required if we want to create cluster via Kubermatic.
 
-In the first case we privileges to create instance profiles in the second we don't as far as we supply an already a given instance profile name.
+As a general rule of thumb we can identify two scenarios, in the first one the specified IAM user, we are using on AWS, has enough privileges to create a new instance profile plus role and a second case where we specify an already existing instance profile and control plane role for the worker nodes.
 
-Ensure that the user used to create clusters via Kubermatic has (atleast) the following IAM permissions, depending on the case (Click to expand)
+
+Ensure that the user used to create clusters via Kubermatic has (atleast) the following IAM permissions, depending on the two uses cases (Click to expand)
 
 <details>
-<summary>**When not specifying an instance profile:** </summary>
+<summary>**Kubermatic will create an instance profile and control plane role:** </summary>
 
 ```json
 {
@@ -90,7 +91,7 @@ Ensure that the user used to create clusters via Kubermatic has (atleast) the fo
 </details>
 
 <details>
-<summary>**When specifying an instance profile:** </summary>
+<summary>**We specify an existing instance profile and control plane role (ARN):** </summary>
 
 ```json
 {
@@ -99,26 +100,12 @@ Ensure that the user used to create clusters via Kubermatic has (atleast) the fo
         {
             "Effect": "Allow",
             "Action": "iam:GetInstanceProfile",
-            "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateRole",
-                "iam:DeleteRole",
-                "iam:DeleteRolePolicy",
-                "iam:GetRole",
-                "iam:ListAttachedRolePolicies",
-                "iam:ListRolePolicies",
-                "iam:PassRole",
-                "iam:PutRolePolicy"
-            ],
-            "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"
+            "Resource": "arn:aws:iam::733553989067:instance-profile/*"
         },
         {
             "Effect": "Allow",
             "Action": "iam:PassRole",
-            "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_WORKER_INSTANCE_PROFILE_NAME"
+            "Resource": "arn:aws:iam::733553989067:role/*"
         },
         {
             "Effect": "Allow",
@@ -155,7 +142,7 @@ Ensure that the user used to create clusters via Kubermatic has (atleast) the fo
 }
 ```
 
-The instance profile for the worker (referenced above as `YOUR_WORKER_INSTANCE_PROFILE_NAME`) nodes must have at least the following IAM permissions:
+The instance profile for the worker nodes must have at least the following IAM permissions:
 
 ```json
 {

--- a/content/requirements/cloud_provider/_aws.en.md
+++ b/content/requirements/cloud_provider/_aws.en.md
@@ -7,8 +7,14 @@ pre = "<b></b>"
 
 ## AWS
 
+A valid user with specific IAM permissions is required if we want to create cluster via Kubermatic. The permissions of this user can be more or less restrictive, this depends if we specify an instance profile or not for the worker nodes.
+
+In the first case we privileges to create instance profiles in the second we don't as far as we supply an already a given instance profile name.
+
+Ensure that the user used to create clusters via Kubermatic has (atleast) the following IAM permissions, depending on the case (Click to expand)
+
 <details>
-<summary>**Ensure that the user used to create clusters via Kubermatic has (atleast) the following IAM permissions (Click to expand):** </summary>
+<summary>**When not specifying an instance profile:** </summary>
 
 ```json
 {
@@ -75,6 +81,86 @@ pre = "<b></b>"
                 "elasticloadbalancing:SetSubnets",
                 "elasticloadbalancing:SetWebAcl",
                 "sts:GetFederationToken"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+</details>
+
+<details>
+<summary>**When specifying an instance profile:** </summary>
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "iam:GetInstanceProfile",
+            "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "iam:PassRole",
+                "iam:PutRolePolicy"
+            ],
+            "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:*",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:DeleteRule",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetRulePriorities",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:SetWebAcl",
+                "sts:GetFederationToken"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+The instance profile for the worker nodes must have at least the following IAM permissions:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeRegions"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
I've extended the AWS documentation in order to describe the case in which we specify an instance profile in the Kubermatic UI and the case in which we don't. The attached policies have been tested to be the minimal requirements for creating and deleting a cluster in both cases, all worker nodes come up correctly also in case of instance profile specification:

```
kubectl --kubeconfig ~/Downloads/kubeconfig-admin-d8slrcptlf get nodes 
NAME                                            STATUS   ROLES    AGE   VERSION
ip-172-31-13-40.eu-central-1.compute.internal   Ready    <none>   52s   v1.14.7
kubectl --kubeconfig ~/Downloads/kubeconfig-admin-d8slrcptlf get pod -A
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   canal-dhfn6                             2/2     Running   0          67s
kube-system   coredns-fdb754d8d-5jbfs                 1/1     Running   0          5m5s
kube-system   coredns-fdb754d8d-b4l5f                 1/1     Running   0          5m5s
kube-system   kube-proxy-xk2lf                        1/1     Running   0          67s
kube-system   kubernetes-dashboard-57dcd9448b-jn4qx   1/1     Running   0          4m45s
kube-system   node-exporter-zpxs8                     2/2     Running   0          66s
kube-system   node-local-dns-m6gzm                    1/1     Running   0          46s
kube-system   openvpn-client-67d8b4755f-jv6mt         1/2     Running   0          5m5s
```