### PR TITLE
Velero Release Notes for Kubermatic 2.12

### DIFF
--- a/content/upgrading/2.11_to_2.12/_index.en.md
+++ b/content/upgrading/2.11_to_2.12/_index.en.md
@@ -10,7 +10,7 @@ pre = "<b></b>"
 
 ### cert-manager
 
-Kubermatic 2.12 ships with cert-manager 0.9, which changed the api versions for its manifests. This requires
+Kubermatic 2.12 ships with cert-manager 0.10, which changed the api versions for its manifests. This requires
 manual intervention and a short time frame where no certificates can be created when upgrading. Before upgrading,
 create a backup of all cert-manager resources (certificates, issuers, ...) because their CRDs will have to be
 recreated.


### PR DESCRIPTION
This mentions how to deal with the removed backup schedules. I chose to not propose Thanos as a replacement because we still have Thanos support in "kind of beta".