### PR TITLE
fixed chapter numbers

### DIFF
--- a/content/changelog/_index.en.md
+++ b/content/changelog/_index.en.md
@@ -3,9 +3,9 @@ title = "Changelog"
 date =  2018-10-17T14:35:34+02:00
 weight = 110
 chapter = true
-pre = "<b>9. </b>"
+pre = "<b>10. </b>"
 +++
 
-### Chapter 9
+### Chapter 10
 
 The Kubermatic changelog

--- a/content/contributing/_index.en.md
+++ b/content/contributing/_index.en.md
@@ -3,11 +3,11 @@ title = "Contributing"
 date = 2018-04-28T12:07:15+02:00
 weight = 100
 chapter = true
-pre = "<b>8. </b>"
+pre = "<b>9. </b>"
 draft = true
 +++
 
-### Chapter 8
+### Chapter 9
 
 # Contributing
 

--- a/content/tutorials/_index.en.md
+++ b/content/tutorials/_index.en.md
@@ -3,10 +3,10 @@ title = "Tutorials"
 date =  2019-10-04T17:35:34+02:00
 weight = 120
 chapter = true
-pre = "<b>10. </b>"
+pre = "<b>11. </b>"
 +++
 
-### Chapter 10
+### Chapter 11
 
 # Tutorials
 


### PR DESCRIPTION
There was a duplicate chapter numbering in the kubermatic docs ( there was two 8s in a row). 

This PR fixes it.