### PR TITLE
fix: remove "-m" as kubeone install flag

### DIFF
--- a/content/kubeone/master/getting_started/aws.en.md
+++ b/content/kubeone/master/getting_started/aws.en.md
@@ -189,7 +189,7 @@ Finally, we're going to install Kubernetes by running the following `install`
 command and providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the Terraform state file is in the current working directory

--- a/content/kubeone/master/getting_started/azure.en.md
+++ b/content/kubeone/master/getting_started/azure.en.md
@@ -208,7 +208,7 @@ Finally, we're going to install Kubernetes by running the following `install`
 command and providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the Terraform state file is in the current working directory

--- a/content/kubeone/master/getting_started/digitalocean.en.md
+++ b/content/kubeone/master/getting_started/digitalocean.en.md
@@ -184,7 +184,7 @@ Finally, we're going to install Kubernetes by using the `install`
 command and providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the Terraform state file is in the current working directory

--- a/content/kubeone/master/getting_started/gce.en.md
+++ b/content/kubeone/master/getting_started/gce.en.md
@@ -202,7 +202,7 @@ Finally, we're going to install Kubernetes by using the `install` command and
 providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the terraform state file is in the current working directory

--- a/content/kubeone/master/getting_started/hetzner.en.md
+++ b/content/kubeone/master/getting_started/hetzner.en.md
@@ -173,7 +173,7 @@ Finally, we're going to install Kubernetes by using the `install` command and
 providing the configuration file:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the terraform state file is in the current working directory

--- a/content/kubeone/master/getting_started/openstack.en.md
+++ b/content/kubeone/master/getting_started/openstack.en.md
@@ -204,7 +204,7 @@ Finally, we're going to install Kubernetes by using the `install` command and
 providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the terraform state file is in the current working directory

--- a/content/kubeone/master/getting_started/packet.en.md
+++ b/content/kubeone/master/getting_started/packet.en.md
@@ -202,7 +202,7 @@ Finally, we're going to install Kubernetes by using the `install` command and
 providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the terraform state file is in the current working directory
@@ -212,7 +212,7 @@ The installation process takes some time, usually 5-10 minutes. The output
 should look like the following one:
 
 ```
-$ kubeone install -m config.yaml -t tf.json
+$ kubeone install config.yaml -t tf.json
 INFO[14:19:46 EEST] Installing prerequisites…
 INFO[14:19:47 EEST] Determine operating system…                   node=147.75.80.241
 INFO[14:19:47 EEST] Determine hostname…                           node=147.75.80.241

--- a/content/kubeone/master/getting_started/vsphere.en.md
+++ b/content/kubeone/master/getting_started/vsphere.en.md
@@ -223,7 +223,7 @@ Finally, we're going to install Kubernetes by using the `install` command and
 providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the terraform state file is in the current working directory
@@ -233,7 +233,7 @@ The installation process takes some time, usually 5-10 minutes. The output
 should look like the following one:
 
 ```
-$ kubeone install -m config.yaml -t tf.json
+$ kubeone install config.yaml -t tf.json
 INFO[13:15:31 EEST] Installing prerequisites…
 INFO[13:15:32 EEST] Determine operating system…                   node=192.168.11.142
 INFO[13:15:33 EEST] Determine operating system…                   node=192.168.11.139


### PR DESCRIPTION
"-m" is not supported by kubeone install but used in documentation