### PR TITLE
Fixed KubeOne doc

### DIFF
--- a/content/kubeone/master/_index.en.md
+++ b/content/kubeone/master/_index.en.md
@@ -57,6 +57,17 @@ invoke it from your terminal.
 sudo mv kubeone_<version>_<operating_system>_amd64/kubeone /usr/local/bin
 ```
 
+For a quick way to install the lastest version of KubeOne, use
+the following commands:
+
+```bash
+OS=$(uname)
+VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/kubermatic/kubeone/releases/latest -o /dev/null | sed -e 's|.*/v||')
+curl -LO "https://github.com/kubermatic/kubeone/releases/download/v${VERSION}/kubeone_${VERSION}_${OS}_amd64.zip"
+unzip kubeone_${VERSION}_${OS}_amd64.zip -d kubeone_${VERSION}_${OS}_amd64
+sudo mv kubeone_${VERSION}_${OS}_amd64/kubeone /usr/local/bin
+```
+
 ### Building KubeOne
 
 The alternative way to install KubeOne is using `go get`.

--- a/content/kubeone/master/getting_started/aws.en.md
+++ b/content/kubeone/master/getting_started/aws.en.md
@@ -189,7 +189,7 @@ Finally, we're going to install Kubernetes by running the following `install`
 command and providing the configuration file and the Terraform output:
 
 ```bash
-kubeone install -m config.yaml --tfjson <DIR-WITH-tfstate-FILE>
+kubeone install config.yaml --tfjson <DIR-WITH-tfstate-FILE>
 ```
 
 Alternatively, if the Terraform state file is in the current working directory

--- a/content/kubermatic/master/installation/install_kubernetes/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubernetes/_index.en.md
@@ -7,7 +7,7 @@ weight = 10
 
 To aid in setting up the seed and master clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/) which can be used to set up a highly-available Kubernetes cluster.
 
-Refer to the [KubeOne readme](https://github.com/kubermatic/kubeone/) and [documentation](https://github.com/kubermatic/kubeone/tree/master/docs) for details on
+Refer to the [KubeOne readme](https://github.com/kubermatic/kubeone/) and [documentation](https://docs.kubermatic.com/kubeone/master/) for details on
 how to use it.
 
 Please take note of the [recommended hardware and networking requirements](../../requirements/cluster_requirements/) before provisioning a cluster.


### PR DESCRIPTION
This PR includes three fixes/improvements to the KubeOne documentation:

-  The quick way of installing KubeOne, taken from the GitHub repo readme file.

-  Fixed the command in the AWS quick start. The "-m" flag is not valid with the latest stable release.

- Fixed the link in the Kubermatic doc that was pointing the docs folder of the GitHub repo instead of the documentation website.