### PR TITLE
change make preview to docker based setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 preview:
-	hugo server -D -F
+	docker run -it --name kubermatic-docs --rm \
+		-p 1313:1313 \
+		-v `pwd`:/docs quay.io/kubermatic/hugo:0.71.1-0 \
+		 bash -c 'cd docs; hugo server -D -F --bind 0.0.0.0'
 
 runbook:
 	./hack/convert-runbook.sh


### PR DESCRIPTION
To make it for user more easy to start and get rid of any installation of hugo the `Makefile` have been modified to a docker based command.