### PR TITLE
fixes of missing config in EE version

### DIFF
--- a/content/kubermatic/master/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubermatic/_index.en.md
@@ -143,6 +143,9 @@ dex:
     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
 kubermaticOperator:
+  image:
+    # image id for EE version
+    repository: "quay.io/kubermatic/kubermatic-ee"
   # insert the Docker authentication JSON provided by Loodse here
   imagePullSecret: |
     {
@@ -252,6 +255,10 @@ spec:
     # this domain must match what you configured as dex.ingress.host
     # in the values.yaml
     domain: kubermatic.example.com
+    # issuer of `nginx-ingress-controller` 
+    # execute: kubectl get clusterissuers
+    certificateIssuer:
+      name: letsencrypt-prod
 
   # These secret keys configure the way components commmunicate with Dex.
   auth:

--- a/content/kubermatic/v2.14/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.14/installation/install_kubermatic/_index.en.md
@@ -141,6 +141,9 @@ dex:
     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
 kubermaticOperator:
+  image:
+    # image id for EE version
+    repository: "quay.io/kubermatic/kubermatic-ee"
   # insert the Docker authentication JSON provided by Loodse here
   imagePullSecret: |
     {
@@ -247,6 +250,10 @@ spec:
     # this domain must match what you configured as dex.ingress.host
     # in the values.yaml
     domain: kubermatic.example.com
+    # issuer of `nginx-ingress-controller` 
+    # execute: kubectl get clusterissuers
+    certificateIssuer:
+      name: letsencrypt-prod
 
   # These secret keys configure the way components commmunicate with Dex.
   auth:


### PR DESCRIPTION
- image name for ee version
- missing certificate issuer spec for kubermatic configuration

Discovered during test installation with latest images:
```
quay.io/kubermatic/dashboard-ee:e4a7535bf0253fb6d5a397a72e35c5d7d4591658
quay.io/kubermatic/kubermatic-ee:2acfea59bc2edb09ccbecf119b0d99e5c7e95538
```