### PR TITLE
Remove nodeport-proxy helm chart

### DIFF
--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -162,12 +162,12 @@ on the seed.
 #### With LoadBalancers
 
 When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
-`nodeport-lb` Service:
+`nodeport-proxy` Service:
 
 ```bash
-kubectl -n nodeport-proxy get services
+kubectl -n kubermatic get services
 #NAME          TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nodeport-lb   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
+#nodeport-proxy   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
 ```
 
 The `EXTERNAL-IP` is what we need to put into the DNS record.

--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -40,26 +40,6 @@ kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admi
 helm --service-account tiller --tiller-namespace kubermatic init
 ```
 
-#### NodePort Proxy
-
-Kubermatic requires the NodePort Proxy to be installed in each seed cluster. The proxy is shipped as a
-[Helm](https://helm.sh) chart in the kubermatic-installer repository.
-
-As the NodePort Proxy Docker image is in a private registry, you need to configure the Docker Pull Secret for
-the Helm chart. You can re-use the `values.yaml` used during the installation or create new one and configure it like
-so:
-
-```yaml
-kubermaticOperator:
-  # insert the Docker authentication JSON provided by Loodse here
-  imagePullSecret: |
-    {
-      "auths": {
-        "quay.io": {....}
-      }
-    }
-```
-
 #### Cluster Backups
 
 Kubermatic performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
@@ -96,7 +76,6 @@ With this you can install the chart:
 
 ```bash
 cd kubermatic-installer
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace nodeport-proxy nodeport-proxy charts/nodeport-proxy/
 helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
 helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace s3-exporter s3-exporter charts/s3-exporter/
 ```

--- a/content/kubermatic/master/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubermatic/_index.en.md
@@ -95,7 +95,7 @@ Kubermatic ships with a number of Helm charts that need to be installed into the
 built so they can be configured using a single, shared `values.yaml` file. The required charts are
 
 * **Master cluster:** cert-manager, nginx-ingress-controller, oauth(, iap)
-* **Seed cluster:** nodeport-proxy, minio, s3-exporter
+* **Seed cluster:** minio, s3-exporter
 
 There are additional charts for the [monitoring]({{< ref "../monitoring_stack" >}}) and [logging stack]({{< ref "../logging_stack" >}})
 which will be discussed in their dedicated chapters, as they are not strictly required for running Kubermatic.

--- a/content/kubermatic/v2.14/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/v2.14/installation/add_seed_cluster/_index.en.md
@@ -162,12 +162,12 @@ on the seed.
 #### With LoadBalancers
 
 When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
-`nodeport-lb` Service:
+`nodeport-proxy` Service:
 
 ```bash
-kubectl -n nodeport-proxy get services
+kubectl -n kubermatic get services
 #NAME          TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nodeport-lb   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
+#nodeport-proxy   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
 ```
 
 The `EXTERNAL-IP` is what we need to put into the DNS record.

--- a/content/kubermatic/v2.14/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/v2.14/installation/add_seed_cluster/_index.en.md
@@ -40,26 +40,6 @@ kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admi
 helm --service-account tiller --tiller-namespace kubermatic init
 ```
 
-#### NodePort Proxy
-
-Kubermatic requires the NodePort Proxy to be installed in each seed cluster. The proxy is shipped as a
-[Helm](https://helm.sh) chart in the kubermatic-installer repository.
-
-As the NodePort Proxy Docker image is in a private registry, you need to configure the Docker Pull Secret for
-the Helm chart. You can re-use the `values.yaml` used during the installation or create new one and configure it like
-so:
-
-```yaml
-kubermaticOperator:
-  # insert the Docker authentication JSON provided by Loodse here
-  imagePullSecret: |
-    {
-      "auths": {
-        "quay.io": {....}
-      }
-    }
-```
-
 #### Cluster Backups
 
 Kubermatic performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
@@ -96,7 +76,6 @@ With this you can install the chart:
 
 ```bash
 cd kubermatic-installer
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace nodeport-proxy nodeport-proxy charts/nodeport-proxy/
 helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
 helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace s3-exporter s3-exporter charts/s3-exporter/
 ```

--- a/content/kubermatic/v2.14/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.14/installation/install_kubermatic/_index.en.md
@@ -95,7 +95,7 @@ Kubermatic ships with a number of Helm charts that need to be installed into the
 built so they can be configured using a single, shared `values.yaml` file. The required charts are
 
 * **Master cluster:** cert-manager, nginx-ingress-controller, oauth(, iap)
-* **Seed cluster:** nodeport-proxy, minio, s3-exporter
+* **Seed cluster:** minio, s3-exporter
 
 There are additional charts for the [monitoring]({{< ref "../monitoring_stack" >}}) and [logging stack]({{< ref "../logging_stack" >}})
 which will be discussed in their dedicated chapters, as they are not strictly required for running Kubermatic.


### PR DESCRIPTION
Currently, when installing nodeport-proxy following the documentation, nodeport-proxy gets deployed twice: by the operator, and later when installing the helm chart. 

With AWS, this leads to issues as the "helm chart" nodeport-proxy LB doesn't get assigned an external IP, and coupled with https://github.com/kubermatic/kubermatic/pull/5609, the communication between the userclusters and control planes are not possible.

As we are moving to the operator install, I've removed the whole nodeport-proxy helm chart section so we get only one clean installation.