### PR TITLE
Update the installation manual to cope with the kubermatic-installer repo cleanup

### DIFF
--- a/content/kubermatic/v2.12/installation/install_kubermatic/_installer.en.md
+++ b/content/kubermatic/v2.12/installation/install_kubermatic/_installer.en.md
@@ -7,6 +7,10 @@ weight = 10
 
 Using the installer is the recommended way of installing Kubermatic into your cluster. It provides a simple web wizard for configuration and automates the installation of all required components.
 
+{{% notice note %}}
+At the moment you need to be invited to get access to Kubermatic's Docker registry before you can try it out. Please [contact sales](mailto:sales@loodse.com) to receive your credentials.
+{{% /notice %}}
+
 ## Quickstart
 
 The installer is available via Docker and can be run by

--- a/content/kubermatic/v2.12/installation/install_kubermatic/_manual.en.md
+++ b/content/kubermatic/v2.12/installation/install_kubermatic/_manual.en.md
@@ -5,6 +5,11 @@ weight = 20
 
 +++
 
+{{% notice warning %}}
+With [Cleanup kubermatic-installer repo](https://github.com/kubermatic/kubermatic/issues/5026) the installer repository is no longer public available.
+This installation manual is kept for reference and those who have access to the installer repository.
+{{% /notice %}}
+
 ### Clone the Installer
 
 Clone the [installer repository](https://github.com/kubermatic/kubermatic-installer) to your disk and make sure to

--- a/content/kubermatic/v2.13/installation/install_kubermatic/_installer.en.md
+++ b/content/kubermatic/v2.13/installation/install_kubermatic/_installer.en.md
@@ -7,6 +7,10 @@ weight = 10
 
 Using the installer is the recommended way of installing Kubermatic into your cluster. It provides a simple web wizard for configuration and automates the installation of all required components.
 
+{{% notice note %}}
+At the moment you need to be invited to get access to Kubermatic's Docker registry before you can try it out. Please [contact sales](mailto:sales@loodse.com) to receive your credentials.
+{{% /notice %}}
+
 ## Quickstart
 
 The installer is available via Docker and can be run by

--- a/content/kubermatic/v2.13/installation/install_kubermatic/_manual.en.md
+++ b/content/kubermatic/v2.13/installation/install_kubermatic/_manual.en.md
@@ -5,6 +5,11 @@ weight = 20
 
 +++
 
+{{% notice warning %}}
+With [Cleanup kubermatic-installer repo](https://github.com/kubermatic/kubermatic/issues/5026) the installer repository is no longer public available.
+This installation manual is kept for reference and those who have access to the installer repository.
+{{% /notice %}}
+
 ### Clone the Installer
 
 Clone the [installer repository](https://github.com/kubermatic/kubermatic-installer) to your disk and make sure to


### PR DESCRIPTION
The  kubermatic-installer repository is no longer public available.

The installation manual of v2.12 and 2.13 is updated to reflect the installer repository is no longer public available and the installation manual is kept for reference and those who have access to the installer repository.

Next to the manual installation update a notice is added to clarify you need access to Kubermatic's Docker registry to be able to use the installer.

Signed-off-by: Peter Hordijk <hordijk@users.noreply.github.com>