### PR TITLE
Fix the KubeOne docs URL in the Install HA-Kubernetes document

### DIFF
--- a/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
@@ -24,7 +24,7 @@ master/seed setup.
 
 To aid in setting up the seed and master clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/),
 which can be used to set up a highly-available Kubernetes cluster. Refer to the [KubeOne readme](https://github.com/kubermatic/kubeone/)
-and [docs](https://github.com/kubermatic/kubeone/tree/master/docs) for details on how to use it.
+and [docs](/kubeone) for details on how to use it.
 
 Please take note of the [recommended hardware and networking requirements](../../requirements/cluster_requirements/)
 before provisioning a cluster.

--- a/content/kubermatic/v2.14/installation/install_kubernetes/_index.en.md
+++ b/content/kubermatic/v2.14/installation/install_kubernetes/_index.en.md
@@ -7,7 +7,7 @@ weight = 10
 
 To aid in setting up the seed and master clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/) which can be used to set up a highly-available Kubernetes cluster.
 
-Refer to the [KubeOne readme](https://github.com/kubermatic/kubeone/) and [documentation](https://github.com/kubermatic/kubeone/tree/master/docs) for details on
+Refer to the [KubeOne readme](https://github.com/kubermatic/kubeone/) and [documentation](/kubeone) for details on
 how to use it.
 
 Please take note of the [recommended hardware and networking requirements](../../requirements/cluster_requirements/) before provisioning a cluster.


### PR DESCRIPTION
We have migrated all KubeOne user documentation from GitHub to the docs website, so I believe it makes more sense to point the docs website directly.

There are some references to docs on the GitHub in Kubermatic docs for v2.12, but I'm not sure do we still update those docs or not.

cc @irozzo-1A @youssefazrak @mskarbe 