### PR TITLE
Upgrade notes for CNI

### DIFF
--- a/content/kubermatic/master/upgrading/2.11_to_2.12/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.11_to_2.12/_index.en.md
@@ -46,7 +46,7 @@ In v2.12, we are upgrading Flannel to v0.11.0 which lead to NetworkPolicies not 
 Flannel doesn't detect some iptables rules and flush the appropriate rules.
 
 To avoid any failures on the cluster, you need to apply on each node of the
-user clusters the following two commands:
+user clusters the following two commands, assuming the Pods CIDR is 172.25.0.0/16:
 
 ```bash
 iptables -t nat -D POSTROUTING -s 172.25.0.0/16 ! -d 224.0.0.0/4 -j MASQUERADE

--- a/content/kubermatic/master/upgrading/2.11_to_2.12/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.11_to_2.12/_index.en.md
@@ -38,3 +38,19 @@ kubectl apply -f schedules.yaml
 ```
 
 This change does not affect user cluster etcds, which are stilled backed up regularly.
+
+
+### CNI
+
+In v2.12, we are upgrading Flannel to v0.11.0 which lead to NetworkPolicies not working properly.
+Flannel doesn't detect some iptables rules and flush the appropriate rules.
+
+To avoid any failures on the cluster, you need to apply on each node of the
+user clusters the following two commands:
+
+```bash
+iptables -t nat -D POSTROUTING -s 172.25.0.0/16 ! -d 224.0.0.0/4 -j MASQUERADE
+iptables -t nat -D POSTROUTING ! -s 172.25.0.0/16 -d 172.25.0.0/16 -j MASQUERADE 
+```
+
+For more details about this issue, please check [the following link](https://github.com/projectcalico/calico/issues/2898)


### PR DESCRIPTION
When upgrading to Kubermatic v2.12, Flannel version is bumped to v0.11 which has an issue when detecting/flushing the iptables of the nat table/POSTROUTING chain.

This leads to having communication broken when using NetworkPolicies and Pods trying to reach each other on different nodes.

This PR introduces a small note on the upgrade document for 2.11 > 2.12 with a workaround.