### PR TITLE
Remove experimental warnings from seed and kubermaticconfiguration docs

### DIFF
--- a/content/kubermatic/master/concepts/kubermaticconfiguration/_index.en.md
+++ b/content/kubermatic/master/concepts/kubermaticconfiguration/_index.en.md
@@ -10,11 +10,6 @@ weight = 20
 The KubermaticConfiguration CustomResourceDefinition is used for configuring the Kubermatic Operator and
 replaces what previously was done with the `values.yaml` for the Kubermatic Helm chart.
 
-{{% notice warning %}}
-The operator is not yet considered ready for production use. Likewise, the CRD structure is not yet
-finalized and changes may occur at any time.
-{{% /notice %}}
-
 The following is an example configuration, showing all possible options. Note that all fields that you
 don't define explicitly are always defaulted to these values.
 

--- a/content/kubermatic/master/concepts/seeds/_index.en.md
+++ b/content/kubermatic/master/concepts/seeds/_index.en.md
@@ -11,10 +11,6 @@ The Seed CustomResourceDefinition replaces the legacy [`datacenters.yaml`]({{< r
 a more flexible, dynamic way of managing seed clusters. Seeds can be added and removed at runtime by simply
 managing Seed resources inside the [master cluster]({{< ref "../architecture" >}}).
 
-{{% notice note %}}
-**Note:** This feature is **experimental** and not enabled by default.
-{{% /notice %}}
-
 ### Example Seed
 
 The following is an example Seed, showing all possible options.

--- a/content/kubermatic/master/data/kubermaticConfiguration.yaml
+++ b/content/kubermatic/master/data/kubermaticConfiguration.yaml
@@ -8,11 +8,12 @@ spec:
   api:
     # AccessibleAddons is a list of addons that should be enabled in the API.
     accessibleAddons:
-    - node-exporter
+      - node-exporter
+      - gatekeeper
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -81,7 +82,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic master-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the master-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -90,7 +91,7 @@ spec:
       # DryRun makes the migrator only log the actions it would take.
       dryRun: false
     # Replicas sets the number of pod replicas for the master-controller-manager.
-    replicas: 2
+    replicas: 1
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.
@@ -105,6 +106,23 @@ spec:
       requests:
         cpu: 50m
         memory: 128Mi
+  # Proxy allows to configure Kubermatic to use proxies to talk to the
+  # world outside of its cluster.
+  proxy:
+    # HTTP is the full URL to the proxy to use for plaintext HTTP
+    # connections, e.g. "http://internalproxy.example.com:8080".
+    http: ""
+    # HTTPS is the full URL to the proxy to use for encrypted HTTPS
+    # connections, e.g. "http://secureinternalproxy.example.com:8080".
+    https: ""
+    # NoProxy is a comma-separated list of hostnames / network masks
+    # for which no proxy shall be used. If you make use of proxies,
+    # this list should contain all local and cluster-internal domains
+    # and networks, e.g. "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,mydomain".
+    # The operator will always prepend the following elements to this
+    # list if proxying is configured (i.e. HTTP/HTTPS are not empty):
+    # "127.0.0.1/8", "localhost", ".local", ".local.", "kubernetes", ".default", ".svc"
+    noProxy: ""
   # SeedController configures the seed-controller-manager.
   seedController:
     # BackupCleanupContainer is the container used for removing expired backups from the storage location.
@@ -168,12 +186,12 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic seed-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
     # Replicas sets the number of pod replicas for the seed-controller-manager.
-    replicas: 2
+    replicas: 1
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.
@@ -196,7 +214,7 @@ spec:
         "share_kubeconfig": false
       }
     # DockerRepository is the repository containing the Kubermatic dashboard image.
-    dockerRepository: quay.io/kubermatic/ui-v2
+    dockerRepository: quay.io/kubermatic/dashboard
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.
@@ -232,26 +250,32 @@ spec:
             kind: Addon
             metadata:
               name: canal
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: csi
-          - apiVersion: kubermatic.k8s.io/v1
-            kind: Addon
-            metadata:
-              name: dns
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: kube-proxy
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: openvpn
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: rbac
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
@@ -263,15 +287,15 @@ spec:
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
-              name: nodelocal-dns-cache
-          - apiVersion: kubermatic.k8s.io/v1
-            kind: Addon
-            metadata:
               name: pod-security-policy
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: logrotate
+              labels:
+                addons.kubermatic.io/ensure: true
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/addons
@@ -337,7 +361,7 @@ spec:
     # EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
     etcdVolumeSize: 5Gi
     # KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
-    kubermaticDockerRepository: quay.io/kubermatic/api
+    kubermaticDockerRepository: quay.io/kubermatic/kubermatic
     # Monitoring can be used to fine-tune to in-cluster Prometheus.
     monitoring:
       # CustomRules can be used to inject custom recording and alerting rules. This field
@@ -367,7 +391,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.15.10
+      default: 1.17.9
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -378,70 +402,62 @@ spec:
       # updates as well. 'automaticNodeUpdate: true' implies 'automatic: true' as well,
       # because Nodes may not have a newer version than the controlplane.
       updates:
-      - # Automatic controls whether this update is executed automatically
-        # for the control plane of all matching user clusters.
-        automatic: false
-        # Automatic controls whether this update is executed automatically
-        # for the worker nodes of all matching user clusters.
-        automaticNodeUpdate: false
-        # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.12.*".
-        from: 1.12.*
-        # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.13.*".
-        to: 1.13.*
-      - automatic: true
-        from: <= 1.13.9, >= 1.13.0
-        to: 1.13.10
-      - from: 1.13.*
-        to: 1.14.*
-      - from: 1.14.*
-        to: 1.14.*
-      - automatic: true
-        from: <= 1.14.7, >= 1.14.0
-        to: 1.14.8
-      - from: 1.14.*
-        to: 1.15.*
-      - from: 1.15.*
-        to: 1.15.*
-      - automatic: true
-        from: <= 1.15.4, >= 1.15.0
-        to: 1.15.5
-      - automatic: true
-        from: 1.15.8
-        to: 1.15.9
-      - from: 1.15.*
-        to: 1.16.*
-      - from: 1.16.*
-        to: 1.16.*
-      - automatic: true
-        from: <= 1.16.1, >= 1.16.0
-        to: 1.16.2
-      - automatic: true
-        from: 1.16.5
-        to: 1.16.6
-      - from: 1.16.*
-        to: 1.17.*
-      - from: 1.17.*
-        to: 1.17.*
-      - automatic: true
-        from: 1.17.1
-        to: 1.17.2
-      - from: 1.17.*
-        to: 1.18.*
+        - # Automatic controls whether this update is executed automatically
+          # for the control plane of all matching user clusters.
+          automatic: false
+          # Automatic controls whether this update is executed automatically
+          # for the worker nodes of all matching user clusters.
+          automaticNodeUpdate: false
+          # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          from: 1.14.*
+          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          to: 1.14.*
+        - automatic: true
+          from: <= 1.14.7, >= 1.14.0
+          to: 1.14.8
+        - from: 1.14.*
+          to: 1.15.*
+        - from: 1.15.*
+          to: 1.15.*
+        - automatic: true
+          from: <= 1.15.4, >= 1.15.0
+          to: 1.15.5
+        - automatic: true
+          from: 1.15.8
+          to: 1.15.9
+        - from: 1.15.*
+          to: 1.16.*
+        - from: 1.16.*
+          to: 1.16.*
+        - automatic: true
+          from: <= 1.16.12, >= 1.16.0
+          to: 1.16.13
+        - from: 1.16.*
+          to: 1.17.*
+        - from: 1.17.*
+          to: 1.17.*
+        - automatic: true
+          from: <= 1.17.8, >= 1.17.0
+          to: 1.17.9
+        - from: 1.17.*
+          to: 1.18.*
+        - from: 1.18.*
+          to: 1.18.*
+        - automatic: true
+          from: <= 1.18.5, >= 1.18.0
+          to: 1.18.6
       # Versions lists the available versions.
       versions:
-      - 1.15.5
-      - 1.15.6
-      - 1.15.7
-      - 1.15.9
-      - 1.15.10
-      - 1.16.2
-      - 1.16.3
-      - 1.16.4
-      - 1.16.6
-      - 1.16.7
-      - 1.17.0
-      - 1.17.2
-      - 1.17.3
+        - 1.15.5
+        - 1.15.6
+        - 1.15.7
+        - 1.15.9
+        - 1.15.10
+        - 1.15.11
+        - 1.15.12
+        - 1.16.13
+        - 1.17.9
+        - 1.18.6
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.
@@ -456,22 +472,22 @@ spec:
       # updates as well. 'automaticNodeUpdate: true' implies 'automatic: true' as well,
       # because Nodes may not have a newer version than the controlplane.
       updates:
-      - # Automatic controls whether this update is executed automatically
-        # for the control plane of all matching user clusters.
-        automatic: false
-        # Automatic controls whether this update is executed automatically
-        # for the worker nodes of all matching user clusters.
-        automaticNodeUpdate: false
-        # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.12.*".
-        from: 4.1.*
-        # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.13.*".
-        to: 4.1.*
-      - from: 4.1.*
-        to: 2.2.*
+        - # Automatic controls whether this update is executed automatically
+          # for the control plane of all matching user clusters.
+          automatic: false
+          # Automatic controls whether this update is executed automatically
+          # for the worker nodes of all matching user clusters.
+          automaticNodeUpdate: false
+          # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          from: 4.1.*
+          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          to: 4.1.*
+        - from: 4.1.*
+          to: 2.2.*
       # Versions lists the available versions.
       versions:
-      - 4.1.9
-      - 4.1.18
+        - 4.1.9
+        - 4.1.18
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/content/kubermatic/master/data/seed.yaml
+++ b/content/kubermatic/master/data/seed.yaml
@@ -54,6 +54,7 @@ spec:
           images:
             centos: ""
             coreos: ""
+            flatcar: ""
             rhel: ""
             sles: ""
             ubuntu: ""
@@ -74,6 +75,9 @@ spec:
         # EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
+        # EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
+        # ignoring cluster-specific settings
+        enforcePodSecurityPolicy: false
         gcp:
           # Region to use, for example "europe-west3", for a full list of regions see
           # https://cloud.google.com/compute/docs/regions-zones/
@@ -106,6 +110,7 @@ spec:
           images:
             centos: ""
             coreos: ""
+            flatcar: ""
             rhel: ""
             sles: ""
             ubuntu: ""
@@ -141,7 +146,10 @@ spec:
           cluster: ""
           # The name of the datacenter to use.
           datacenter: ""
-          # The name of the datastore to use.
+          # The name of the default Datastore to be used for provisioning volumes
+          # using storage classes/dynamic provisioning and for storing virtual
+          # machine files in case no `Datastore` or `DatastoreCluster` is provided
+          # with the `VSphereCloudSpec`.
           datastore: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""
@@ -161,6 +169,7 @@ spec:
           templates:
             centos: ""
             coreos: ""
+            flatcar: ""
             rhel: ""
             sles: ""
             ubuntu: ""

--- a/content/kubermatic/v2.14/concepts/kubermaticconfiguration/_index.en.md
+++ b/content/kubermatic/v2.14/concepts/kubermaticconfiguration/_index.en.md
@@ -10,11 +10,6 @@ weight = 20
 The KubermaticConfiguration CustomResourceDefinition is used for configuring the Kubermatic Operator and
 replaces what previously was done with the `values.yaml` for the Kubermatic Helm chart.
 
-{{% notice warning %}}
-The operator is not yet considered ready for production use. Likewise, the CRD structure is not yet
-finalized and changes may occur at any time.
-{{% /notice %}}
-
 The following is an example configuration, showing all possible options. Note that all fields that you
 don't define explicitly are always defaulted to these values.
 

--- a/content/kubermatic/v2.14/concepts/seeds/_index.en.md
+++ b/content/kubermatic/v2.14/concepts/seeds/_index.en.md
@@ -11,10 +11,6 @@ The Seed CustomResourceDefinition replaces the legacy [`datacenters.yaml`]({{< r
 a more flexible, dynamic way of managing seed clusters. Seeds can be added and removed at runtime by simply
 managing Seed resources inside the [master cluster]({{< ref "../architecture" >}}).
 
-{{% notice note %}}
-**Note:** This feature is **experimental** and not enabled by default.
-{{% /notice %}}
-
 ### Example Seed
 
 The following is an example Seed, showing all possible options.

--- a/content/kubermatic/v2.14/data/kubermaticConfiguration.yaml
+++ b/content/kubermatic/v2.14/data/kubermaticConfiguration.yaml
@@ -8,11 +8,12 @@ spec:
   api:
     # AccessibleAddons is a list of addons that should be enabled in the API.
     accessibleAddons:
-    - node-exporter
+      - node-exporter
+      - gatekeeper
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -81,7 +82,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic master-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the master-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -90,7 +91,7 @@ spec:
       # DryRun makes the migrator only log the actions it would take.
       dryRun: false
     # Replicas sets the number of pod replicas for the master-controller-manager.
-    replicas: 2
+    replicas: 1
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.
@@ -105,6 +106,23 @@ spec:
       requests:
         cpu: 50m
         memory: 128Mi
+  # Proxy allows to configure Kubermatic to use proxies to talk to the
+  # world outside of its cluster.
+  proxy:
+    # HTTP is the full URL to the proxy to use for plaintext HTTP
+    # connections, e.g. "http://internalproxy.example.com:8080".
+    http: ""
+    # HTTPS is the full URL to the proxy to use for encrypted HTTPS
+    # connections, e.g. "http://secureinternalproxy.example.com:8080".
+    https: ""
+    # NoProxy is a comma-separated list of hostnames / network masks
+    # for which no proxy shall be used. If you make use of proxies,
+    # this list should contain all local and cluster-internal domains
+    # and networks, e.g. "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,mydomain".
+    # The operator will always prepend the following elements to this
+    # list if proxying is configured (i.e. HTTP/HTTPS are not empty):
+    # "127.0.0.1/8", "localhost", ".local", ".local.", "kubernetes", ".default", ".svc"
+    noProxy: ""
   # SeedController configures the seed-controller-manager.
   seedController:
     # BackupCleanupContainer is the container used for removing expired backups from the storage location.
@@ -168,12 +186,12 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic seed-controller-manager image.
-    dockerRepository: quay.io/kubermatic/api
+    dockerRepository: quay.io/kubermatic/kubermatic
     # PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
     # Replicas sets the number of pod replicas for the seed-controller-manager.
-    replicas: 2
+    replicas: 1
     # Resources describes the requested and maximum allowed CPU/memory usage.
     resources:
       # Limits describes the maximum amount of compute resources allowed.
@@ -196,7 +214,7 @@ spec:
         "share_kubeconfig": false
       }
     # DockerRepository is the repository containing the Kubermatic dashboard image.
-    dockerRepository: quay.io/kubermatic/ui-v2
+    dockerRepository: quay.io/kubermatic/dashboard
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.
@@ -232,26 +250,32 @@ spec:
             kind: Addon
             metadata:
               name: canal
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: csi
-          - apiVersion: kubermatic.k8s.io/v1
-            kind: Addon
-            metadata:
-              name: dns
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: kube-proxy
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: openvpn
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: rbac
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
@@ -263,15 +287,15 @@ spec:
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
-              name: nodelocal-dns-cache
-          - apiVersion: kubermatic.k8s.io/v1
-            kind: Addon
-            metadata:
               name: pod-security-policy
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:
               name: logrotate
+              labels:
+                addons.kubermatic.io/ensure: true
         # DockerRepository is the repository containing the Docker image containing
         # the possible addon manifests.
         dockerRepository: quay.io/kubermatic/addons
@@ -337,7 +361,7 @@ spec:
     # EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
     etcdVolumeSize: 5Gi
     # KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
-    kubermaticDockerRepository: quay.io/kubermatic/api
+    kubermaticDockerRepository: quay.io/kubermatic/kubermatic
     # Monitoring can be used to fine-tune to in-cluster Prometheus.
     monitoring:
       # CustomRules can be used to inject custom recording and alerting rules. This field
@@ -367,7 +391,7 @@ spec:
     # Kubernetes configures the Kubernetes versions and updates.
     kubernetes:
       # Default is the default version to offer users.
-      default: 1.15.10
+      default: 1.17.9
       # Updates is a list of available and automatic upgrades.
       # All 'to' versions must be configured in the version list for this orchestrator.
       # Each update may optionally be configured to be 'automatic: true', in which case the
@@ -378,70 +402,62 @@ spec:
       # updates as well. 'automaticNodeUpdate: true' implies 'automatic: true' as well,
       # because Nodes may not have a newer version than the controlplane.
       updates:
-      - # Automatic controls whether this update is executed automatically
-        # for the control plane of all matching user clusters.
-        automatic: false
-        # Automatic controls whether this update is executed automatically
-        # for the worker nodes of all matching user clusters.
-        automaticNodeUpdate: false
-        # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.12.*".
-        from: 1.12.*
-        # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.13.*".
-        to: 1.13.*
-      - automatic: true
-        from: <= 1.13.9, >= 1.13.0
-        to: 1.13.10
-      - from: 1.13.*
-        to: 1.14.*
-      - from: 1.14.*
-        to: 1.14.*
-      - automatic: true
-        from: <= 1.14.7, >= 1.14.0
-        to: 1.14.8
-      - from: 1.14.*
-        to: 1.15.*
-      - from: 1.15.*
-        to: 1.15.*
-      - automatic: true
-        from: <= 1.15.4, >= 1.15.0
-        to: 1.15.5
-      - automatic: true
-        from: 1.15.8
-        to: 1.15.9
-      - from: 1.15.*
-        to: 1.16.*
-      - from: 1.16.*
-        to: 1.16.*
-      - automatic: true
-        from: <= 1.16.1, >= 1.16.0
-        to: 1.16.2
-      - automatic: true
-        from: 1.16.5
-        to: 1.16.6
-      - from: 1.16.*
-        to: 1.17.*
-      - from: 1.17.*
-        to: 1.17.*
-      - automatic: true
-        from: 1.17.1
-        to: 1.17.2
-      - from: 1.17.*
-        to: 1.18.*
+        - # Automatic controls whether this update is executed automatically
+          # for the control plane of all matching user clusters.
+          automatic: false
+          # Automatic controls whether this update is executed automatically
+          # for the worker nodes of all matching user clusters.
+          automaticNodeUpdate: false
+          # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          from: 1.14.*
+          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          to: 1.14.*
+        - automatic: true
+          from: <= 1.14.7, >= 1.14.0
+          to: 1.14.8
+        - from: 1.14.*
+          to: 1.15.*
+        - from: 1.15.*
+          to: 1.15.*
+        - automatic: true
+          from: <= 1.15.4, >= 1.15.0
+          to: 1.15.5
+        - automatic: true
+          from: 1.15.8
+          to: 1.15.9
+        - from: 1.15.*
+          to: 1.16.*
+        - from: 1.16.*
+          to: 1.16.*
+        - automatic: true
+          from: <= 1.16.12, >= 1.16.0
+          to: 1.16.13
+        - from: 1.16.*
+          to: 1.17.*
+        - from: 1.17.*
+          to: 1.17.*
+        - automatic: true
+          from: <= 1.17.8, >= 1.17.0
+          to: 1.17.9
+        - from: 1.17.*
+          to: 1.18.*
+        - from: 1.18.*
+          to: 1.18.*
+        - automatic: true
+          from: <= 1.18.5, >= 1.18.0
+          to: 1.18.6
       # Versions lists the available versions.
       versions:
-      - 1.15.5
-      - 1.15.6
-      - 1.15.7
-      - 1.15.9
-      - 1.15.10
-      - 1.16.2
-      - 1.16.3
-      - 1.16.4
-      - 1.16.6
-      - 1.16.7
-      - 1.17.0
-      - 1.17.2
-      - 1.17.3
+        - 1.15.5
+        - 1.15.6
+        - 1.15.7
+        - 1.15.9
+        - 1.15.10
+        - 1.15.11
+        - 1.15.12
+        - 1.16.13
+        - 1.17.9
+        - 1.18.6
     # Openshift configures the Openshift versions and updates.
     openshift:
       # Default is the default version to offer users.
@@ -456,22 +472,22 @@ spec:
       # updates as well. 'automaticNodeUpdate: true' implies 'automatic: true' as well,
       # because Nodes may not have a newer version than the controlplane.
       updates:
-      - # Automatic controls whether this update is executed automatically
-        # for the control plane of all matching user clusters.
-        automatic: false
-        # Automatic controls whether this update is executed automatically
-        # for the worker nodes of all matching user clusters.
-        automaticNodeUpdate: false
-        # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.12.*".
-        from: 4.1.*
-        # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.13.*".
-        to: 4.1.*
-      - from: 4.1.*
-        to: 2.2.*
+        - # Automatic controls whether this update is executed automatically
+          # for the control plane of all matching user clusters.
+          automatic: false
+          # Automatic controls whether this update is executed automatically
+          # for the worker nodes of all matching user clusters.
+          automaticNodeUpdate: false
+          # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          from: 4.1.*
+          # From is the version to which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+          to: 4.1.*
+        - from: 4.1.*
+          to: 2.2.*
       # Versions lists the available versions.
       versions:
-      - 4.1.9
-      - 4.1.18
+        - 4.1.9
+        - 4.1.18
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/content/kubermatic/v2.14/data/seed.yaml
+++ b/content/kubermatic/v2.14/data/seed.yaml
@@ -54,6 +54,7 @@ spec:
           images:
             centos: ""
             coreos: ""
+            flatcar: ""
             rhel: ""
             sles: ""
             ubuntu: ""
@@ -74,6 +75,9 @@ spec:
         # EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
+        # EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
+        # ignoring cluster-specific settings
+        enforcePodSecurityPolicy: false
         gcp:
           # Region to use, for example "europe-west3", for a full list of regions see
           # https://cloud.google.com/compute/docs/regions-zones/
@@ -106,6 +110,7 @@ spec:
           images:
             centos: ""
             coreos: ""
+            flatcar: ""
             rhel: ""
             sles: ""
             ubuntu: ""
@@ -141,7 +146,10 @@ spec:
           cluster: ""
           # The name of the datacenter to use.
           datacenter: ""
-          # The name of the datastore to use.
+          # The name of the default Datastore to be used for provisioning volumes
+          # using storage classes/dynamic provisioning and for storing virtual
+          # machine files in case no `Datastore` or `DatastoreCluster` is provided
+          # with the `VSphereCloudSpec`.
           datastore: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""
@@ -161,6 +169,7 @@ spec:
           templates:
             centos: ""
             coreos: ""
+            flatcar: ""
             rhel: ""
             sles: ""
             ubuntu: ""


### PR DESCRIPTION
Remove experimental warnings from seed and kubermaticconfiguration docs starting from version 2.14 and update example manifests.