### PR TITLE
kubeone: Add Packet to natively-supported providers

### DIFF
--- a/content/kubeone/master/compatibility_info/_index.en.md
+++ b/content/kubeone/master/compatibility_info/_index.en.md
@@ -15,7 +15,7 @@ the current KubeOne version. The additional features include the KubeOne
 Terraform integration and the integration with Kubermatic machine-controller.
 
 KubeOne supports AWS, Azure, DigitalOcean, GCP, Hetzner Cloud,
-OpenStack, and VMware vSphere.
+OpenStack, Packet, and VMware vSphere.
 
 ## Supported Kubernetes Versions
 

--- a/content/kubeone/v1.0/compatibility_info/_index.en.md
+++ b/content/kubeone/v1.0/compatibility_info/_index.en.md
@@ -15,7 +15,7 @@ the current KubeOne version. The additional features include the KubeOne
 Terraform integration and the integration with Kubermatic machine-controller.
 
 KubeOne supports AWS, Azure, DigitalOcean, GCP, Hetzner Cloud,
-OpenStack, and VMware vSphere.
+OpenStack, Packet, and VMware vSphere.
 
 ## Supported Kubernetes Versions
 


### PR DESCRIPTION
We've forgotten to mention Packet as a supported provider, so this PR adds it to the list of natively-supported providers.

/assign @kron4eg 