### PR TITLE
Kubermatic Installer

### DIFF
--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -12,7 +12,7 @@ cluster installation). In this case both master and seed components will run on 
 the same namespace. It is however not possible to use the same cluster for multiple seeds.
 {{% /notice %}}
 
-Plese refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
+Please refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
 about the cluster relationships.
 
 ## Install KKP Dependencies

--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Add Seed Cluster for CE"
 date = 2018-08-09T12:07:15+02:00
-weight = 30
+weight = 40
 
 +++
 

--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -84,7 +84,8 @@ The Kubermatic repository provides a [script](https://github.com/kubermatic/kube
 a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
 the kubeconfig file. Afterwards the file can be used in KKP.
 
-The Seed resource itself needs to be called `kubermatic` and needs to reference the new kubeconfig Secret like so:
+The Seed resource itself needs to be called `kubermatic` (for the Community Edition) and needs to reference the new
+kubeconfig Secret like so:
 
 ```yaml
 apiVersion: v1

--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -2,24 +2,31 @@
 title = "Add Seed Cluster for CE"
 date = 2018-08-09T12:07:15+02:00
 weight = 40
-
 +++
 
+This document describes how a new seed cluster can be added to an existing KKP master cluster.
 
-This document describes how a new seed cluster can be added to an existing Kubermatic Kubernetes Platform (KKP) master cluster.
+{{% notice note %}}
+For smaller scale setups it's possible to use the existing master cluster as a seed cluster (a "shared"
+cluster installation). In this case both master and seed components will run on the same cluster and in
+the same namespace. It is however not possible to use the same cluster for multiple seeds.
+{{% /notice %}}
 
-Please refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
+Plese refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
 about the cluster relationships.
 
-### Install KKP Dependencies
+## Install KKP Dependencies
 
-#### Cluster Backups
+Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
+will improve the setup experience further.
+
+### Cluster Backups
 
 KKP performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
-are stored locally inside the cluster, but they can be reconfigured to work with any S3-compatible storage.
+are stored locally inside the seed cluster, but they can be reconfigured to work with any S3-compatible storage.
 The in-cluster storage is provided by [Minio](https://min.io/) and the accompanying `minio` Helm chart.
 
-If your cluster has no default storage class, it's required to configure a class explicitely for Minio. You can check
+If your cluster has no default storage class, it's required to configure a class explicitly for Minio. You can check
 the cluster's storage classes via:
 
 ```bash
@@ -29,8 +36,8 @@ kubectl get storageclasses
 #standard (default)   kubernetes.io/gce-pd   2y43d
 ```
 
-As Minio does not require any of the SSD's advantages, we can use HDDs.
-For a cluster running on AWS, an example class could look like this:
+As Minio does not require any of the SSD's advantages, we can use HDDs. For a cluster running on AWS, an example
+class could look like this:
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -42,7 +49,7 @@ parameters:
   type: sc1
 ```
 
-To configure the storage class and size, extend your `values.yaml` like so:
+To configure the storage class and size, extend your Helm `values.yaml` like so:
 
 ```yaml
 minio:
@@ -52,42 +59,50 @@ minio:
 
 It's also advisable to install the `s3-exporter` Helm chart, as it provides basic metrics about user cluster backups.
 
-#### Install Charts
+### Install Charts
 
 With this you can install the chart:
 
 ```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace s3-exporter s3-exporter charts/s3-exporter/
+helm --namespace minio upgrade --install --values /path/to/your/helm/values.yaml minio charts/minio/
+helm --namespace s3-exporter upgrade --install --values /path/to/your/helm/values.yaml s3-exporter charts/s3-exporter/
 ```
 
+## Add the Seed Resource
 
-### Add the Seed Resource
+To connect the new seed cluster with the master, you need to create a kubeconfig Secret and a Seed resource. This allows
+the KKP components in the master cluster to communicate with the seed cluster and reconcile user-cluster control planes.
 
-To connect the new seed cluster with the master, you need to create a kubeconfig Secret and a Seed resource.
+{{% notice warning %}}
+To make sure that the kubeconfig stays valid forever, it must not contain temporary login tokens. Depending on the
+cloud provider, the default kubeconfig that is provided may not contain username+password / a client certificate, but instead
+try to talk to local token helper programs like `aws-iam-authenticator` for AWS or `gcloud` for the Google Cloud (GKE).
+These kubeconfig files **will not work** for setting up Seeds.
+{{% /notice %}}
 
-You will add the **master cluster** as the **seed cluster**
+The Kubermatic repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/release/v2.14/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in Kubermatic. The script will create
+a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
+the kubeconfig file. Afterwards the file can be used in KKP.
 
-Make sure the kubeconfig contains static, long-lived credentials. Some cloud providers use custom authentication providers
-(like GKE using `gcloud` and EKS using `aws-iam-authenticator`). Those will not work in KKP’s usecase because the
-required tools are not installed inside the cluster environment.
-
-The Seed resource needs to be called `kubermatic` and needs to reference the new kubeconfig Secret like so:
+The Seed resource itself needs to be called `kubermatic` and needs to reference the new kubeconfig Secret like so:
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kubeconfig-europe-west1
+  name: kubeconfig-kubermatic
   namespace: kubermatic
 type: Opaque
 data:
+  # You can use `base64 -w0 my-kubeconfig-file` to encode the
+  # kubeconfig properly for inserting into this Secret.
   kubeconfig: <base64 encoded kubeconfig>
 
 ---
 apiVersion: kubermatic.k8s.io/v1
 kind: Seed
 metadata:
+  # The Seed *must* be named "kubermatic".
   name: kubermatic
   namespace: kubermatic
 spec:
@@ -100,7 +115,7 @@ spec:
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:
-    name: kubeconfig-europe-west1
+    name: kubeconfig-kubermatic
     namespace: kubermatic
 ```
 
@@ -108,33 +123,54 @@ Refer to the [Seed CRD documentation]({{< ref "../../concepts/seeds" >}}) for a 
 Seed CustomResource and all possible datacenters.
 
 Apply the manifest above in the master cluster and KKP will pick up the new Seed and begin to
-reconcile it by installing the required KKP components.
+reconcile it by installing the required KKP components. You can watch the progress by using
+`kubectl` and `watch`:
 
-### Update DNS
+```bash
+kubectl apply -f seed-with-secret.yaml
+Secret/kubeconfig-kubermatic created.
+Seed/kubermatic created.
+
+watch kubectl -n kubermatic get pods
+#NAME                                                   READY   STATUS    RESTARTS   AGE
+#kubermatic-api-55765568f7-br9jl                        1/1     Running   0          5m4s
+#kubermatic-api-55765568f7-xbvz2                        1/1     Running   0          5m13s
+#kubermatic-dashboard-5d784d586b-f46f8                  1/1     Running   0          35m
+#kubermatic-dashboard-5d784d586b-rgl29                  1/1     Running   0          35m
+#kubermatic-master-controller-manager-f58d4df59-w7rkz   1/1     Running   0          5m13s
+#kubermatic-operator-7f6957869d-89g55                   1/1     Running   0          5m37s
+#nodeport-proxy-envoy-6d8bb6fbff-9z57l                  2/2     Running   0          5m6s
+#nodeport-proxy-envoy-6d8bb6fbff-dl58l                  2/2     Running   0          4m54s
+#nodeport-proxy-envoy-6d8bb6fbff-k4gp8                  2/2     Running   0          4m44s
+#nodeport-proxy-updater-7fd55f948-cll8n                 1/1     Running   0          4m44s
+#seed-proxy-kubermatic-6dd5cc95cf-r6wvb                 1/1     Running   0          80m
+```
+
+## Update DNS
 
 The apiservers of all user cluster control planes running in the seed cluster are exposed by the
 NodePort Proxy. By default each user cluster gets a virtual domain name like
-`[cluster-id].[seed-name].[kubermatic-domain]`, e.g. `hdu328tr.europe-west1.kubermatic.example.com`
+`[cluster-id].[seed-name].[kubermatic-domain]`, e.g. `hdu328tr.kubermatic.kubermatic.example.com`
 for the Seed from the previous step when `kubermatic.example.com` is the main domain where the
 KKP dashboard/API are available.
 
 To facilitate this, a wildcard DNS record `*.[seed-name].[kubermatic-domain]` must be created. The target of the
 DNS wildcard record should be the `EXTERNAL-IP` of the `nodeport-proxy` service in the `kubermatic` namespace.
 
-#### With LoadBalancers
+### With LoadBalancers
 
-When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
+When your cloud provider supports LoadBalancers, you can find the target IP / hostname by looking at the
 `nodeport-proxy` Service:
 
 ```bash
 kubectl -n kubermatic get services
-#NAME          TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
+#NAME             TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
 #nodeport-proxy   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
 ```
 
 The `EXTERNAL-IP` is what we need to put into the DNS record.
 
-#### Without Load Balancers
+### Without LoadBalancers
 
 Without a LoadBalancer, you will need to point to one or many of the seed cluster's nodes. You can get a
 list of external IPs like so:
@@ -147,16 +183,16 @@ kubectl get nodes -o wide
 #worker-node-cbd686cd-90j3   Ready    <none>   45m     v1.15.8-gke.3   10.156.0.22   8.7.6.2
 ```
 
-#### DNS Record
+### DNS Record
 
 Create an A or CNAME record as needed pointing to the target:
 
 ```plain
-*.europe-west1.kubermatic.example.com.   IN   A   8.7.6.5
+*.kubermatic.kubermatic.example.com.   IN   A   8.7.6.5
 ```
 
 or, for a CNAME:
 
 ```plain
-*.europe-west1.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
+*.kubermatic.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
 ```

--- a/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
@@ -13,7 +13,7 @@ cluster installation). In this case both master and seed components will run on 
 the same namespace. It is however not possible to use the same cluster for multiple seeds.
 {{% /notice %}}
 
-Plese refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
+Please refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
 about the cluster relationships.
 
 ## Install KKP Dependencies

--- a/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
@@ -5,48 +5,29 @@ weight = 50
 enterprise = true
 +++
 
-This document describes how a new seed cluster can be added to an existing Kubermatic Kubernetes Platform (KKP) master cluster.
+This document describes how a new seed cluster can be added to an existing KKP master cluster.
 
 {{% notice note %}}
-For smaller scale setups it's also possible to use the existing master cluster as a seed cluster (a "shared"
+For smaller scale setups it's possible to use the existing master cluster as a seed cluster (a "shared"
 cluster installation). In this case both master and seed components will run on the same cluster and in
-the same namespace. You can skip the first step and directly continue with installing the seed dependencies.
+the same namespace. It is however not possible to use the same cluster for multiple seeds.
 {{% /notice %}}
 
 Plese refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
 about the cluster relationships.
 
-### Install Kubernetes Cluster
+## Install KKP Dependencies
 
-First, you need to install a Kubernetes cluster with some additional components. After the installation of
-Kubernetes you will need a copy of the `kubeconfig` to create a configuration for the new KKP
-master/seed setup.
+Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
+will improve the setup experience further.
 
-To aid in setting up the seed and master clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/),
-which can be used to set up a highly-available Kubernetes cluster. Refer to the [KubeOne readme](https://github.com/kubermatic/kubeone/)
-and [docs](/kubeone) for details on how to use it.
-
-Please take note of the [recommended hardware and networking requirements](../../requirements/cluster_requirements/)
-before provisioning a cluster.
-
-### Install KKP Dependencies
-
-When using Helm 2, install Tiller into the seed cluster first:
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
-#### Cluster Backups
+### Cluster Backups
 
 KKP performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
-are stored locally inside the cluster, but they can be reconfigured to work with any S3-compatible storage.
+are stored locally inside the seed cluster, but they can be reconfigured to work with any S3-compatible storage.
 The in-cluster storage is provided by [Minio](https://min.io/) and the accompanying `minio` Helm chart.
 
-If your cluster has no default storage class, it's required to configure a class explicitely for Minio. You can check
+If your cluster has no default storage class, it's required to configure a class explicitly for Minio. You can check
 the cluster's storage classes via:
 
 ```bash
@@ -56,8 +37,8 @@ kubectl get storageclasses
 #standard (default)   kubernetes.io/gce-pd   2y43d
 ```
 
-As Minio does not require any of the SSD's advantages, we can use HDDs.
-For a cluster running on AWS, an example class could look like this:
+As Minio does not require any of the SSD's advantages, we can use HDDs. For a cluster running on AWS, an example
+class could look like this:
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -69,7 +50,7 @@ parameters:
   type: sc1
 ```
 
-To configure the storage class and size, extend your `values.yaml` like so:
+To configure the storage class and size, extend your Helm `values.yaml` like so:
 
 ```yaml
 minio:
@@ -79,42 +60,30 @@ minio:
 
 It's also advisable to install the `s3-exporter` Helm chart, as it provides basic metrics about user cluster backups.
 
-#### Install Charts
+### Install Charts
 
 With this you can install the chart:
 
 ```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace s3-exporter s3-exporter charts/s3-exporter/
+helm --namespace minio upgrade --install --values /path/to/your/helm/values.yaml minio charts/minio/
+helm --namespace s3-exporter upgrade --install --values /path/to/your/helm/values.yaml s3-exporter charts/s3-exporter/
 ```
 
-### Create Seed Resource
+## Add the Seed Resource
 
-To connect the new seed cluster with the master, you need to create a kubeconfig Secret and a Seed resource
-**in the master cluster**.
+To connect the new seed cluster with the master, you need to create a kubeconfig Secret and a Seed resource. This allows
+the KKP components in the master cluster to communicate with the seed cluster and reconcile user-cluster control planes.
 
 {{% notice warning %}}
-Do not install the `kubermatic-operator` chart into seed clusters. It's possible to run master and seed in the same
-Kubernetes cluster, but this still means only a single operator is deployed into the shared cluster.
+To make sure that the kubeconfig stays valid forever, it must not contain temporary login tokens. Depending on the
+cloud provider, the default kubeconfig that is provided may not contain username+password / a client certificate, but instead
+try to talk to local token helper programs like `aws-iam-authenticator` for AWS or `gcloud` for the Google Cloud (GKE).
+These kubeconfig files **will not work** for setting up Seeds.
 {{% /notice %}}
 
-Make sure the kubeconfig contains static, long-lived credentials. Some cloud providers use custom authentication providers
-(like GKE using `gcloud` and EKS using `aws-iam-authenticator`). Those will not work in KKP’s usecase because the
-required tools are not installed inside the cluster environment. You can use the `kubeconfig-serviceaccounts.sh` script from
-the KKP-installer repository to automatically create proper service accounts inside the seed cluster with static
-credentials:
-
-```bash
-./kubeconfig-service-accounts.sh mykubeconfig.yaml
-Cluster: example
- > context: europe
- > creating service account kubermatic-seed-account ...
- > assigning cluster role kubermatic-seed-account-cluster-role ...
- > reading auth token ...
- > adding user example-kubermatic-service-account ...
- > updating cluster context ...
- > kubeconfig updated
-```
+The KKP repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/release/v2.14/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in KKP. The script will create
+a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
+the kubeconfig file. Afterwards the file can be used in KKP.
 
 The Seed resource then needs to reference the new kubeconfig Secret like so:
 
@@ -122,17 +91,19 @@ The Seed resource then needs to reference the new kubeconfig Secret like so:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kubeconfig-europe-west1
+  name: kubeconfig-europe-west3
   namespace: kubermatic
 type: Opaque
 data:
+  # You can use `base64 -w0 my-kubeconfig-file` to encode the
+  # kubeconfig properly for inserting into this Secret.
   kubeconfig: <base64 encoded kubeconfig>
 
 ---
 apiVersion: kubermatic.k8s.io/v1
 kind: Seed
 metadata:
-  name: europe-west1
+  name: europe-west3
   namespace: kubermatic
 spec:
   # these two fields are only informational
@@ -144,7 +115,7 @@ spec:
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:
-    name: kubeconfig-europe-west1
+    name: kubeconfig-europe-west3
     namespace: kubermatic
 ```
 
@@ -152,34 +123,54 @@ Refer to the [Seed CRD documentation]({{< ref "../../concepts/seeds" >}}) for a 
 Seed CustomResource and all possible datacenters.
 
 Apply the manifest above in the master cluster and KKP will pick up the new Seed and begin to
-reconcile it by installing the required KKP components.
+reconcile it by installing the required Kubermatic components. You can watch the progress by using
+`kubectl` and `watch`:
 
-### Update DNS
+```bash
+kubectl apply -f seed-with-secret.yaml
+Secret/kubeconfig-europe-west3 created.
+Seed/kubermatic created.
+
+watch kubectl -n kubermatic get pods
+#NAME                                                   READY   STATUS    RESTARTS   AGE
+#kubermatic-api-55765568f7-br9jl                        1/1     Running   0          5m4s
+#kubermatic-api-55765568f7-xbvz2                        1/1     Running   0          5m13s
+#kubermatic-dashboard-5d784d586b-f46f8                  1/1     Running   0          35m
+#kubermatic-dashboard-5d784d586b-rgl29                  1/1     Running   0          35m
+#kubermatic-master-controller-manager-f58d4df59-w7rkz   1/1     Running   0          5m13s
+#kubermatic-operator-7f6957869d-89g55                   1/1     Running   0          5m37s
+#nodeport-proxy-envoy-6d8bb6fbff-9z57l                  2/2     Running   0          5m6s
+#nodeport-proxy-envoy-6d8bb6fbff-dl58l                  2/2     Running   0          4m54s
+#nodeport-proxy-envoy-6d8bb6fbff-k4gp8                  2/2     Running   0          4m44s
+#nodeport-proxy-updater-7fd55f948-cll8n                 1/1     Running   0          4m44s
+#seed-proxy-europe-west3-6dd5cc95cf-r6wvb               1/1     Running   0          80m
+```
+
+## Update DNS
 
 The apiservers of all user cluster control planes running in the seed cluster are exposed by the
 NodePort Proxy. By default each user cluster gets a virtual domain name like
-`[cluster-id].[seed-name].[kubermatic-domain]`, e.g. `hdu328tr.europe-west1.kubermatic.example.com`
+`[cluster-id].[seed-name].[kubermatic-domain]`, e.g. `hdu328tr.europe-west3.kubermatic.example.com`
 for the Seed from the previous step when `kubermatic.example.com` is the main domain where the
 KKP dashboard/API are available.
 
-To facilitate this, a wildcard DNS record `*.[seed-name].[kubermatic-domain]` must be created. As with
-the other DNS records the exact target depends on whether or not LoadBalancer services are supported
-on the seed.
+To facilitate this, a wildcard DNS record `*.[seed-name].[kubermatic-domain]` must be created. The target of the
+DNS wildcard record should be the `EXTERNAL-IP` of the `nodeport-proxy` service in the `kubermatic` namespace.
 
-#### With LoadBalancers
+### With LoadBalancers
 
-When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
+When your cloud provider supports LoadBalancers, you can find the target IP / hostname by looking at the
 `nodeport-proxy` Service:
 
 ```bash
 kubectl -n kubermatic get services
-#NAME          TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
+#NAME             TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
 #nodeport-proxy   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
 ```
 
 The `EXTERNAL-IP` is what we need to put into the DNS record.
 
-#### Without Load Balancers
+### Without LoadBalancers
 
 Without a LoadBalancer, you will need to point to one or many of the seed cluster's nodes. You can get a
 list of external IPs like so:
@@ -192,16 +183,16 @@ kubectl get nodes -o wide
 #worker-node-cbd686cd-90j3   Ready    <none>   45m     v1.15.8-gke.3   10.156.0.22   8.7.6.2
 ```
 
-#### DNS Record
+### DNS Record
 
 Create an A or CNAME record as needed pointing to the target:
 
 ```plain
-*.europe-west1.kubermatic.example.com.   IN   A   8.7.6.5
+*.europe-west3.kubermatic.example.com.   IN   A   8.7.6.5
 ```
 
 or, for a CNAME:
 
 ```plain
-*.europe-west1.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
+*.europe-west3.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
 ```

--- a/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Add Seed Cluster for EE"
 date = 2018-08-09T12:07:15+02:00
-weight = 31
+weight = 50
 enterprise = true
 +++
 

--- a/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
@@ -129,7 +129,7 @@ reconcile it by installing the required Kubermatic components. You can watch the
 ```bash
 kubectl apply -f seed-with-secret.yaml
 Secret/kubeconfig-europe-west3 created.
-Seed/kubermatic created.
+Seed/europe-west3 created.
 
 watch kubectl -n kubermatic get pods
 #NAME                                                   READY   STATUS    RESTARTS   AGE

--- a/content/kubermatic/master/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubermatic/_index.en.md
@@ -111,8 +111,8 @@ properly generated secrets for you when it notices that some are missing, for ex
 
 ```bash
 ./kubermatic-installer deploy --config kubermatic.yaml --helm-values values.yaml
-INFO[15:15:20] � Initializing installer…                     edition="Community Edition" version=v2.15.11
-INFO[15:15:20] � Validating the provided configuration…�
+INFO[15:15:20] 🛫 Initializing installer…                     edition="Community Edition" version=v2.15.11
+INFO[15:15:20] 🚦 Validating the provided configuration…
 ERRO[15:15:20]    The provided configuration files are invalid:
 ERRO[15:15:20]    KubermaticConfiguration: spec.auth.serviceAccountKey must be a non-empty secret, for example: ZPCs7_KzgJxUSA5lCk_oNzL7RQFTQ6cOnHuTLAh4pGw
 ERRO[15:15:20]    Operation failed: please review your configuration and try again.
@@ -156,6 +156,30 @@ to apply your changes.
 In order to acquire a valid certificate, a DNS name needs to point to your cluster. Depending on your environment,
 this can mean a LoadBalancer service or a NodePort service. The nginx-ingress-controller Helm chart will by default
 create a LoadBalancer, unless you reconfigure it because your environment does not support LoadBalancers.
+
+The installer will do its best to inform you about the required DNS records to set up. You will receive an output
+similar to this:
+
+```bash
+INFO[13:03:33]    📝 Applying Kubermatic Configuration…
+INFO[13:03:33]    ✅ Success.
+INFO[13:03:33]    📡 Determining DNS settings…
+INFO[13:03:33]       The main LoadBalancer is ready.
+INFO[13:03:33]
+INFO[13:03:33]         Service             : nginx-ingress-controller / nginx-ingress-controller
+INFO[13:03:33]         Ingress via hostname: EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com
+INFO[13:03:33]
+INFO[13:03:33]       Please ensure your DNS settings for "kubermatic.example.com" include the following records:
+INFO[13:03:33]
+INFO[13:03:33]          kubermatic.example.com.    IN  CNAME  EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com.
+INFO[13:03:33]          *.kubermatic.example.com.  IN  CNAME  EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com.
+INFO[13:03:33]
+INFO[13:03:33] 🛬 Installation completed successfully. ✌
+```
+
+Follow the instructions on screen to setup your DNS. If the installer for whatever reason is unable to determine
+the appropriate DNS settings, it will tell you so and you can manually collect the required information from the
+cluster. See the following sections for more information regarding the how and why what DNS records are required.
 
 #### With LoadBalancers
 

--- a/content/kubermatic/master/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubermatic/_index.en.md
@@ -23,7 +23,7 @@ and make yourself familiar with the requirements for your chosen cloud provider.
 For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
 
 {{% notice warning %}}
-This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
+This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "../../upgrading" >}}) for more information on
 migrating existing installations to the Kubermatic Installer.
 {{% /notice %}}
 
@@ -35,7 +35,8 @@ permissions.
 ### Download the Installer
 
 Download the [tarball](https://github.com/kubermatic/kubermatic/releases/) (e.g. kubermatic-ce-X.Y-linux-amd64.tar.gz)
-containing the Kubermatic Installer and the required Helm charts and extract it locally, for example:
+containing the Kubermatic Installer and the required Helm charts for your operating system and extract it locally. Note that
+for Windows, ZIP files are provided instead of tar.gz files.
 
 ```bash
 # For latest version:
@@ -45,9 +46,6 @@ VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/kubermatic/k
 wget https://github.com/kubermatic/kubermatic/releases/download/v${VERSION}/kubermatic-ce-v${VERSION}-linux-amd64.tar.gz
 tar -xzvf kubermatic-ce-v${VERSION}-linux-amd64.tar.gz
 ```
-
-Make sure to download the installer built for your operating system (Linux, Darwin or Windows). Also note that for Windows,
-ZIP files are provided for convenience.
 
 ### Prepare Configuration
 
@@ -63,7 +61,7 @@ The installation and configuration for a KKP system consists of two important fi
 The release archive hosted on GitHub contains examples for both of the configuration files (`values.example.yaml` and
 `kubermatic.example.yaml`). It's a good idea to take them as a starting point and add more options as necessary.
 
-The main things to configure are:
+The key items to configure are:
 
 * The base domain under which KKP shall be accessible (e.g. `kubermatic.example.com`).
 * The certificate issuer: KKP requires that its dashboard and Dex are only accessible via HTTPS, so a
@@ -92,7 +90,7 @@ ERRO[15:15:20]    Operation failed: please review your configuration and try aga
 {{% notice note %}}
 A couple of settings are duplicated across the `values.yaml` and the KubermaticConfiguration CRD. The installer
 will take care of filling in the gaps, so it is sufficient to configure the base domain in the
-KubermaticConfiguration and letting the installer then set it in the `values.yaml` as well.
+KubermaticConfiguration and let the installer set it in `values.yaml` as well.
 {{% /notice %}}
 
 ### Create a StorageClass
@@ -105,9 +103,16 @@ The installer can automatically create an SSD-based StorageClass for a subset of
 simply copy the default StorageClass, but this is not recommended for production setups unless the default class
 is using SSDs.
 
-Use the `--storageclass` parameter for automatically creating the class during installation. It supports
-automatic creation for AWS, Azure, DigitalOcean, GCE and Hetzner. Run the installer with `--help` to see the current
-list of supported providers.
+Use the `--storageclass` parameter for automatically creating the class during installation. Currently th efollowing
+providers are supported:
+
+- AWS
+- Azure
+- DigitalOcean
+- GCE
+- Hetzner
+
+Run the installer with `--help` to also see the current list of supported providers.
 
 If no automatic provisioning is possible, please manually create a StorageClass called `kubermatic-fast`. Consult
 the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters) for more
@@ -171,7 +176,7 @@ INFO[13:03:33] 🛬 Installation completed successfully. ✌
 
 Follow the instructions on screen to setup your DNS. If the installer for whatever reason is unable to determine
 the appropriate DNS settings, it will tell you so and you can manually collect the required information from the
-cluster. See the following sections for more information regarding the how and why what DNS records are required.
+cluster. See the following sections for more information regarding the required DNS records.
 
 #### With LoadBalancers
 

--- a/content/kubermatic/master/installation/install_kubermatic_ee/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubermatic_ee/_index.en.md
@@ -29,8 +29,8 @@ and make yourself familiar with the requirements for your chosen cloud provider.
 For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
 
 {{% notice warning %}}
-This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
-migrating existing KKP installations to the Kubermatic Installer.
+This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "../../upgrading" >}})
+for more information on migrating existing installations to the Kubermatic Installer.
 {{% /notice %}}
 
 ## Installation

--- a/content/kubermatic/master/installation/install_kubermatic_ee/_index.en.md
+++ b/content/kubermatic/master/installation/install_kubermatic_ee/_index.en.md
@@ -1,14 +1,16 @@
 +++
 title = "Install Kubermatic Kubernetes Platform (KKP) EE"
 date = 2018-04-28T12:07:15+02:00
-weight = 20
+weight = 30
 enterprise = true
 +++
 
-This chapter explains the installation procedure of KKP into a pre-existing Kubernetes cluster.
+This chapter explains the installation procedure of KKP Enterprise Edition (EE) into a pre-existing
+Kubernetes cluster.
 
 {{% notice note %}}
-At the moment you need to be invited to get access to KKP's Docker registry before you can try it out. Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
+At the moment you need to be invited to get access to Kubermatic's EE Docker repository before you can try it out.
+Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
 ## Terminology
@@ -24,222 +26,24 @@ At the moment you need to be invited to get access to KKP's Docker registry befo
 Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "../../requirements" >}})
 and make yourself familiar with the requirements for your chosen cloud provider.
 
-For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 2 or 3) installed locally.
+For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
+
+{{% notice warning %}}
+This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
+migrating existing KKP installations to the Kubermatic Installer.
+{{% /notice %}}
 
 ## Installation
 
-To begin the installation, make sure you have a kubeconfig at hand, with a user context that grants `cluster-admin`
-permissions.
+The installation procedure is identical to the [Community Edition]({{< ref "../install_kubermatic" >}}), with the exception that
+a different installer needs to be downloaded and that the Docker credentials need to be configured.
 
-### Download the Installer
+When downloading the installer, make sure to choose the `-ee-` variant on GitHub. Extract it like documented in the CE install
+guide.
 
-Download the [tarball](https://github.com/kubermatic/kubermatic/releases/) (e.g. kubermatic-X.Y.tar.gz) containing the
-Helm charts choosing the appropriate release (`vX.Y`) and extract it. e.g.
-
-```bash
-# For latest version:
-VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/kubermatic/kubermatic/releases/latest -o /dev/null | sed -e 's|.*/v||')
-# For specific version set it explicitly:
-# VERSION=2.14.x
-wget https://github.com/kubermatic/kubermatic/releases/download/v${VERSION}/kubermatic-ee-v${VERSION}.tar.gz
-tar -xzvf kubermatic-ee-v${VERSION}.tar.gz
-```
-
-### Create a StorageClass
-
-KKP uses a custom storage class for the volumes created for user clusters. This class, `kubermatic-fast`, needs
-to be manually created during the installation and its parameters depend highly on the environment where KKP is
-installed.
-
-It's highly recommended to use SSD-based volumes, as etcd is very sensitive to slow disk I/O. If your cluster already
-provides a default SSD-based storage class, you can simply copy and re-create it as `kubermatic-fast`. For a cluster
-running on AWS, an example class could look like this:
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: kubermatic-fast
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-```
-
-Store the above YAML snippet in a file and then apply it using `kubectl`:
-
-```bash
-kubectl apply -f aws-storageclass.yaml
-```
-
-Please consult the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters)
-for more information about the possible parameters for your storage backend.
-
-### Install Helm's Tiller
-
-{{% notice note %}}
-This step is only required when using Helm 2.
-{{% /notice %}}
-
-When using Helm 2, it's required to setup Tiller inside the cluster. This requires setting up a ClusterRole and
--Binding, before installing Tiller itself. If your cluster already has Tiller installed in another namespace, you
-can re-use it, but an installation dedicated for KKP is preferred.
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
-### Prepare Configuration
-
-KKP ships with a number of Helm charts that need to be installed into the master or seed clusters. These are
-built so they can be configured using a single, shared `values.yaml` file. The required charts are
-
-* **Master cluster:** cert-manager, nginx-ingress-controller, oauth(, iap)
-* **Seed cluster:** nodeport-proxy, minio, s3-exporter
-
-There are additional charts for the [monitoring]({{< ref "../monitoring_stack" >}}) and [logging stack]({{< ref "../logging_stack" >}})
-which will be discussed in their dedicated chapters, as they are not strictly required for running KKP.
-
-In addition to the `values.yaml` for configuring the charts, a number of options will later be made inside a special
-`KubermaticConfiguration` resource.
-
-A minimal configuration for Helm charts sets these options. The secret keys mentioned below can be generated using any
-password generator or on the shell using `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
-
-```yaml
-# Dex Is the OpenID Provider for KKP.
-dex:
-  ingress:
-    # configure your base domain, under which the KKP dashboard shall be available
-    host: kubermatic.example.com
-
-  clients:
-  # The "KKP" client is used for logging into the KKP dashboard. It always
-  # needs to be configured.
-  - id: kubermatic
-    name: Kubermatic
-    # generate a secure secret key
-    secret: <dex-kubermatic-oauth-secret-here>
-    RedirectURIs:
-    # ensure the URLs below use the dex.ingress.host configured above
-    - https://kubermatic.example.com
-    - https://kubermatic.example.com/projects
-
-  # Depending on your chosen login method, you need to configure either an OAuth provider like
-  # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
-  # for an overview over all available connectors.
-
-  # For testing purposes, we configure a single static user/password combination.
-  staticPasswords:
-  - email: "kubermatic@example.com"
-    # bcrypt hash of the string "password", can be created using recent versions of htpasswd:
-    # `htpasswd -bnBC 10 "" PASSWORD_HERE | tr -d ':\n' | sed 's/$2y/$2a/'`
-    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-
-    # these are used within KKP to identify the user
-    username: "admin"
-    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
-
-kubermaticOperator:
-  # insert the Docker authentication JSON provided by KKP here
-  imagePullSecret: |
-    {
-      "auths": {
-        "quay.io": {....}
-      }
-    }
-```
-
-### Install Dependencies
-
-With the configuration prepared, it's now time to install the required Helm charts into the master
-cluster. Take note of where you placed your `values.yaml` and then run the following commands in your
-shell:
-
-```bash
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace nginx-ingress-controller nginx-ingress-controller charts/nginx-ingress-controller/
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace cert-manager cert-manager charts/cert-manager/
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace oauth oauth charts/oauth/
-```
-
-Please, make sure that the `cert-manager` is available, before continuing and installing `oauth`, by waiting a minute for its pods to be running (see: *Validation* section below).
-
-#### Validation
-
-Before continuing, make sure the charts we just installed are functioning correctly. Check that pods inside the
-`nginx-ingress-controller`, `oauth` and `cert-manager` namespaces are in status `Running`:
-
-```bash
-kubectl -n nginx-ingress-controller get pods
-#NAME                                        READY   STATUS    RESTARTS   AGE
-#nginx-ingress-controller-55dd87fc7f-5q4zb   1/1     Running   0          17m
-#nginx-ingress-controller-55dd87fc7f-l492k   1/1     Running   0          4h56m
-#nginx-ingress-controller-55dd87fc7f-rwcwf   1/1     Running   0          5h33m
-
-kubectl -n oauth get pods
-#NAME                   READY   STATUS    RESTARTS   AGE
-#dex-7795d657ff-b4fmq   1/1     Running   0          4h59m
-#dex-7795d657ff-kqbk8   1/1     Running   0          20m
-
-kubectl -n cert-manager get pods
-#NAME                           READY   STATUS    RESTARTS   AGE
-#cainjector-5dc8ccbd45-gk6xp    1/1     Running   0          5h36m
-#cert-manager-799ccc8b5-m7wxk   1/1     Running   0          20m
-#webhook-575b887-zb6m2          1/1     Running   0          5h36m
-```
-
-You should also have a working LoadBalancer service created by nginx:
-
-{{% notice note %}}
-Not all cloud providers provide support for LoadBalancers. In these environments the `nginx-ingress-controller` chart can
-be configured to use a NodePort Service instead, which would open ports 80 and 443 on every node of the cluster. Refer to
-the `charts/nginx-ingress-controller/values.yaml` for more information.
-{{% /notice %}}
-
-```bash
-kubectl -n nginx-ingress-controller get services
-#NAME                       TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
-```
-
-Take note of the `EXTERNAL-IP` of this service (`1.2.3.4` in the example above). You will need to configure a DNS record
-pointing to this in a later step.
-
-If any of the pods above are not working, check their logs and describe them (`kubectl -n nginx-ingress-controller describe pod ...`)
-to see what's causing the issues.
-
-### Install KKP Operator
-
-Before installing the KKP Operator, the KKP CRDs need to be installed. You can install them like so:
-
-```bash
-kubectl apply -f charts/kubermatic/crd/
-```
-
-After this, the operator chart can be installed like the previous Helm charts:
-
-```bash
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace kubermatic charts/kubermatic-operator/
-```
-
-#### Validation
-
-Once again, let's check that the operator is working properly:
-
-```bash
-kubectl -n kubermatic get pods
-#NAME                                   READY   STATUS    RESTARTS   AGE
-#kubermatic-operator-769986fc8b-7gpsc   1/1     Running   0          28m
-```
-
-### Create KubermaticConfiguration
-
-It's now time to configure KKP itself. This will be done in a `KubermaticConfiguration` CRD, for which a
-[full example]({{< ref "../../concepts/kubermaticconfiguration" >}}) with all options is available, but for the
-purpose of this document we will only need to configure a few things:
+During configuration, it's required to set the Docker Pull Secret, which allows the local Docker daemons to pull the KKP
+images from the private Docker repository. The Docker Pull Secret is a tiny JSON snippet and needs to be configured in the
+KubermaticConfiguration (e.g. in the `kubermatic.yaml`):
 
 ```yaml
 apiVersion: operator.kubermatic.io/v1alpha1
@@ -248,147 +52,20 @@ metadata:
   name: kubermatic
   namespace: kubermatic
 spec:
-  ingress:
-    # this domain must match what you configured as dex.ingress.host
-    # in the values.yaml
-    domain: kubermatic.example.com
+  # skipping everything else in this file
+  # for demonstration purposes
 
-  # These secret keys configure the way components commmunicate with Dex.
-  auth:
-    # this must match the secret configured for the KKP client from
-    # the values.yaml.
-    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
-
-    # these need to be randomly generated
-    issuerCookieKey: <a-random-key>
-    serviceAccountKey: <another-random-key>
+  # This is where the JSON snippet needs to be configured. It does not need to be
+  # a multiline JSON string.
+  imagePullSecret: |
+    {
+      "auths": {
+        "quay.io": {....}
+      }
+    }
 ```
 
-You can find the YAML above under `examples/kubermatic.example.ee.yaml`
-Save the YAML above as `kubermatic.yaml` and apply it like so:
-Apply it like using kubectl:
-
-```bash
-kubectl apply -f examples/kubermatic.example.ee.yaml
-```
-
-This will now cause the operator to being provisioning a master cluster for KKP. You can observe the progress by
-looking at `watch kubectl -n kubermatic get pods`:
-
-```bash
-watch kubectl -n kubermatic get pods
-#NAME                                                    READY   STATUS    RESTARTS   AGE
-#kubermatic-api-cfcd95746-5r9z2                          1/1     Running   0          24m
-#kubermatic-api-cfcd95746-tsqjc                          1/1     Running   0          28m
-#kubermatic-master-controller-manager-7d97bb887d-8nb74   1/1     Running   0          3m23s
-#kubermatic-master-controller-manager-7d97bb887d-z8t9w   1/1     Running   0          28m
-#kubermatic-operator-769986fc8b-7gpsc                    1/1     Running   0          28m
-#kubermatic-ui-7fc858fb4b-dq5b5                          1/1     Running   0          85m
-#kubermatic-ui-7fc858fb4b-s8fnn                          1/1     Running   0          24m
-```
-
-{{% notice note %}}
-Note that because we don't yet have a TLS certificate and no DNS records configured, some of the pods will crashloop
-until this is fixed.
-{{% /notice %}}
-
-### Create DNS Records
-
-In order to acquire a valid certificate, a DNS name needs to point to your cluster. Depending on your environment,
-this can mean a LoadBalancer service or a NodePort service.
-
-#### With Load Balancers
-
-When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
-`nginx-ingress-controller` Service:
-
-```bash
-kubectl -n nginx-ingress-controller get services
-#NAME                       TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
-```
-
-The `EXTERNAL-IP` is what we need to put into the DNS record.
-
-#### Without Load Balancers
-
-Without a LoadBalancer, you will need to use the NodePort service (refer to the `charts/nginx-ingress-controller/values.yaml`
-for more information) and setup the DNS records to point to one or many of your cluster's nodes. You can get a list of
-external IPs like so:
-
-```bash
-kubectl get nodes -o wide
-#NAME                        STATUS   ROLES    AGE     VERSION         INTERNAL-IP   EXTERNAL-IP
-#worker-node-cbd686cd-50nx   Ready    <none>   3h36m   v1.15.8-gke.3   10.156.0.36   1.2.3.4
-#worker-node-cbd686cd-59s2   Ready    <none>   21m     v1.15.8-gke.3   10.156.0.14   1.2.3.5
-#worker-node-cbd686cd-90j3   Ready    <none>   45m     v1.15.8-gke.3   10.156.0.22   1.2.3.6
-```
-
-{{% notice note %}}
-Some cloud providers list the external IP as the `INTERNAL-IP` and show no value for the `EXTENAL-IP`. In this case,
-use the internal IP.
-{{% /notice %}}
-
-For this example we choose the second node, and so `1.2.3.5` is our DNS record target.
-
-#### DNS Records
-
-The main DNS record must connect the `kubermatic.example.com` domain with the target IP / hostname. Depending on whether
-or not your LoadBalancer/node uses hostnames instead of IPs (like AWS ELB), create either an **A** or a **CNAME** record,
-respectively.
-
-```plain
-kubermatic.example.com.   IN   A   1.2.3.4
-```
-
-or, for a CNAME:
-
-```plain
-kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
-```
-
-#### Identity Aware Proxy
-
-It's a common step to later setup an identity-aware proxy (IAP) to
-[securely access other KKP components]({{< ref "../securing_services" >}}) from the logging or monitoring
-stacks. This involves setting up either individual DNS records per IAP deployment or simply creating a single **wildcard**
-record: `*.kubermatic.example.com`.
-
-Whatever you choose, the DNS record needs to point to the same endpoint (IP or hostname, meaning A or CNAME
-records respectively) as the previous record, i.e. `1.2.3.4`.
-
-```plain
-*.kubermatic.example.com.   IN   A       1.2.3.4
-; or for a CNAME:
-*.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
-```
-
-If CNAME records are not possible, you would configure individual records instead:
-
-```plain
-prometheus.kubermatic.example.com.     IN   A       1.2.3.4
-alertmanager.kubermatic.example.com.   IN   A       1.2.3.4
-```
-
-#### Validation
-
-With the 2 DNS records configured, it's now time to wait for the certificate to be acquired. You can watch the progress
-by doing `watch kubectl -n kubermatic get certificates` until it shows `READY=True`:
-
-```bash
-watch kubectl -n kubermatic get certificates
-#NAME         READY   SECRET           AGE
-#kubermatic   True    kubermatic-tls   1h
-```
-
-If the certificate does not become ready, `describe` it and follow the chain from Certificate to Order to Challenges.
-Typical faults include bad DNS records or a misconfigured KubermaticConfiguration pointing to a different domain.
-
-### Have a Break
-
-With all this in place, you should be able to access https://kubermatic.example.com/ and login either with your static
-password from the `values.yaml` or using any of your chosen connectors. All pods running inside the `kubermatic` namespace
-should now be running. If they are not, check their logs to find out what's broken.
+Follow the CE install guide as normal, the remaining steps apply equally to the Enterprise Edition.
 
 ### Next Steps
 

--- a/content/kubermatic/master/installation/logging_stack/_index.en.md
+++ b/content/kubermatic/master/installation/logging_stack/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Logging Stack"
 date = 2020-02-14T12:07:15+02:00
-weight = 50
+weight = 80
 
 +++
 

--- a/content/kubermatic/master/installation/monitoring_stack/_index.en.md
+++ b/content/kubermatic/master/installation/monitoring_stack/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Monitoring Stack"
 date = 2020-02-14T12:07:15+02:00
-weight = 40
+weight = 70
 
 +++
 

--- a/content/kubermatic/master/installation/securing_services/_index.en.md
+++ b/content/kubermatic/master/installation/securing_services/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Securing System Services"
 date = 2018-04-28T12:07:15+02:00
-weight = 60
+weight = 90
 
 +++
 

--- a/content/kubermatic/v2.15/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/v2.15/installation/add_seed_cluster/_index.en.md
@@ -84,7 +84,8 @@ The Kubermatic repository provides a [script](https://github.com/kubermatic/kube
 a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
 the kubeconfig file. Afterwards the file can be used in KKP.
 
-The Seed resource itself needs to be called `kubermatic` and needs to reference the new kubeconfig Secret like so:
+The Seed resource itself needs to be called `kubermatic` (for the Community Edition) and needs to reference the new
+kubeconfig Secret like so:
 
 ```yaml
 apiVersion: v1

--- a/content/kubermatic/v2.15/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/v2.15/installation/add_seed_cluster/_index.en.md
@@ -1,25 +1,32 @@
 +++
 title = "Add Seed Cluster for CE"
 date = 2018-08-09T12:07:15+02:00
-weight = 30
-
+weight = 40
 +++
 
+This document describes how a new seed cluster can be added to an existing KKP master cluster.
 
-This document describes how a new seed cluster can be added to an existing Kubermatic Kubernetes Platform (KKP) master cluster.
+{{% notice note %}}
+For smaller scale setups it's possible to use the existing master cluster as a seed cluster (a "shared"
+cluster installation). In this case both master and seed components will run on the same cluster and in
+the same namespace. It is however not possible to use the same cluster for multiple seeds.
+{{% /notice %}}
 
 Please refer to the [architecture]({{< ref "../../concepts/architecture" >}}) diagrams for more information
 about the cluster relationships.
 
-### Install KKP Dependencies
+## Install KKP Dependencies
 
-#### Cluster Backups
+Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
+will improve the setup experience further.
+
+### Cluster Backups
 
 KKP performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
-are stored locally inside the cluster, but they can be reconfigured to work with any S3-compatible storage.
+are stored locally inside the seed cluster, but they can be reconfigured to work with any S3-compatible storage.
 The in-cluster storage is provided by [Minio](https://min.io/) and the accompanying `minio` Helm chart.
 
-If your cluster has no default storage class, it's required to configure a class explicitely for Minio. You can check
+If your cluster has no default storage class, it's required to configure a class explicitly for Minio. You can check
 the cluster's storage classes via:
 
 ```bash
@@ -29,8 +36,8 @@ kubectl get storageclasses
 #standard (default)   kubernetes.io/gce-pd   2y43d
 ```
 
-As Minio does not require any of the SSD's advantages, we can use HDDs.
-For a cluster running on AWS, an example class could look like this:
+As Minio does not require any of the SSD's advantages, we can use HDDs. For a cluster running on AWS, an example
+class could look like this:
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -42,7 +49,7 @@ parameters:
   type: sc1
 ```
 
-To configure the storage class and size, extend your `values.yaml` like so:
+To configure the storage class and size, extend your Helm `values.yaml` like so:
 
 ```yaml
 minio:
@@ -52,42 +59,50 @@ minio:
 
 It's also advisable to install the `s3-exporter` Helm chart, as it provides basic metrics about user cluster backups.
 
-#### Install Charts
+### Install Charts
 
 With this you can install the chart:
 
 ```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace s3-exporter s3-exporter charts/s3-exporter/
+helm --namespace minio upgrade --install --values /path/to/your/helm/values.yaml minio charts/minio/
+helm --namespace s3-exporter upgrade --install --values /path/to/your/helm/values.yaml s3-exporter charts/s3-exporter/
 ```
 
+## Add the Seed Resource
 
-### Add the Seed Resource
+To connect the new seed cluster with the master, you need to create a kubeconfig Secret and a Seed resource. This allows
+the KKP components in the master cluster to communicate with the seed cluster and reconcile user-cluster control planes.
 
-To connect the new seed cluster with the master, you need to create a kubeconfig Secret and a Seed resource.
+{{% notice warning %}}
+To make sure that the kubeconfig stays valid forever, it must not contain temporary login tokens. Depending on the
+cloud provider, the default kubeconfig that is provided may not contain username+password / a client certificate, but instead
+try to talk to local token helper programs like `aws-iam-authenticator` for AWS or `gcloud` for the Google Cloud (GKE).
+These kubeconfig files **will not work** for setting up Seeds.
+{{% /notice %}}
 
-You will add the **master cluster** as the **seed cluster**
+The Kubermatic repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/release/v2.14/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in Kubermatic. The script will create
+a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
+the kubeconfig file. Afterwards the file can be used in KKP.
 
-Make sure the kubeconfig contains static, long-lived credentials. Some cloud providers use custom authentication providers
-(like GKE using `gcloud` and EKS using `aws-iam-authenticator`). Those will not work in KKP’s usecase because the
-required tools are not installed inside the cluster environment.
-
-The Seed resource needs to be called `kubermatic` and needs to reference the new kubeconfig Secret like so:
+The Seed resource itself needs to be called `kubermatic` and needs to reference the new kubeconfig Secret like so:
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kubeconfig-europe-west1
+  name: kubeconfig-kubermatic
   namespace: kubermatic
 type: Opaque
 data:
+  # You can use `base64 -w0 my-kubeconfig-file` to encode the
+  # kubeconfig properly for inserting into this Secret.
   kubeconfig: <base64 encoded kubeconfig>
 
 ---
 apiVersion: kubermatic.k8s.io/v1
 kind: Seed
 metadata:
+  # The Seed *must* be named "kubermatic".
   name: kubermatic
   namespace: kubermatic
 spec:
@@ -100,7 +115,7 @@ spec:
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:
-    name: kubeconfig-europe-west1
+    name: kubeconfig-kubermatic
     namespace: kubermatic
 ```
 
@@ -108,33 +123,54 @@ Refer to the [Seed CRD documentation]({{< ref "../../concepts/seeds" >}}) for a 
 Seed CustomResource and all possible datacenters.
 
 Apply the manifest above in the master cluster and KKP will pick up the new Seed and begin to
-reconcile it by installing the required KKP components.
+reconcile it by installing the required KKP components. You can watch the progress by using
+`kubectl` and `watch`:
 
-### Update DNS
+```bash
+kubectl apply -f seed-with-secret.yaml
+Secret/kubeconfig-kubermatic created.
+Seed/kubermatic created.
+
+watch kubectl -n kubermatic get pods
+#NAME                                                   READY   STATUS    RESTARTS   AGE
+#kubermatic-api-55765568f7-br9jl                        1/1     Running   0          5m4s
+#kubermatic-api-55765568f7-xbvz2                        1/1     Running   0          5m13s
+#kubermatic-dashboard-5d784d586b-f46f8                  1/1     Running   0          35m
+#kubermatic-dashboard-5d784d586b-rgl29                  1/1     Running   0          35m
+#kubermatic-master-controller-manager-f58d4df59-w7rkz   1/1     Running   0          5m13s
+#kubermatic-operator-7f6957869d-89g55                   1/1     Running   0          5m37s
+#nodeport-proxy-envoy-6d8bb6fbff-9z57l                  2/2     Running   0          5m6s
+#nodeport-proxy-envoy-6d8bb6fbff-dl58l                  2/2     Running   0          4m54s
+#nodeport-proxy-envoy-6d8bb6fbff-k4gp8                  2/2     Running   0          4m44s
+#nodeport-proxy-updater-7fd55f948-cll8n                 1/1     Running   0          4m44s
+#seed-proxy-kubermatic-6dd5cc95cf-r6wvb                 1/1     Running   0          80m
+```
+
+## Update DNS
 
 The apiservers of all user cluster control planes running in the seed cluster are exposed by the
 NodePort Proxy. By default each user cluster gets a virtual domain name like
-`[cluster-id].[seed-name].[kubermatic-domain]`, e.g. `hdu328tr.europe-west1.kubermatic.example.com`
+`[cluster-id].[seed-name].[kubermatic-domain]`, e.g. `hdu328tr.kubermatic.kubermatic.example.com`
 for the Seed from the previous step when `kubermatic.example.com` is the main domain where the
 KKP dashboard/API are available.
 
 To facilitate this, a wildcard DNS record `*.[seed-name].[kubermatic-domain]` must be created. The target of the
 DNS wildcard record should be the `EXTERNAL-IP` of the `nodeport-proxy` service in the `kubermatic` namespace.
 
-#### With LoadBalancers
+### With LoadBalancers
 
-When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
+When your cloud provider supports LoadBalancers, you can find the target IP / hostname by looking at the
 `nodeport-proxy` Service:
 
 ```bash
 kubectl -n kubermatic get services
-#NAME          TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
+#NAME             TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
 #nodeport-proxy   LoadBalancer   10.47.248.232   8.7.6.5        80:32014/TCP,443:30772/TCP   449d
 ```
 
 The `EXTERNAL-IP` is what we need to put into the DNS record.
 
-#### Without Load Balancers
+### Without LoadBalancers
 
 Without a LoadBalancer, you will need to point to one or many of the seed cluster's nodes. You can get a
 list of external IPs like so:
@@ -147,16 +183,16 @@ kubectl get nodes -o wide
 #worker-node-cbd686cd-90j3   Ready    <none>   45m     v1.15.8-gke.3   10.156.0.22   8.7.6.2
 ```
 
-#### DNS Record
+### DNS Record
 
 Create an A or CNAME record as needed pointing to the target:
 
 ```plain
-*.europe-west1.kubermatic.example.com.   IN   A   8.7.6.5
+*.kubermatic.kubermatic.example.com.   IN   A   8.7.6.5
 ```
 
 or, for a CNAME:
 
 ```plain
-*.europe-west1.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
+*.kubermatic.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
 ```

--- a/content/kubermatic/v2.15/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/v2.15/installation/add_seed_cluster_ee/_index.en.md
@@ -129,7 +129,7 @@ reconcile it by installing the required Kubermatic components. You can watch the
 ```bash
 kubectl apply -f seed-with-secret.yaml
 Secret/kubeconfig-europe-west3 created.
-Seed/kubermatic created.
+Seed/europe-west3 created.
 
 watch kubectl -n kubermatic get pods
 #NAME                                                   READY   STATUS    RESTARTS   AGE

--- a/content/kubermatic/v2.15/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.15/installation/install_kubermatic/_index.en.md
@@ -23,7 +23,7 @@ and make yourself familiar with the requirements for your chosen cloud provider.
 For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
 
 {{% notice warning %}}
-This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
+This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "../../upgrading" >}}) for more information on
 migrating existing installations to the Kubermatic Installer.
 {{% /notice %}}
 
@@ -35,7 +35,8 @@ permissions.
 ### Download the Installer
 
 Download the [tarball](https://github.com/kubermatic/kubermatic/releases/) (e.g. kubermatic-ce-X.Y-linux-amd64.tar.gz)
-containing the Kubermatic Installer and the required Helm charts and extract it locally, for example:
+containing the Kubermatic Installer and the required Helm charts for your operating system and extract it locally. Note that
+for Windows, ZIP files are provided instead of tar.gz files.
 
 ```bash
 # For latest version:
@@ -45,9 +46,6 @@ VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/kubermatic/k
 wget https://github.com/kubermatic/kubermatic/releases/download/v${VERSION}/kubermatic-ce-v${VERSION}-linux-amd64.tar.gz
 tar -xzvf kubermatic-ce-v${VERSION}-linux-amd64.tar.gz
 ```
-
-Make sure to download the installer built for your operating system (Linux, Darwin or Windows). Also note that for Windows,
-ZIP files are provided for convenience.
 
 ### Prepare Configuration
 
@@ -63,7 +61,7 @@ The installation and configuration for a KKP system consists of two important fi
 The release archive hosted on GitHub contains examples for both of the configuration files (`values.example.yaml` and
 `kubermatic.example.yaml`). It's a good idea to take them as a starting point and add more options as necessary.
 
-The main things to configure are:
+The key items to configure are:
 
 * The base domain under which KKP shall be accessible (e.g. `kubermatic.example.com`).
 * The certificate issuer: KKP requires that its dashboard and Dex are only accessible via HTTPS, so a
@@ -92,7 +90,7 @@ ERRO[15:15:20]    Operation failed: please review your configuration and try aga
 {{% notice note %}}
 A couple of settings are duplicated across the `values.yaml` and the KubermaticConfiguration CRD. The installer
 will take care of filling in the gaps, so it is sufficient to configure the base domain in the
-KubermaticConfiguration and letting the installer then set it in the `values.yaml` as well.
+KubermaticConfiguration and let the installer set it in `values.yaml` as well.
 {{% /notice %}}
 
 ### Create a StorageClass
@@ -105,9 +103,16 @@ The installer can automatically create an SSD-based StorageClass for a subset of
 simply copy the default StorageClass, but this is not recommended for production setups unless the default class
 is using SSDs.
 
-Use the `--storageclass` parameter for automatically creating the class during installation. It supports
-automatic creation for AWS, Azure, DigitalOcean, GCE and Hetzner. Run the installer with `--help` to see the current
-list of supported providers.
+Use the `--storageclass` parameter for automatically creating the class during installation. Currently th efollowing
+providers are supported:
+
+- AWS
+- Azure
+- DigitalOcean
+- GCE
+- Hetzner
+
+Run the installer with `--help` to also see the current list of supported providers.
 
 If no automatic provisioning is possible, please manually create a StorageClass called `kubermatic-fast`. Consult
 the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters) for more
@@ -171,7 +176,7 @@ INFO[13:03:33] 🛬 Installation completed successfully. ✌
 
 Follow the instructions on screen to setup your DNS. If the installer for whatever reason is unable to determine
 the appropriate DNS settings, it will tell you so and you can manually collect the required information from the
-cluster. See the following sections for more information regarding the how and why what DNS records are required.
+cluster. See the following sections for more information regarding the required DNS records.
 
 #### With LoadBalancers
 

--- a/content/kubermatic/v2.15/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.15/installation/install_kubermatic/_index.en.md
@@ -20,287 +20,162 @@ This chapter explains the installation procedure of KKP into a pre-existing Kube
 Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "../../requirements" >}})
 and make yourself familiar with the requirements for your chosen cloud provider.
 
-For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 2) installed locally.
+For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
+
+{{% notice warning %}}
+This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
+migrating existing installations to the Kubermatic Installer.
+{{% /notice %}}
 
 ## Installation
 
-To begin the installation, make sure you have a kubeconfig at hand, with a user context that grants `cluster-admin`
+To begin the installation, make sure you have a kubeconfig file at hand, with a user context that grants `cluster-admin`
 permissions.
 
 ### Download the Installer
 
-Download the [tarball](https://github.com/kubermatic/kubermatic/releases/) (e.g. kubermatic-X.Y.tar.gz) containing the
-Helm charts choosing the appropriate release (`vX.Y`) and extract it. e.g.
+Download the [tarball](https://github.com/kubermatic/kubermatic/releases/) (e.g. kubermatic-ce-X.Y-linux-amd64.tar.gz)
+containing the Kubermatic Installer and the required Helm charts and extract it locally, for example:
 
 ```bash
 # For latest version:
 VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/kubermatic/kubermatic/releases/latest -o /dev/null | sed -e 's|.*/v||')
 # For specific version set it explicitly:
-# VERSION=2.14.x
-wget https://github.com/kubermatic/kubermatic/releases/download/v${VERSION}/kubermatic-ce-v${VERSION}.tar.gz
-tar -xzvf kubermatic-ce-v${VERSION}.tar.gz
+# VERSION=2.15.x
+wget https://github.com/kubermatic/kubermatic/releases/download/v${VERSION}/kubermatic-ce-v${VERSION}-linux-amd64.tar.gz
+tar -xzvf kubermatic-ce-v${VERSION}-linux-amd64.tar.gz
 ```
+
+Make sure to download the installer built for your operating system (Linux, Darwin or Windows). Also note that for Windows,
+ZIP files are provided for convenience.
+
+### Prepare Configuration
+
+The installation and configuration for a KKP system consists of two important files:
+
+* A `values.yaml` used to configure the various Helm charts KKP ships with. This is where nginx, Prometheus,
+  Dex etc. can be adjusted to the target environment. A single `values.yaml` is used to configure all Helm charts
+  combined.
+* A `kubermatic.yaml` that configures KKP itself and is an instance of the
+  [KubermaticConfiguration]({{< ref "../../concepts/kubermaticconfiguration" >}}) CRD. This configuration will
+  be stored in the cluster and serves as the basis for the Kubermatic Operator to manage the actual KKP installation.
+
+The release archive hosted on GitHub contains examples for both of the configuration files (`values.example.yaml` and
+`kubermatic.example.yaml`). It's a good idea to take them as a starting point and add more options as necessary.
+
+The main things to configure are:
+
+* The base domain under which KKP shall be accessible (e.g. `kubermatic.example.com`).
+* The certificate issuer: KKP requires that its dashboard and Dex are only accessible via HTTPS, so a
+  certificate is required. By default cert-manager is used, but you have to choose between the production or
+  staging Let's Encrypt services (if in doubt, choose the production server).
+  It is possible to use a custom CA (i.e. self-signed certificates), but this is outside of the scope of this
+  document.
+* For proper authentication, shared secrets must be configured between Dex and KKP. Likewise, Dex uses
+  yet another random secret to encrypt cookiesstored in the users' browsers.
+
+There are many more options, but these are essential to get a minimal system up and running. The secret keys
+mentioned above can be generated using any password generator or on the shell using
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
+properly generated secrets for you when it notices that some are missing, for example:
+
+```bash
+./kubermatic-installer deploy --config kubermatic.yaml --helm-values values.yaml
+INFO[15:15:20] 🛫 Initializing installer…                     edition="Community Edition" version=v2.15.11
+INFO[15:15:20] 🚦 Validating the provided configuration…
+ERRO[15:15:20]    The provided configuration files are invalid:
+ERRO[15:15:20]    KubermaticConfiguration: spec.auth.serviceAccountKey must be a non-empty secret, for example: ZPCs7_KzgJxUSA5lCk_oNzL7RQFTQ6cOnHuTLAh4pGw
+ERRO[15:15:20]    Operation failed: please review your configuration and try again.
+```
+
+{{% notice note %}}
+A couple of settings are duplicated across the `values.yaml` and the KubermaticConfiguration CRD. The installer
+will take care of filling in the gaps, so it is sufficient to configure the base domain in the
+KubermaticConfiguration and letting the installer then set it in the `values.yaml` as well.
+{{% /notice %}}
 
 ### Create a StorageClass
 
 KKP uses a custom storage class for the volumes created for user clusters. This class, `kubermatic-fast`, needs
-to be manually created during the installation and its parameters depend highly on the environment where KKP is
-installed.
+to be created before the installation can succeed and is strongly recommended to use SSDs. The etcd clusters for
+every user cluster will store their data in this StorageClass and etcd is highly sensitive to slow disk I/O.
 
-It's highly recommended to use SSD-based volumes, as etcd is very sensitive to slow disk I/O. If your cluster already
-provides a default SSD-based storage class, you can simply copy and re-create it as `kubermatic-fast`. For a cluster
-running on AWS, an example class could look like this:
+The installer can automatically create an SSD-based StorageClass for a subset of cloud providers. It can also
+simply copy the default StorageClass, but this is not recommended for production setups unless the default class
+is using SSDs.
 
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: kubermatic-fast
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-```
+Use the `--storageclass` parameter for automatically creating the class during installation. It supports
+automatic creation for AWS, Azure, DigitalOcean, GCE and Hetzner. Run the installer with `--help` to see the current
+list of supported providers.
 
-Store the above YAML snippet in a file and then apply it using `kubectl`:
+If no automatic provisioning is possible, please manually create a StorageClass called `kubermatic-fast`. Consult
+the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters) for more
+information about the possible parameters for your storage backend.
 
-```bash
-kubectl apply -f aws-storageclass.yaml
-```
+### Run Installer
 
-Please consult the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters)
-for more information about the possible parameters for your storage backend.
-
-### Install Helm's Tiller
-
-It's required to setup Tiller inside the cluster. This requires setting up a ClusterRole and
--Binding, before installing Tiller itself. If your cluster already has Tiller installed in another namespace, you
-can re-use it, but an installation dedicated for KKP is preferred.
+Once the configuration files have been prepared, it's time to run the installer, which will validate them
+and then install all the required components into the cluster. Open a terminal window and run the installer
+like so:
 
 ```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-
-helm --service-account tiller --tiller-namespace kubermatic init
+./kubermatic-installer deploy \
+  --config kubermatic.yaml \
+  --helm-values values.yaml \
+  --storageclass aws
 ```
 
-### Prepare Configuration
-
-KKP ships with a number of Helm charts that need to be installed into the master or seed clusters. These are
-built so they can be configured using a single, shared `values.yaml` file. The required charts are:
-
-* **Master cluster:** cert-manager, nginx-ingress-controller, oauth
-
-Optional charts are:
-
-* **Master cluster:** iap, [monitoring]({{< ref "../monitoring_stack" >}}), [logging stack]({{< ref "../logging_stack" >}})
-* **Seed cluster:** minio, s3-exporter
-
-In addition to the `values.yaml` for configuring the charts, a number of options will later be made inside a special
-`KubermaticConfiguration` resource.
-
-A minimal configuration for Helm charts sets these options. The secret keys mentioned below can be generated using any
-password generator or on the shell using `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
-On MacOS, use `brew install gnu-tar` and `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`
-
-For the purpose of this document, we only need to configure a few things in the values.yaml:
-
-```yaml
-# Dex is the OpenID Provider for KKP.
-dex:
-  ingress:
-    # configure your base domain, under which the KKP dashboard shall be available
-    host: kubermatic.example.com
-
-  clients:
-  # The "KKP" client is used for logging into the KKP dashboard. It always
-  # needs to be configured.
-  - id: kubermatic
-    name: Kubermatic
-    # generate a secure secret key
-    secret: <dex-kubermatic-oauth-secret-here>
-    RedirectURIs:
-    # ensure the URLs below use the dex.ingress.host configured above
-    - https://kubermatic.example.com
-    - https://kubermatic.example.com/projects
-
-  # Depending on your chosen login method, you need to configure either an OAuth provider like
-  # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
-  # for an overview over all available connectors.
-
-  # For testing purposes, we configure a single static user/password combination.
-  staticPasswords:
-  - email: "kubermatic@example.com"
-    # bcrypt hash of the string "password", can be created using recent versions of htpasswd:
-    # `htpasswd -bnBC 10 "" PASSWORD_HERE | tr -d ':\n' | sed 's/$2y/$2a/'`
-    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-
-    # these are used within KKP to identify the user
-    username: "admin"
-    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
-```
-
-### Install Dependencies
-
-With the configuration prepared, it's now time to install the required Helm charts into the master
-cluster. Take note of where you placed your `values.yaml` and then run the following commands in your
-shell. Note that CRDs are not managed by Helm, so you must apply them manually both when installing
-a component like cert-manager, as well as during any updates later.
-
-```bash
-kubectl apply -f charts/cert-manager/crd/
-
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace nginx-ingress-controller nginx-ingress-controller charts/nginx-ingress-controller/
-
-kubectl apply -f charts/cert-manager/crd/
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace cert-manager cert-manager charts/cert-manager/
-
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace oauth oauth charts/oauth/
-```
-
-Please, make sure that the `cert-manager` is available, before continuing and installing `oauth`, by waiting a minute for its pods to be running (see: *Validation* section below).
-
-#### Validation
-
-Before continuing, make sure the charts we just installed are functioning correctly. Check that pods inside the
-`nginx-ingress-controller`, `oauth` and `cert-manager` namespaces are in status `Running`:
-
-```bash
-kubectl -n nginx-ingress-controller get pods
-#NAME                                        READY   STATUS    RESTARTS   AGE
-#nginx-ingress-controller-55dd87fc7f-5q4zb   1/1     Running   0          17m
-#nginx-ingress-controller-55dd87fc7f-l492k   1/1     Running   0          4h56m
-#nginx-ingress-controller-55dd87fc7f-rwcwf   1/1     Running   0          5h33m
-
-kubectl -n oauth get pods
-#NAME                   READY   STATUS    RESTARTS   AGE
-#dex-7795d657ff-b4fmq   1/1     Running   0          4h59m
-#dex-7795d657ff-kqbk8   1/1     Running   0          20m
-
-kubectl -n cert-manager get pods
-#NAME                           READY   STATUS    RESTARTS   AGE
-#cainjector-5dc8ccbd45-gk6xp    1/1     Running   0          5h36m
-#cert-manager-799ccc8b5-m7wxk   1/1     Running   0          20m
-#webhook-575b887-zb6m2          1/1     Running   0          5h36m
-```
-
-You should also have a working LoadBalancer service created by nginx:
-
-{{% notice note %}}
-Not all cloud providers provide support for LoadBalancers. In these environments the `nginx-ingress-controller` chart can
-be configured to use a NodePort Service instead, which would open ports 80 and 443 on every node of the cluster. Refer to
-the `charts/nginx-ingress-controller/values.yaml` for more information.
+{{% notice warning %}}
+If you get an error about Helm being too old, download the most recent version from https://helm.sh/ and either
+replace your system's Helm installation or specify the path to the Helm 3 binary via `--helm-binary ...` (for
+example `./kubermatic-installer deploy .... --helm-binary /home/me/Downloads/helm-3.3.1`)
 {{% /notice %}}
 
-```bash
-kubectl -n nginx-ingress-controller get services
-#NAME                       TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
-```
-
-Take note of the `EXTERNAL-IP` of this service (`1.2.3.4` in the example above). You will need to configure a DNS record
-pointing to this in a later step.
-
-If any of the pods above are not working, check their logs and describe them (`kubectl -n nginx-ingress-controller describe pod ...`)
-to see what's causing the issues.
-
-### Install KKP Operator
-
-Before installing the KKP Operator, the KKP CRDs need to be installed. You can install them like so:
-
-```bash
-kubectl apply -f charts/kubermatic/crd/
-```
-
-After this, the operator chart can be installed like the previous Helm charts:
-
-```bash
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace kubermatic kubermatic-operator charts/kubermatic-operator/
-```
-
-#### Validation
-
-Once again, let's check that the operator is working properly:
-
-```bash
-kubectl -n kubermatic get pods
-#NAME                                   READY   STATUS    RESTARTS   AGE
-#kubermatic-operator-769986fc8b-7gpsc   1/1     Running   0          28m
-```
-
-### Create KubermaticConfiguration
-
-It's now time to configure KKP itself. This will be done in a `KubermaticConfiguration` CRD, for which a
-[full example]({{< ref "../../concepts/kubermaticconfiguration" >}}) with all options is available, but for the
-purpose of this document we will only need to configure a few things:
-
-```yaml
-apiVersion: operator.kubermatic.io/v1alpha1
-kind: KubermaticConfiguration
-metadata:
-  name: kubermatic
-  namespace: kubermatic
-spec:
-  ingress:
-    # this domain must match what you configured as dex.ingress.host
-    # in the values.yaml
-    domain: kubermatic.example.com
-
-  # These secret keys configure the way components commmunicate with Dex.
-  auth:
-    # this must match the secret configured for the KKP client from
-    # the values.yaml.
-    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
-
-    # these need to be randomly generated. Those can be generated on the
-    # shell using:
-    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
-    issuerCookieKey: <a-random-key>
-    serviceAccountKey: <another-random-key>
-
-  # this needs to match the one in the values.yaml file.
-  imagePullSecret: |
-    {
-      "auths": {
-        "quay.io": {....}
-      }
-    }
-```
-
-Save the YAML above as `kubermatic.yaml` and apply it like so:
-
-```bash
-kubectl apply -f kubermatic.yaml
-```
-
-This will now cause the operator to being provisioning a master cluster for KKP. You can observe the progress by
-looking at `watch kubectl -n kubermatic get pods`:
-
-```bash
-watch kubectl -n kubermatic get pods
-#NAME                                                    READY   STATUS    RESTARTS   AGE
-#kubermatic-api-cfcd95746-5r9z2                          1/1     Running   0          24m
-#kubermatic-api-cfcd95746-tsqjc                          1/1     Running   0          28m
-#kubermatic-master-controller-manager-7d97bb887d-8nb74   1/1     Running   0          3m23s
-#kubermatic-master-controller-manager-7d97bb887d-z8t9w   1/1     Running   0          28m
-#kubermatic-operator-769986fc8b-7gpsc                    1/1     Running   0          28m
-#kubermatic-ui-7fc858fb4b-dq5b5                          1/1     Running   0          85m
-#kubermatic-ui-7fc858fb4b-s8fnn                          1/1     Running   0          24m
-```
+Once the installer has finished, the KKP Master cluster has been installed and will be ready to use once
+the necessary DNS records have been configured (see the next steps).
 
 {{% notice note %}}
-Note that because we don't yet have a TLS certificate and no DNS records configured, some of the pods will crashloop
-until this is fixed.
+Note that because we don't yet have a TLS certificate and no DNS records configured, some of the pods will crashloop.
+This is normal for fresh setups and once the DNS records have been set, things will sort themselves out.
 {{% /notice %}}
+
+If you change your mind later on and adjust configuration options, it's safe to just run the installer again
+to apply your changes.
 
 ### Create DNS Records
 
 In order to acquire a valid certificate, a DNS name needs to point to your cluster. Depending on your environment,
-this can mean a LoadBalancer service or a NodePort service.
+this can mean a LoadBalancer service or a NodePort service. The nginx-ingress-controller Helm chart will by default
+create a LoadBalancer, unless you reconfigure it because your environment does not support LoadBalancers.
 
-#### With Load Balancers
+The installer will do its best to inform you about the required DNS records to set up. You will receive an output
+similar to this:
 
-When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
+```bash
+INFO[13:03:33]    📝 Applying Kubermatic Configuration…
+INFO[13:03:33]    ✅ Success.
+INFO[13:03:33]    📡 Determining DNS settings…
+INFO[13:03:33]       The main LoadBalancer is ready.
+INFO[13:03:33]
+INFO[13:03:33]         Service             : nginx-ingress-controller / nginx-ingress-controller
+INFO[13:03:33]         Ingress via hostname: EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com
+INFO[13:03:33]
+INFO[13:03:33]       Please ensure your DNS settings for "kubermatic.example.com" include the following records:
+INFO[13:03:33]
+INFO[13:03:33]          kubermatic.example.com.    IN  CNAME  EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com.
+INFO[13:03:33]          *.kubermatic.example.com.  IN  CNAME  EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com.
+INFO[13:03:33]
+INFO[13:03:33] 🛬 Installation completed successfully. ✌
+```
+
+Follow the instructions on screen to setup your DNS. If the installer for whatever reason is unable to determine
+the appropriate DNS settings, it will tell you so and you can manually collect the required information from the
+cluster. See the following sections for more information regarding the how and why what DNS records are required.
+
+#### With LoadBalancers
+
+When your cloud provider supports LoadBalancers, you can find the target IP / hostname by looking at the
 `nginx-ingress-controller` Service:
 
 ```bash
@@ -309,9 +184,11 @@ kubectl -n nginx-ingress-controller get services
 #nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
 ```
 
-The `EXTERNAL-IP` is what we need to put into the DNS record.
+The `EXTERNAL-IP` is what we need to put into the DNS record. Note that this can be a hostname (for example on AWS,
+this can be `my-loadbalancer-1234567890.us-west-2.elb.amazonaws.com`) and in this case, the DNS record needs to
+be a `CNAME` rather than an `A` record.
 
-#### Without Load Balancers
+#### Without LoadBalancers
 
 Without a LoadBalancer, you will need to use the NodePort service (refer to the `charts/nginx-ingress-controller/values.yaml`
 for more information) and setup the DNS records to point to one or many of your cluster's nodes. You can get a list of
@@ -352,11 +229,12 @@ kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
 
 It's a common step to later setup an identity-aware proxy (IAP) to
 [securely access other KKP components]({{< ref "../securing_services" >}}) from the logging or monitoring
-stacks. This involves setting up either individual DNS records per IAP deployment or simply creating a single **wildcard**
-record: `*.kubermatic.example.com`.
+stacks. This involves setting up either individual DNS records per IAP deployment (one for Prometheus, one for Grafana, etc.)
+or simply creating a single **wildcard** record: `*.kubermatic.example.com`.
 
 Whatever you choose, the DNS record needs to point to the same endpoint (IP or hostname, meaning A or CNAME
-records respectively) as the previous record, i.e. `1.2.3.4`.
+records respectively) as the previous record, i.e. `1.2.3.4`. This is because the one nginx-ingress-controller is routing
+traffic both for KKP and all other services.
 
 ```plain
 *.kubermatic.example.com.   IN   A       1.2.3.4
@@ -382,7 +260,7 @@ watch kubectl -n kubermatic get certificates
 #kubermatic   True    kubermatic-tls   1h
 ```
 
-If the certificate does not become ready, `describe` it and follow the chain from Certificate to Order to Challenges.
+If the certificate does not become ready, `kubectl describe` it and follow the chain from Certificate to Order to Challenges.
 Typical faults include bad DNS records or a misconfigured KubermaticConfiguration pointing to a different domain.
 
 ### Have a Break
@@ -390,7 +268,6 @@ Typical faults include bad DNS records or a misconfigured KubermaticConfiguratio
 With all this in place, you should be able to access https://kubermatic.example.com/ and login either with your static
 password from the `values.yaml` or using any of your chosen connectors. All pods running inside the `kubermatic` namespace
 should now be running. If they are not, check their logs to find out what's broken.
-
 
 ### Next Steps
 

--- a/content/kubermatic/v2.15/installation/install_kubermatic_ee/_index.en.md
+++ b/content/kubermatic/v2.15/installation/install_kubermatic_ee/_index.en.md
@@ -29,8 +29,8 @@ and make yourself familiar with the requirements for your chosen cloud provider.
 For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
 
 {{% notice warning %}}
-This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
-migrating existing KKP installations to the Kubermatic Installer.
+This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "../../upgrading" >}})
+for more information on migrating existing installations to the Kubermatic Installer.
 {{% /notice %}}
 
 ## Installation

--- a/content/kubermatic/v2.15/installation/install_kubermatic_ee/_index.en.md
+++ b/content/kubermatic/v2.15/installation/install_kubermatic_ee/_index.en.md
@@ -1,14 +1,16 @@
 +++
 title = "Install Kubermatic Kubernetes Platform (KKP) EE"
 date = 2018-04-28T12:07:15+02:00
-weight = 20
+weight = 30
 enterprise = true
 +++
 
-This chapter explains the installation procedure of KKP into a pre-existing Kubernetes cluster.
+This chapter explains the installation procedure of KKP Enterprise Edition (EE) into a pre-existing
+Kubernetes cluster.
 
 {{% notice note %}}
-At the moment you need to be invited to get access to KKP's Docker registry before you can try it out. Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
+At the moment you need to be invited to get access to Kubermatic's EE Docker repository before you can try it out.
+Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
 ## Terminology
@@ -24,222 +26,24 @@ At the moment you need to be invited to get access to KKP's Docker registry befo
 Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "../../requirements" >}})
 and make yourself familiar with the requirements for your chosen cloud provider.
 
-For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 2 or 3) installed locally.
+For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
+
+{{% notice warning %}}
+This guide assumes a clean installation into an empty cluster. Please refer to the upgrade notes for more information on
+migrating existing KKP installations to the Kubermatic Installer.
+{{% /notice %}}
 
 ## Installation
 
-To begin the installation, make sure you have a kubeconfig at hand, with a user context that grants `cluster-admin`
-permissions.
+The installation procedure is identical to the [Community Edition]({{< ref "../install_kubermatic" >}}), with the exception that
+a different installer needs to be downloaded and that the Docker credentials need to be configured.
 
-### Download the Installer
+When downloading the installer, make sure to choose the `-ee-` variant on GitHub. Extract it like documented in the CE install
+guide.
 
-Download the [tarball](https://github.com/kubermatic/kubermatic/releases/) (e.g. kubermatic-X.Y.tar.gz) containing the
-Helm charts choosing the appropriate release (`vX.Y`) and extract it. e.g.
-
-```bash
-# For latest version:
-VERSION=$(curl -w '%{url_effective}' -I -L -s -S https://github.com/kubermatic/kubermatic/releases/latest -o /dev/null | sed -e 's|.*/v||')
-# For specific version set it explicitly:
-# VERSION=2.14.x
-wget https://github.com/kubermatic/kubermatic/releases/download/v${VERSION}/kubermatic-ee-v${VERSION}.tar.gz
-tar -xzvf kubermatic-ee-v${VERSION}.tar.gz
-```
-
-### Create a StorageClass
-
-KKP uses a custom storage class for the volumes created for user clusters. This class, `kubermatic-fast`, needs
-to be manually created during the installation and its parameters depend highly on the environment where KKP is
-installed.
-
-It's highly recommended to use SSD-based volumes, as etcd is very sensitive to slow disk I/O. If your cluster already
-provides a default SSD-based storage class, you can simply copy and re-create it as `kubermatic-fast`. For a cluster
-running on AWS, an example class could look like this:
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: kubermatic-fast
-provisioner: kubernetes.io/aws-ebs
-parameters:
-  type: gp2
-```
-
-Store the above YAML snippet in a file and then apply it using `kubectl`:
-
-```bash
-kubectl apply -f aws-storageclass.yaml
-```
-
-Please consult the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters)
-for more information about the possible parameters for your storage backend.
-
-### Install Helm's Tiller
-
-{{% notice note %}}
-This step is only required when using Helm 2.
-{{% /notice %}}
-
-When using Helm 2, it's required to setup Tiller inside the cluster. This requires setting up a ClusterRole and
--Binding, before installing Tiller itself. If your cluster already has Tiller installed in another namespace, you
-can re-use it, but an installation dedicated for KKP is preferred.
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
-### Prepare Configuration
-
-KKP ships with a number of Helm charts that need to be installed into the master or seed clusters. These are
-built so they can be configured using a single, shared `values.yaml` file. The required charts are
-
-* **Master cluster:** cert-manager, nginx-ingress-controller, oauth(, iap)
-* **Seed cluster:** nodeport-proxy, minio, s3-exporter
-
-There are additional charts for the [monitoring]({{< ref "../monitoring_stack" >}}) and [logging stack]({{< ref "../logging_stack" >}})
-which will be discussed in their dedicated chapters, as they are not strictly required for running KKP.
-
-In addition to the `values.yaml` for configuring the charts, a number of options will later be made inside a special
-`KubermaticConfiguration` resource.
-
-A minimal configuration for Helm charts sets these options. The secret keys mentioned below can be generated using any
-password generator or on the shell using `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
-
-```yaml
-# Dex Is the OpenID Provider for KKP.
-dex:
-  ingress:
-    # configure your base domain, under which the KKP dashboard shall be available
-    host: kubermatic.example.com
-
-  clients:
-  # The "KKP" client is used for logging into the KKP dashboard. It always
-  # needs to be configured.
-  - id: kubermatic
-    name: Kubermatic
-    # generate a secure secret key
-    secret: <dex-kubermatic-oauth-secret-here>
-    RedirectURIs:
-    # ensure the URLs below use the dex.ingress.host configured above
-    - https://kubermatic.example.com
-    - https://kubermatic.example.com/projects
-
-  # Depending on your chosen login method, you need to configure either an OAuth provider like
-  # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`
-  # for an overview over all available connectors.
-
-  # For testing purposes, we configure a single static user/password combination.
-  staticPasswords:
-  - email: "kubermatic@example.com"
-    # bcrypt hash of the string "password", can be created using recent versions of htpasswd:
-    # `htpasswd -bnBC 10 "" PASSWORD_HERE | tr -d ':\n' | sed 's/$2y/$2a/'`
-    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-
-    # these are used within KKP to identify the user
-    username: "admin"
-    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
-
-kubermaticOperator:
-  # insert the Docker authentication JSON provided by KKP here
-  imagePullSecret: |
-    {
-      "auths": {
-        "quay.io": {....}
-      }
-    }
-```
-
-### Install Dependencies
-
-With the configuration prepared, it's now time to install the required Helm charts into the master
-cluster. Take note of where you placed your `values.yaml` and then run the following commands in your
-shell:
-
-```bash
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace nginx-ingress-controller nginx-ingress-controller charts/nginx-ingress-controller/
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace cert-manager cert-manager charts/cert-manager/
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace oauth oauth charts/oauth/
-```
-
-Please, make sure that the `cert-manager` is available, before continuing and installing `oauth`, by waiting a minute for its pods to be running (see: *Validation* section below).
-
-#### Validation
-
-Before continuing, make sure the charts we just installed are functioning correctly. Check that pods inside the
-`nginx-ingress-controller`, `oauth` and `cert-manager` namespaces are in status `Running`:
-
-```bash
-kubectl -n nginx-ingress-controller get pods
-#NAME                                        READY   STATUS    RESTARTS   AGE
-#nginx-ingress-controller-55dd87fc7f-5q4zb   1/1     Running   0          17m
-#nginx-ingress-controller-55dd87fc7f-l492k   1/1     Running   0          4h56m
-#nginx-ingress-controller-55dd87fc7f-rwcwf   1/1     Running   0          5h33m
-
-kubectl -n oauth get pods
-#NAME                   READY   STATUS    RESTARTS   AGE
-#dex-7795d657ff-b4fmq   1/1     Running   0          4h59m
-#dex-7795d657ff-kqbk8   1/1     Running   0          20m
-
-kubectl -n cert-manager get pods
-#NAME                           READY   STATUS    RESTARTS   AGE
-#cainjector-5dc8ccbd45-gk6xp    1/1     Running   0          5h36m
-#cert-manager-799ccc8b5-m7wxk   1/1     Running   0          20m
-#webhook-575b887-zb6m2          1/1     Running   0          5h36m
-```
-
-You should also have a working LoadBalancer service created by nginx:
-
-{{% notice note %}}
-Not all cloud providers provide support for LoadBalancers. In these environments the `nginx-ingress-controller` chart can
-be configured to use a NodePort Service instead, which would open ports 80 and 443 on every node of the cluster. Refer to
-the `charts/nginx-ingress-controller/values.yaml` for more information.
-{{% /notice %}}
-
-```bash
-kubectl -n nginx-ingress-controller get services
-#NAME                       TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
-```
-
-Take note of the `EXTERNAL-IP` of this service (`1.2.3.4` in the example above). You will need to configure a DNS record
-pointing to this in a later step.
-
-If any of the pods above are not working, check their logs and describe them (`kubectl -n nginx-ingress-controller describe pod ...`)
-to see what's causing the issues.
-
-### Install KKP Operator
-
-Before installing the KKP Operator, the KKP CRDs need to be installed. You can install them like so:
-
-```bash
-kubectl apply -f charts/kubermatic/crd/
-```
-
-After this, the operator chart can be installed like the previous Helm charts:
-
-```bash
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace kubermatic charts/kubermatic-operator/
-```
-
-#### Validation
-
-Once again, let's check that the operator is working properly:
-
-```bash
-kubectl -n kubermatic get pods
-#NAME                                   READY   STATUS    RESTARTS   AGE
-#kubermatic-operator-769986fc8b-7gpsc   1/1     Running   0          28m
-```
-
-### Create KubermaticConfiguration
-
-It's now time to configure KKP itself. This will be done in a `KubermaticConfiguration` CRD, for which a
-[full example]({{< ref "../../concepts/kubermaticconfiguration" >}}) with all options is available, but for the
-purpose of this document we will only need to configure a few things:
+During configuration, it's required to set the Docker Pull Secret, which allows the local Docker daemons to pull the KKP
+images from the private Docker repository. The Docker Pull Secret is a tiny JSON snippet and needs to be configured in the
+KubermaticConfiguration (e.g. in the `kubermatic.yaml`):
 
 ```yaml
 apiVersion: operator.kubermatic.io/v1alpha1
@@ -248,147 +52,20 @@ metadata:
   name: kubermatic
   namespace: kubermatic
 spec:
-  ingress:
-    # this domain must match what you configured as dex.ingress.host
-    # in the values.yaml
-    domain: kubermatic.example.com
+  # skipping everything else in this file
+  # for demonstration purposes
 
-  # These secret keys configure the way components commmunicate with Dex.
-  auth:
-    # this must match the secret configured for the KKP client from
-    # the values.yaml.
-    issuerClientSecret: <dex-kubermatic-oauth-secret-here>
-
-    # these need to be randomly generated
-    issuerCookieKey: <a-random-key>
-    serviceAccountKey: <another-random-key>
+  # This is where the JSON snippet needs to be configured. It does not need to be
+  # a multiline JSON string.
+  imagePullSecret: |
+    {
+      "auths": {
+        "quay.io": {....}
+      }
+    }
 ```
 
-You can find the YAML above under `examples/kubermatic.example.ee.yaml`
-Save the YAML above as `kubermatic.yaml` and apply it like so:
-Apply it like using kubectl:
-
-```bash
-kubectl apply -f examples/kubermatic.example.ee.yaml
-```
-
-This will now cause the operator to being provisioning a master cluster for KKP. You can observe the progress by
-looking at `watch kubectl -n kubermatic get pods`:
-
-```bash
-watch kubectl -n kubermatic get pods
-#NAME                                                    READY   STATUS    RESTARTS   AGE
-#kubermatic-api-cfcd95746-5r9z2                          1/1     Running   0          24m
-#kubermatic-api-cfcd95746-tsqjc                          1/1     Running   0          28m
-#kubermatic-master-controller-manager-7d97bb887d-8nb74   1/1     Running   0          3m23s
-#kubermatic-master-controller-manager-7d97bb887d-z8t9w   1/1     Running   0          28m
-#kubermatic-operator-769986fc8b-7gpsc                    1/1     Running   0          28m
-#kubermatic-ui-7fc858fb4b-dq5b5                          1/1     Running   0          85m
-#kubermatic-ui-7fc858fb4b-s8fnn                          1/1     Running   0          24m
-```
-
-{{% notice note %}}
-Note that because we don't yet have a TLS certificate and no DNS records configured, some of the pods will crashloop
-until this is fixed.
-{{% /notice %}}
-
-### Create DNS Records
-
-In order to acquire a valid certificate, a DNS name needs to point to your cluster. Depending on your environment,
-this can mean a LoadBalancer service or a NodePort service.
-
-#### With Load Balancers
-
-When your cloud provider supports Load Balancers, you can find the target IP / hostname by looking at the
-`nginx-ingress-controller` Service:
-
-```bash
-kubectl -n nginx-ingress-controller get services
-#NAME                       TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
-```
-
-The `EXTERNAL-IP` is what we need to put into the DNS record.
-
-#### Without Load Balancers
-
-Without a LoadBalancer, you will need to use the NodePort service (refer to the `charts/nginx-ingress-controller/values.yaml`
-for more information) and setup the DNS records to point to one or many of your cluster's nodes. You can get a list of
-external IPs like so:
-
-```bash
-kubectl get nodes -o wide
-#NAME                        STATUS   ROLES    AGE     VERSION         INTERNAL-IP   EXTERNAL-IP
-#worker-node-cbd686cd-50nx   Ready    <none>   3h36m   v1.15.8-gke.3   10.156.0.36   1.2.3.4
-#worker-node-cbd686cd-59s2   Ready    <none>   21m     v1.15.8-gke.3   10.156.0.14   1.2.3.5
-#worker-node-cbd686cd-90j3   Ready    <none>   45m     v1.15.8-gke.3   10.156.0.22   1.2.3.6
-```
-
-{{% notice note %}}
-Some cloud providers list the external IP as the `INTERNAL-IP` and show no value for the `EXTENAL-IP`. In this case,
-use the internal IP.
-{{% /notice %}}
-
-For this example we choose the second node, and so `1.2.3.5` is our DNS record target.
-
-#### DNS Records
-
-The main DNS record must connect the `kubermatic.example.com` domain with the target IP / hostname. Depending on whether
-or not your LoadBalancer/node uses hostnames instead of IPs (like AWS ELB), create either an **A** or a **CNAME** record,
-respectively.
-
-```plain
-kubermatic.example.com.   IN   A   1.2.3.4
-```
-
-or, for a CNAME:
-
-```plain
-kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
-```
-
-#### Identity Aware Proxy
-
-It's a common step to later setup an identity-aware proxy (IAP) to
-[securely access other KKP components]({{< ref "../securing_services" >}}) from the logging or monitoring
-stacks. This involves setting up either individual DNS records per IAP deployment or simply creating a single **wildcard**
-record: `*.kubermatic.example.com`.
-
-Whatever you choose, the DNS record needs to point to the same endpoint (IP or hostname, meaning A or CNAME
-records respectively) as the previous record, i.e. `1.2.3.4`.
-
-```plain
-*.kubermatic.example.com.   IN   A       1.2.3.4
-; or for a CNAME:
-*.kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
-```
-
-If CNAME records are not possible, you would configure individual records instead:
-
-```plain
-prometheus.kubermatic.example.com.     IN   A       1.2.3.4
-alertmanager.kubermatic.example.com.   IN   A       1.2.3.4
-```
-
-#### Validation
-
-With the 2 DNS records configured, it's now time to wait for the certificate to be acquired. You can watch the progress
-by doing `watch kubectl -n kubermatic get certificates` until it shows `READY=True`:
-
-```bash
-watch kubectl -n kubermatic get certificates
-#NAME         READY   SECRET           AGE
-#kubermatic   True    kubermatic-tls   1h
-```
-
-If the certificate does not become ready, `describe` it and follow the chain from Certificate to Order to Challenges.
-Typical faults include bad DNS records or a misconfigured KubermaticConfiguration pointing to a different domain.
-
-### Have a Break
-
-With all this in place, you should be able to access https://kubermatic.example.com/ and login either with your static
-password from the `values.yaml` or using any of your chosen connectors. All pods running inside the `kubermatic` namespace
-should now be running. If they are not, check their logs to find out what's broken.
+Follow the CE install guide as normal, the remaining steps apply equally to the Enterprise Edition.
 
 ### Next Steps
 

--- a/content/kubermatic/v2.15/installation/logging_stack/_index.en.md
+++ b/content/kubermatic/v2.15/installation/logging_stack/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Logging Stack"
 date = 2020-02-14T12:07:15+02:00
-weight = 50
+weight = 80
 
 +++
 

--- a/content/kubermatic/v2.15/installation/monitoring_stack/_index.en.md
+++ b/content/kubermatic/v2.15/installation/monitoring_stack/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Monitoring Stack"
 date = 2020-02-14T12:07:15+02:00
-weight = 40
+weight = 70
 
 +++
 

--- a/content/kubermatic/v2.15/installation/securing_services/_index.en.md
+++ b/content/kubermatic/v2.15/installation/securing_services/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Securing System Services"
 date = 2018-04-28T12:07:15+02:00
-weight = 60
+weight = 90
 
 +++
 


### PR DESCRIPTION
This documents how to use the new installer starting with Kubermatic 2.15. The PR

* rewords the install docs to use the installer and Helm 3 exclusively.
* improves the DNS setup stuff by pointing at the installer.
* ends our practice of duplicating CE and EE docs by simply saying "EE installation is identical except for this one thing". This will make it easier to keep the docs up-to-date, as they don't get out of sync so quickly.