### PR TITLE
Document Helm 3 in KKP

### DIFF
--- a/content/kubermatic/master/advanced/oidc_auth/_index.en.md
+++ b/content/kubermatic/master/advanced/oidc_auth/_index.en.md
@@ -23,7 +23,7 @@ explicitly granted by creating appropriate [RBAC](https://kubernetes.io/docs/ref
 
 In order to demonstrate the feature we are going to need a working cluster. If you don't have one please check the
 [how to create a cluster]({{< ref "../../getting_started/create_cluster/" >}}) section. If the feature was enabled on your
-installation you should see a "Share cluster" button after navigating to "Cluster details" page.
+installation you will see a "Share cluster" button after navigating to "Cluster details" page.
 
 ![Share cluster button](/img/kubermatic/master/advanced/oidc-auth/share-cluster.png)
 
@@ -133,8 +133,8 @@ dex:
 
 ### Root CA Certificates Chain
 
-In order to verify OIDC provider's certificate in `kubermatic-controll-manager` when establishing
-TLS connection, a public root CA certificate is required. Ideally the whole chain including all intermediary
+In order to verify OIDC provider's certificate in `kubermatic-controller-manager` when establishing
+TLS connection, a public root CA certificate is required. Ideally the whole chain including all intermediate
 CAs certificates is included. Note that we expect that all certificates will be PEM encoded.
 
 For example if the certificate used by your provider was issued by Let's Encrypt. You can visit
@@ -169,7 +169,7 @@ Now that the issuer is available, update the `KubermaticConfiguration`:
 kubectl -n kubermatic apply -f kubermaticconfig.yaml
 ```
 
-After the operator has reconciled the KKP installation, OIDC auth should be available.
+After the operator has reconciled the KKP installation, OIDC auth will become available.
 
 ### Role-Based Access Control Predefined Roles
 

--- a/content/kubermatic/master/advanced/oidc_auth/_index.en.md
+++ b/content/kubermatic/master/advanced/oidc_auth/_index.en.md
@@ -18,11 +18,12 @@ section for instruction on how to enable this for your installation.
 ### How Does It Work
 
 This section will demonstrate how to obtain and use the `kubeconfig` to connect to a cluster owned by a different user.
-Note that the user to which the `kubeconfig` is shared will not have any permissions inside that shared cluster unless explicitly granted
-by creating appropriate [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac) bindings.
+Note that the user to which the `kubeconfig` is shared will not have any permissions inside that shared cluster unless
+explicitly granted by creating appropriate [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac) bindings.
 
-In order to demonstrate the feature we are going to need a working cluster. If you don't have one please check the [how to create a cluster](../../getting_started/create_cluster/) section.
-If the feature was enabled on your installation you should see a "Share cluster" button after navigating to "Cluster details" page.
+In order to demonstrate the feature we are going to need a working cluster. If you don't have one please check the
+[how to create a cluster]({{< ref "../../getting_started/create_cluster/" >}}) section. If the feature was enabled on your
+installation you should see a "Share cluster" button after navigating to "Cluster details" page.
 
 ![Share cluster button](/img/kubermatic/master/advanced/oidc-auth/share-cluster.png)
 
@@ -33,92 +34,148 @@ Right after clicking on the button you will see a modal window where you can cop
 You can now share this link with anyone that can access the KKP UI. After login, that person will get a download link for a
 `kubeconfig`.
 
-In order for the shared `kubeconfig` to be of any use, we must grant that other user some permissions. To do so, configure `kubectl` to
-point to the cluster and create a `rolebinding` or `clusterrolebinding`, using the email address of the user the `kubeconfig` was
-shared to as value for the `user` property.
+In order for the shared `kubeconfig` to be of any use, we must grant that other user some permissions. To do so, configure
+`kubectl` to point to the cluster and create a `rolebinding` or `clusterrolebinding`, using the email address of the user
+the `kubeconfig` was shared to as value for the `user` property.
 
-The following example command grants read-only access to the cluster to `lukasz@kubermatic.com`:
+The following example command grants read-only access to the cluster to `user@example.com`:
 
 ```bash
-kubectl create clusterrolebinding lukaszviewer --clusterrole=view --user=lukasz@kubermatic.com
+kubectl create clusterrolebinding exampleuserviewer --clusterrole=view --user=user@example.com
 ```
 
 Now it's time to let the user the cluster was shared to use the config and list some resources for example `pods`.
 Even though there might be no `pods` running at the moment the command will not report any authorization related issues.
 
-```plaintext
+```bash
 kubectl get pods
-No resources found.
+#No resources found.
 ```
 
-If the `lukaszviewer` binding gets deleted or something else goes wrong, the following output is displayed instead:
+If the `exampleuserviewer` binding gets deleted or something else goes wrong, the following output is displayed instead:
 
 ```bash
 kubectl get pods
-
-Error from server (Forbidden): pods is forbidden: User "lukasz@kubermatic.com" cannot list pods in the namespace "default"
+#Error from server (Forbidden): pods is forbidden: User "user@example.com" cannot list pods in the namespace "default"
 ```
 
 ### Prerequisites
 
 In order to enable the feature the necessary flags must be passed to various applications.
-This is best done by directly changing the entries in the corresponding `values.yaml` file.
 
-`kubermatic-api-server` must be run with the following flags.
+KKP needs to be reconfigured by adjusting the `KubermaticConfiguration`. In the `auth.spec` section, more fields
+need to be specified. In addition to this, two feature flags need to be set.
 
-```plaintext
---feature-gates={{ .Values.kubermatic.api.featureGates }} # must contain "OIDCKubeCfgEndpoint=true"
---oidc-issuer-redirect-uri={{ .Values.kubermatic.auth.issuerRedirectURL }}
---oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
---oidc-issuer-client-secret={{ .Values.kubermatic.auth.issuerClientSecret }}
---oidc-issuer-cookie-hash-key={{ .Values.kubermatic.auth.issuerCookieKey }}
+```yaml
+apiVersion: operator.kubermatic.io/v1alpha1
+kind: KubermaticConfiguration
+metadata:
+  # ...
+spec:
+  featureGates:
+    # exposes an HTTP endpoint for generating kubeconfig
+    # for a cluster that will contain OIDC tokens
+    OIDCKubeCfgEndpoint:
+      enabled: {}
+    # configures the flags on the API server to use
+    # OAuth2 identity providers
+    OpenIDAuthPlugin:
+      enabled: {}
+
+  ui:
+    # enable shared kubeconfig feature in the dashboard
+    config: |-
+      {
+        "share_kubeconfig": true
+      }
+
+  auth:
+    # This is the OIDC issuer client ID and defaults to
+    # "<spec.auth.clientID>Issuer". As the default issuer used
+    # for the dashboard is "kubermatic", this defaults to:
+    issuerClientID: kubermaticIssuer
+
+    # The shared secret between Dex and KKP. This needs to be
+    # randomly generated, e.g. via
+    #   cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    issuerClientSecret: ""
+
+    # used for encrypting HTTP cookies, also needs to be
+    # randomly generated
+    issuerCookieKey: ""
+
+    # This is the OIDC redirect URL and defaults to the
+    # kubeconfig endpoint in the dashboard, i.e.
+    # "https://<spec.ingress.domain>/api/v1/kubeconfig"
+    issuerRedirectURL: https://example.com/api/v1/kubeconfig
+
+    # OIDC provider's root CA certificates chain, see
+    # the section further down in this document for more
+    # information on how to generate this
+    caBundle: |-
+      -----BEGIN CERTIFICATE-----
+      ....
+      -----END CERTIFICATE-----
 ```
 
-{{% notice note %}}
-The value for `.Values.kubermatic.auth.issuerCookieKey` can be randomly generated (e.g. `openssl rand -hex 32`) and should have 32 or 64 bytes.
-{{% /notice %}}
+These values must match the configuration used for the `oauth` Helm chart (Dex). Define
+the new `issuerClientID` in Dex by editing your `values.yaml` used for setting Dex up:
 
-`kubermatic-controll-manager` must be run with the following flags:
-
-```plaintext
---feature-gates={{ .Values.kubermatic.controller.featureGates }}  # must contain "OpenIDAuthPlugin=true"
---oidc-issuer-url={{ .Values.kubermatic.auth.tokenIssuer }}
---oidc-issuer-client-id={{ .Values.kubermatic.auth.issuerClientID }}
---oidc-ca-file={{ .Values.kubermatic.auth.caBundle }}
+```yaml
+dex:
+  clients:
+  - id: kubermaticIssuer
+    name: Kubermatic OIDC Issuer
+    secret: "" # put the value of issuerClientSecret here
+    RedirectURIs:
+    - https://example.com/api/v1/kubeconfig # issuerRedirectURL
 ```
-
-{{% notice note %}}
-Note that `.Values.kubermatic.auth.caBundle` must contain OIDC provider's root CA certificates chain, see [Root CA certificates chain](#root-ca-certificates-chain) section that explains how to create the file.
-{{% /notice %}}
-
-`conifg.json` file for `kubermatic-dashboard` must contain `"share_kubeconfig":true`.
-You can set it by changing the `kubermatic.ui.config` entry in the `values.yaml` file. Afterwards, [update KKP](#update-kubermatic).
 
 ### Root CA Certificates Chain
 
-In order to verify OIDC provider's certificate in `kubermatic-controll-manager` when establishing TLS connection a public root CA certificate is required. Ideally the whole
-chain including all intermediary CAs certificates. Note that we expect that all certificates will be PEM encoded.
+In order to verify OIDC provider's certificate in `kubermatic-controll-manager` when establishing
+TLS connection, a public root CA certificate is required. Ideally the whole chain including all intermediary
+CAs certificates is included. Note that we expect that all certificates will be PEM encoded.
 
-For example if the certificate used by your provider was issued by Let's Encrypt. You can visit [Let's Encrypt](https://letsencrypt.org/certificates) to download the necessary certificates
-and use the following command to prepare the bundle.
+For example if the certificate used by your provider was issued by Let's Encrypt. You can visit
+[Let's Encrypt](https://letsencrypt.org/certificates) to download the necessary certificates and use the
+following command to prepare the bundle.
 
 ```bash
 cat isrgrootx1.pem.txt lets-encrypt-x3-cross-signed.pem.txt > caBundle.pem
 ```
 
+This bundle must then be copied verbatim into the `KubermaticConfiguration`.
+
 ### Update KKP
 
-After all values are set at the `values.yaml` the installed helm charts `kubermatic` and `oauth` need to get updated (at the master cluster):
+After all values are set up, it's time to update the KKP master cluster. Update the `oauth` chart first:
+
+**Helm 3**
 
 ```bash
-helm upgrade --install --wait --timeout 300 --values values.yaml --namespace oauth oauth charts/kubermatic/oauth
-helm upgrade --install --wait --timeout 300 --values values.yaml --namespace kubermatic kubermatic charts/kubermatic/
+helm --namespace oauth upgrade --install --wait --values values.yaml oauth charts/oauth/
 ```
+
+**Helm 2**
+
+```bash
+helm upgrade --install --wait --timeout 300 --values values.yaml --namespace oauth oauth charts/oauth/
+```
+
+Now that the issuer is available, update the `KubermaticConfiguration`:
+
+```bash
+kubectl -n kubermatic apply -f kubermaticconfig.yaml
+```
+
+After the operator has reconciled the KKP installation, OIDC auth should be available.
 
 ### Role-Based Access Control Predefined Roles
 
-KKP provides predefined roles and cluster roles to help implement granular permissions for specific resources and
-to simplify access control across the user cluster. All of the default roles and cluster roles are labeled with `component=userClusterRole`.
+KKP provides predefined roles and cluster roles to help implement granular permissions for specific resources
+and to simplify access control across the user cluster. All of the default roles and cluster roles are labeled
+with `component=userClusterRole`.
 
 | Default ClusterRole | Description                                                                                                                                                                                                                                       |
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster/_index.en.md
@@ -20,6 +20,15 @@ about the cluster relationships.
 Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
 will improve the setup experience further.
 
+When using Helm 2, install Tiller into the seed cluster first:
+
+```bash
+kubectl create namespace kubermatic
+kubectl create serviceaccount -n kubermatic tiller
+kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
+helm --service-account tiller --tiller-namespace kubermatic init
+```
+
 ### Cluster Backups
 
 KKP performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
@@ -61,11 +70,20 @@ It's also advisable to install the `s3-exporter` Helm chart, as it provides basi
 
 ### Install Charts
 
-With this you can install the chart:
+With this you can install the charts:
+
+**Helm 3**
 
 ```bash
-helm --namespace minio upgrade --install --values /path/to/your/helm/values.yaml minio charts/minio/
-helm --namespace s3-exporter upgrade --install --values /path/to/your/helm/values.yaml s3-exporter charts/s3-exporter/
+helm --namespace minio upgrade --install --wait --values /path/to/your/helm-values.yaml minio charts/minio/
+helm --namespace kube-system upgrade --install --wait --values /path/to/your/helm-values.yaml s3-exporter charts/s3-exporter/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace kube-system s3-exporter charts/s3-exporter/
 ```
 
 ## Add the Seed Resource

--- a/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/master/installation/add_seed_cluster_ee/_index.en.md
@@ -21,6 +21,15 @@ about the cluster relationships.
 Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
 will improve the setup experience further.
 
+When using Helm 2, install Tiller into the seed cluster first:
+
+```bash
+kubectl create namespace kubermatic
+kubectl create serviceaccount -n kubermatic tiller
+kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
+helm --service-account tiller --tiller-namespace kubermatic init
+```
+
 ### Cluster Backups
 
 KKP performs regular backups of user cluster by snapshotting the etcd of each cluster. By default these backups
@@ -62,11 +71,20 @@ It's also advisable to install the `s3-exporter` Helm chart, as it provides basi
 
 ### Install Charts
 
-With this you can install the chart:
+With this you can install the charts:
+
+**Helm 3**
 
 ```bash
-helm --namespace minio upgrade --install --values /path/to/your/helm/values.yaml minio charts/minio/
-helm --namespace s3-exporter upgrade --install --values /path/to/your/helm/values.yaml s3-exporter charts/s3-exporter/
+helm --namespace minio upgrade --install --wait --values /path/to/your/helm-values.yaml minio charts/minio/
+helm --namespace kube-system upgrade --install --wait --values /path/to/your/helm-values.yaml s3-exporter charts/s3-exporter/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace kube-system s3-exporter charts/s3-exporter/
 ```
 
 ## Add the Seed Resource

--- a/content/kubermatic/master/installation/logging_stack/_index.en.md
+++ b/content/kubermatic/master/installation/logging_stack/_index.en.md
@@ -54,7 +54,16 @@ promtail:
 
 With this file prepared, we can now install all required charts:
 
+**Helm 3**
+
 ```bash
-helm upgrade --install --values values.yaml --namespace monitoring promtail charts/monitoring/promtail/
-helm upgrade --install --values values.yaml --namespace monitoring loki charts/monitoring/loki/
+helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml promtail charts/logging/promtail/
+helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml loki charts/logging/loki/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace logging promtail charts/logging/promtail/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace logging loki charts/logging/loki/
 ```

--- a/content/kubermatic/master/installation/monitoring_stack/_index.en.md
+++ b/content/kubermatic/master/installation/monitoring_stack/_index.en.md
@@ -69,13 +69,26 @@ grafana:
 
 With this file prepared, we can now install all required charts:
 
+**Helm 3**
+
 ```bash
-helm upgrade --install --values values.yaml --namespace monitoring prometheus charts/monitoring/prometheus/
-helm upgrade --install --values values.yaml --namespace monitoring alertmanager charts/monitoring/alertmanager/
-helm upgrade --install --values values.yaml --namespace monitoring node-exporter charts/monitoring/node-exporter/
-helm upgrade --install --values values.yaml --namespace monitoring kube-state-metrics charts/monitoring/kube-state-metrics/
-helm upgrade --install --values values.yaml --namespace monitoring grafana charts/monitoring/grafana/
-helm upgrade --install --values values.yaml --namespace monitoring karma charts/monitoring/karma/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml prometheus charts/monitoring/prometheus/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml alertmanager charts/monitoring/alertmanager/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml node-exporter charts/monitoring/node-exporter/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml kube-state-metrics charts/monitoring/kube-state-metrics/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml grafana charts/monitoring/grafana/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml karma charts/monitoring/karma/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring prometheus charts/monitoring/prometheus/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring alertmanager charts/monitoring/alertmanager/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring node-exporter charts/monitoring/node-exporter/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring kube-state-metrics charts/monitoring/kube-state-metrics/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring grafana charts/monitoring/grafana/
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring karma charts/monitoring/karma/
 ```
 
 ### Going Further

--- a/content/kubermatic/master/installation/securing_services/_index.en.md
+++ b/content/kubermatic/master/installation/securing_services/_index.en.md
@@ -57,9 +57,16 @@ Each service should have its own credentials (i.e. a different `secret` for ever
 with Helm will now prepare Dex to act as an authentication provider, but there is no OAuth2-Proxy yet to make use of
 this:
 
+**Helm 3**
+
 ```bash
-cd kubermatic-installer
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace oauth oauth charts/oauth/
+helm --namespace oauth upgrade --install --wait --values /path/to/your/helm-values.yaml oauth charts/oauth/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace oauth oauth charts/oauth/
 ```
 
 ### OAuth2-Proxy (IAP)
@@ -120,9 +127,16 @@ iap:
 
 With all this configured, it's now time to install/upgrade the `iap` Helm chart:
 
+**Helm 3**
+
 ```bash
-cd kubermatic-installer
-helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_PATH --namespace iap charts/iap/
+helm --namespace iap upgrade --install --wait --values /path/to/your/helm-values.yaml iap charts/iap/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace iap iap charts/iap/
 ```
 
 This will create one Ingress per deployment you configured. If all your Ingress hosts are subdomains of your

--- a/content/kubermatic/master/upgrading/2.14_to_2.15/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.14_to_2.15/_index.en.md
@@ -5,6 +5,14 @@ weight = 90
 
 +++
 
+## Helm 3 Support
+
+KKP now supports Helm 3. Previous versions required some manual intervention to get all charts
+installed. With the updated CRD handling (see below), we made the switch to recommending Helm 3
+for new installations.
+
+A [migration guide]({{< ref "helm_2to3" >}}) is provided.
+
 ## [EE] Deprecation of `kubermatic` Helm Chart
 
 After the Kubermatic Operator has been introduced as a beta in version 2.14, it is now the recommended way of
@@ -58,6 +66,15 @@ other deployment mechanisms.
 Upgrading existing Helm releases in a cluster is simple, as Helm does not delete CRDs. To update cert-manager, simply
 install the CRDs and then run Helm as usual:
 
+**Helm 3**
+
+```bash
+kubectl apply -f charts/cert-manager/crd/
+helm --namespace cert-manager upgrade --install --values YOUR_VALUES_YAML_HERE cert-manager charts/cert-manager/
+```
+
+**Helm 2**
+
 ```bash
 kubectl apply -f charts/cert-manager/crd/
 helm --tiller-namespace kubermatic upgrade --install --values YOUR_VALUES_YAML_HERE --namespace cert-manager cert-manager charts/cert-manager/
@@ -75,6 +92,15 @@ Helm-owned resources", which can be safely ignored.
 
 Perform the same steps for Velero:
 
+**Helm 3**
+
+```bash
+kubectl apply -f charts/backup/velero/crd/
+helm --namespace velero upgrade --install --values YOUR_VALUES_YAML_HERE velero charts/backup/velero/
+```
+
+**Helm 2**
+
 ```bash
 kubectl apply -f charts/backup/velero/crd/
 helm --tiller-namespace kubermatic upgrade --install --values YOUR_VALUES_YAML_HERE --namespace velero velero charts/backup/velero/
@@ -84,6 +110,15 @@ helm --tiller-namespace kubermatic upgrade --install --values YOUR_VALUES_YAML_H
 
 The labeling for the Promtail DaemonSet has changed, requiring administrators to re-install the Helm chart. As a clean
 upgrade is not possible, we advise to delete and re-install the chart.
+
+**Helm 3**
+
+```bash
+helm --namespace logging delete promtail
+helm --namespace logging upgrade --install --values YOUR_VALUES_YAML_HERE promtail charts/logging/promtail/
+```
+
+**Helm 2**
 
 ```bash
 helm --tiller-namespace kubermatic delete promtail
@@ -142,8 +177,17 @@ A few examples can be found in the relevant [code change in KKP](https://github.
 To prevent issues with Helm re-using IAP deployment config values from a previous release, it can be helpful to purge and
 reinstall the chart:
 
+**Helm 3**
+
 ```bash
-helm --tiller-namespace kubermatic delete --purge iap
+helm --namespace iap delete iap
+helm --namespace iap upgrade --install --values YOUR_VALUES_YAML_HERE iap charts/iap/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic delete iap
 helm --tiller-namespace kubermatic upgrade --install --values YOUR_VALUES_YAML_HERE --namespace iap iap charts/iap/
 ```
 

--- a/content/kubermatic/master/upgrading/2.14_to_2.15/chart_migration/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.14_to_2.15/chart_migration/_index.en.md
@@ -152,8 +152,15 @@ It is now recommended to setup Kubermatic in a test environment, using the newly
 It's now time to change the Helm charts. Begin by uninstalling the `kubermatic` chart. This will make
 the dashboard unavailable and begin the downtime.
 
+**Helm 3**
+
 ```bash
-# This is written for Helm 2.x
+helm --namespace kubermatic delete kubermatic
+```
+
+**Helm 2**
+
+```bash
 helm --tiller-namespace kubermatic delete --purge kubermatic
 ```
 
@@ -194,9 +201,16 @@ Now it's time to install the operator. Make sure to configure the `kubermatic-op
 taking care of setting the correct ImagePullSecret in the `values.yaml`. Once you're satisfied, install
 the operator:
 
+**Helm 3**
+
 ```bash
-# This is written for Helm 3.x
 helm -n kubermatic install --values myvalues.yaml kubermatic-operator charts/kubermatic-operator/
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic install --values myvalues.yaml --namespace kubermatic kubermatic-operator charts/kubermatic-operator/
 ```
 
 Once the operator is up, it will begin reconciling the KKP Master and Seed clusters. It will now take a
@@ -210,8 +224,15 @@ completed relatively quickly.
 
 To migrate a seed, first uninstall the `kubermatic` Helm chart from it. As with the master, **do not delete the CRDs.**
 
+**Helm 3**
+
 ```bash
-# This is written for Helm 2.x
+helm --namespace kubermatic delete kubermatic
+```
+
+**Helm 2**
+
+```bash
 helm --tiller-namespace kubermatic delete --purge kubermatic
 ```
 
@@ -267,8 +288,16 @@ Take the `nodeport-proxy`'s EXTERNAL IP, in this case `34.89.181.151`, and updat
 It will take some time for the DNS changes to propagate to every user, so it is recommended to leave the old
 nodeport-proxy in place for a period of time (e.g. a week), before finally removing it:
 
+**Helm 3**
+
 ```bash
-# This is written for Helm 2.x
+helm --namespace nodeport-proxy delete nodeport-proxy
+kubectl delete ns nodeport-proxy
+```
+
+**Helm 2**
+
+```bash
 helm --tiller-namespace kubermatic delete --purge nodeport-proxy
 kubectl delete ns nodeport-proxy
 ```

--- a/content/kubermatic/master/upgrading/2.14_to_2.15/helm_2to3/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.14_to_2.15/helm_2to3/_index.en.md
@@ -1,0 +1,76 @@
++++
+title = "Migrating to Helm 3"
+date = 2020-06-09T11:09:15+02:00
+weight = 40
+
++++
+
+Helm supports in-place migrations using the [2to3 plugin](https://github.com/helm/helm-2to3).
+The migration involves converting the Helm 2 release information (stored in ConfigMaps/Secrets in
+the Tiller namepace) to Helm 3 releases, cleaning up Helm 2 releases afterwards and then removing
+Tiller and its associated resources in the final step.
+
+During the migration, existing resources are not modified, so LoadBalancers will for example not
+potentially trigger an IP change.
+
+### Example
+
+{{% notice warning %}}
+Make sure that during a migration no other operations are performed using Helm 2, for example
+due to "accidental" automated deployment jobs. Ideally, all charts are migrated sequentially
+and then Tiller is removed.
+{{% /notice %}}
+
+In this example, the `cert-manager` chart is migrated to Helm 3.
+
+Before we begin, we have to install the 2to3 plugin. Throughout the example, we're using Helm 3
+exclusively.
+
+```bash
+helm plugin install https://github.com/helm/helm-2to3.git
+#Downloading and installing helm-2to3 v0.6.0 ...
+#https://github.com/helm/helm-2to3/releases/download/v0.6.0/helm-2to3_0.6.0_linux_amd64.tar.gz
+#Installed plugin: 2to3
+```
+
+Next you need a kubeconfig for the cluster in which the releases should be migrated. The
+kubeconfig can either be specified explicitly for each `2to3` call
+(e.g. `helm 2to3 convert --kubeconfig=<path>`) or set as a `KUBECONFIG` environment variable.
+
+```bash
+export KUBECONFIG=/path/to/kubeconfig
+```
+
+We can now convert the release information from version 2 to 3. This will by default only
+convert (and delete) the 10 most recent releases, so a cleanup is later required to remove the
+remaining releases (if there were more than 10).
+
+Remove `--dry-run` to actually perform the conversion.
+
+```bash
+helm 2to3 convert \
+  --dry-run \
+  --tiller-ns kubermatic-installer \
+  --delete-v2-releases \
+  cert-manager
+```
+
+Now the remaining Helm 2 releases can be removed:
+
+```bash
+helm 2to3 cleanup \
+  --dry-run \
+  --tiller-ns kubermatic-installer \
+  --name cert-manager
+```
+
+This completes the migration for the `cert-manager` chart.
+
+After all migrations have completed, Tiller can then also be removed by running the `cleanup`
+command again without a `--name` flag (see `--help`):
+
+```bash
+helm 2to3 cleanup \
+  --dry-run \
+  --tiller-ns kubermatic-installer
+```

--- a/content/kubermatic/master/upgrading/2.14_to_2.15/helm_2to3/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.14_to_2.15/helm_2to3/_index.en.md
@@ -50,7 +50,7 @@ Remove `--dry-run` to actually perform the conversion.
 ```bash
 helm 2to3 convert \
   --dry-run \
-  --tiller-ns kubermatic-installer \
+  --tiller-ns kubermatic \
   --delete-v2-releases \
   cert-manager
 ```
@@ -60,7 +60,7 @@ Now the remaining Helm 2 releases can be removed:
 ```bash
 helm 2to3 cleanup \
   --dry-run \
-  --tiller-ns kubermatic-installer \
+  --tiller-ns kubermatic \
   --name cert-manager
 ```
 
@@ -72,5 +72,5 @@ command again without a `--name` flag (see `--help`):
 ```bash
 helm 2to3 cleanup \
   --dry-run \
-  --tiller-ns kubermatic-installer
+  --tiller-ns kubermatic
 ```

--- a/content/kubermatic/master/upgrading/2.14_to_2.15/kubermatic_chart/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.14_to_2.15/kubermatic_chart/_index.en.md
@@ -27,6 +27,17 @@ kubectl apply -f charts/kubermatic/crd/
 
 Then use your Helm `values.yaml` and upgrade the releases in your master cluster:
 
+**Helm 3**
+
+```bash
+helm --namespace nginx-ingress-controller upgrade --install --values myvalues.yaml nginx-ingress-controller charts/nginx-ingress-controller/
+helm --namespace cert-manager upgrade --install --values myvalues.yaml cert-manager charts/cert-manager/
+helm --namespace oauth upgrade --install --values myvalues.yaml oauth charts/oauth/
+helm --namespace kubermatic upgrade --install --values myvalues.yaml kubermatic charts/kubermatic/
+```
+
+**Helm 2**
+
 ```bash
 helm --tiller-namespace kubermatic upgrade --install --values myvalues.yaml --namespace nginx-ingress-controller nginx-ingress-controller charts/nginx-ingress-controller/
 helm --tiller-namespace kubermatic upgrade --install --values myvalues.yaml --namespace cert-manager cert-manager charts/cert-manager/
@@ -36,6 +47,15 @@ helm --tiller-namespace kubermatic upgrade --install --values myvalues.yaml --na
 
 Once the master cluster is updated, update the `kubermatic` and `nodeport-proxy` chart on all seed clusters
 as well. Remember to set `isMaster` to `false` in the `values.yaml` for your seed clusters.
+
+**Helm 3**
+
+```bash
+helm --namespace nodeport-proxy upgrade --install --values myvalues.yaml nodeport-proxy charts/nodeport-proxy/
+helm --namespace kubermatic upgrade --install --values myvalues.yaml kubermatic charts/kubermatic/
+```
+
+**Helm 2**
 
 ```bash
 helm --tiller-namespace kubermatic upgrade --install --values myvalues.yaml --namespace nodeport-proxy nodeport-proxy charts/nodeport-proxy/

--- a/content/kubermatic/master/upgrading/2.14_to_2.15/kubermatic_operator/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.14_to_2.15/kubermatic_operator/_index.en.md
@@ -28,6 +28,17 @@ kubectl apply -f charts/kubermatic/crd/
 
 Then use your Helm `values.yaml` and upgrade the releases in your master cluster:
 
+**Helm 3**
+
+```bash
+helm --namespace nginx-ingress-controller upgrade --install --values myvalues.yaml nginx-ingress-controller charts/nginx-ingress-controller/
+helm --namespace cert-manager upgrade --install --values myvalues.yaml cert-manager charts/cert-manager/
+helm --namespace oauth upgrade --install --values myvalues.yaml oauth charts/oauth/
+helm --namespace kubermatic upgrade --install --values myvalues.yaml kubermatic-operator charts/kubermatic-operator/
+```
+
+**Helm 2**
+
 ```bash
 helm --tiller-namespace kubermatic upgrade --install --values myvalues.yaml --namespace nginx-ingress-controller nginx-ingress-controller charts/nginx-ingress-controller/
 helm --tiller-namespace kubermatic upgrade --install --values myvalues.yaml --namespace cert-manager cert-manager charts/cert-manager/
@@ -71,8 +82,16 @@ Take the `nodeport-proxy`'s EXTERNAL IP, in this case `34.89.181.151`, and updat
 It will take some time for the DNS changes to propagate to every user, so it is recommended to leave the old
 nodeport-proxy in place for a period of time (e.g. a week), before finally removing it:
 
+**Helm 3**
+
 ```bash
-# This is written for Helm 2.x
+helm --namespace nodeport-proxy delete nodeport-proxy
+kubectl delete ns nodeport-proxy
+```
+
+**Helm 2**
+
+```bash
 helm --tiller-namespace kubermatic delete --purge nodeport-proxy
 kubectl delete ns nodeport-proxy
 ```


### PR DESCRIPTION
This documents that Helm 3 is now the preferred choice when installing KKP. The PR also updates all existing Helm instructions to include both Helm 2 and 3. And because the OIDC docs were so outdated, I rewrote a larger chunk of it.