### PR TITLE
Improve image-loader Docs

### DIFF
--- a/content/kubermatic/master/advanced/addons/_index.en.md
+++ b/content/kubermatic/master/advanced/addons/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Addons"
+title = "Addons"
 date = 2018-06-21T14:07:15+02:00
-weight = 110
+weight = 40
 
 +++
 

--- a/content/kubermatic/master/advanced/custom_links/_index.en.md
+++ b/content/kubermatic/master/advanced/custom_links/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Global Settings"
+title = "Global Settings"
 date = 2018-06-21T14:07:15+02:00
 weight = 20
 

--- a/content/kubermatic/master/advanced/custom_ui/_index.en.md
+++ b/content/kubermatic/master/advanced/custom_ui/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Customizing the Dashboard Theme"
+title = "Customizing the Dashboard"
 date = 2018-06-21T14:07:15+02:00
-weight = 40
+weight = 30
 
 +++
 

--- a/content/kubermatic/master/advanced/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/master/advanced/dynamic_kubelet_config/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Dynamic Kubelet configuration"
 date = 2020-04-01T12:00:00+02:00
-weight = 55
+weight = 100
 
 +++
 

--- a/content/kubermatic/master/advanced/offline_mode/_index.en.md
+++ b/content/kubermatic/master/advanced/offline_mode/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Offline Mode"
+title = "Offline Mode"
 date = 2018-04-28T12:07:15+02:00
-weight = 7
+weight = 120
 
 +++
 

--- a/content/kubermatic/master/advanced/offline_mode/_index.en.md
+++ b/content/kubermatic/master/advanced/offline_mode/_index.en.md
@@ -91,9 +91,29 @@ helm -n oauth upgrade \
 {{% notice note %}}
 When adjusting the `values.yaml`, do not use the same file for the image-loader, as it would
 attempt to mirror `172.20.0.2:5000/dexidp/dex` to `172.20.0.2:5000/dexidp/dex` (a no-op).
-Either provide the image-loader with a stock configuration or set the overriden image repositories
+Either provide the image-loader with a stock configuration or set the overridden image repositories
 via `--set` when using Helm.
 {{% /notice %}}
+
+Likewise, carefully go through the [KubermaticConfiguration]({{< ref "../../concepts/kubermaticconfiguration" >}})
+and adjust the `dockerRepository` fields:
+
+```yaml
+spec:
+  masterController:
+    dockerRepository: 172.20.0.2:5000/kubermatic/kubermatic
+  seedController:
+    dockerRepository: 172.20.0.2:5000/kubermatic/kubermatic
+  ui:
+    dockerRepository: 172.20.0.2:5000/kubermatic/dashboard
+  # etc.
+```
+
+Re-apply the updated configuration to make the KKP Operator reconcile the setup:
+
+```bash
+kubectl apply -f mykubermatic.yaml
+```
 
 ### Worker Nodes Behind a Proxy
 

--- a/content/kubermatic/master/advanced/oidc_auth/_index.en.md
+++ b/content/kubermatic/master/advanced/oidc_auth/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Share Clusters via Delegated OIDC Authentication"
 date = 2018-11-23T12:01:35+02:00
-weight = 70
+weight = 80
 
 +++
 

--- a/content/kubermatic/master/advanced/oidc_config/_index.en.md
+++ b/content/kubermatic/master/advanced/oidc_config/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "OIDC Provider Configuration"
 date = 2018-06-21T14:07:15+02:00
-weight = 30
+weight = 70
 
 +++
 

--- a/content/kubermatic/master/advanced/proxy_whitelisting/_index.en.md
+++ b/content/kubermatic/master/advanced/proxy_whitelisting/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Proxy Whitelisting"
+title = "Proxy Whitelisting"
 date = 2019-09-13T12:07:15+02:00
-weight = 90
+weight = 110
 
 +++
 

--- a/content/kubermatic/master/advanced/user_settings/_index.en.md
+++ b/content/kubermatic/master/advanced/user_settings/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) User Settings"
+title = "User Settings"
 date = 2020-04-01T14:07:15+02:00
 weight = 10
 

--- a/content/kubermatic/master/advanced/versions_updates/_index.en.md
+++ b/content/kubermatic/master/advanced/versions_updates/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Versions & Update Configuration"
 date = 2019-07-05T10:45:00+02:00
-weight = 80
+weight = 90
 
 +++
 

--- a/content/kubermatic/v2.13/advanced/offline_mode/_index.en.md
+++ b/content/kubermatic/v2.13/advanced/offline_mode/_index.en.md
@@ -1,49 +1,148 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Offline Mode"
+title = "Offline Mode"
 date = 2018-04-28T12:07:15+02:00
 weight = 7
 
 +++
 
-### KKP Offline Mode
+It's possible to run KKP in an airgapped/offline environment, by mirroring all required
+Docker images to a local Docker registry. The `image-loader` utility is provided to aid
+in this process.
 
-## Download All Required Images
+In general, to setup an airgapped system, the Docker images must be mirrored and the
+Helm charts / KubermaticConfiguration need to be adjusted to point to the new registry.
 
-To aid in downloading all required images, KKP provides the `image-loader` CLI utility. It can be used like
-this:
+### Download All Required Images
+
+There are a number of sources for the Docker images used in a KKP setup:
+
+* The Docker images used by KKP itself (e.g. `quay.io/kubermatic/kubermatic`)
+* The images used by the various Helm charts used to deploy KKP (nginx, cert-manager,
+  Grafana, ...)
+* The images used for creating a usercluster control plane (the Kubernetes apiserver,
+  scheduler, metrics-server, ...).
+* The images referenced by cluster addons.
+
+To make it easier to collect all required images, the `image-loader` utility is provided.
+It will scan the Helm charts and uses the KKP code itself to determine all images that
+need to be mirrored. Once it has determined these, it will pull, re-tag and then push
+the images.
+
+To use it, provide it with the `values.yaml` file used to install the Helm charts.
+
+The image-loader is included in the regular KKP Docker images (i.e.
+`quay.io/kubermatic/api`). It is recommended to extract the binary out of the
+Docker image and use it locally, as a Helm 3 binary is also required to use it.
 
 ```bash
-image-loader \
-  -versions charts/kubermatic/static/master/versions.yaml \
-  -registry 172.20.0.2:5000 \
-  -log-format=Console
+CONTAINER_ID=$(docker create --name copier quay.io/kubermatic/api:v2.13.10)
+docker cp $CONTAINER_ID:/usr/local/bin/image-loader .
+docker rm $CONTAINER_ID
 ```
 
-## Worker Nodes Behind a Proxy
+It is important to use the image-loader that ships with the KKP version you're using,
+as this will ensure that it finds the same images actually used in the clusters later on.
 
-In situations where worker nodes will require a proxy to reach the internet, the `datacenters.yaml` must be modified:
+As the next step, download the Helm charts for your KKP version from the
+[kubermatic-installer](https://github.com/kubermatic/kubermatic-installer/) repository.
+Once you have the charts and the image-loader, you can run the loader like so:
+
+```bash
+./image-loader \
+  -helm-values-file myhelmvalues.yaml \
+  -charts-path /path/to/the/extracte/charts \
+  -registry 172.20.0.2:5000 \
+  -dry-run
+```
+
+Remove the `-dry-run` to let the tool actually download and push Docker images.
+
+#### Addons
+
+Note that by default, the image-loader will determine the configured addons Docker image
+from the Helm values, pull it down and then extract the addon manifests from the image,
+so that it can then scan them for Docker images to mirror.
+
+You can skip this step by pointing the image-loader to a local directory that contains
+all addons, like so:
+
+```bash
+./image-loader \
+  -helm-values-file myhelmvalues.yaml \
+  -charts-path /path/to/the/extracte/charts \
+  -addons-path /path/to/my/addons \
+  -registry 172.20.0.2:5000 \
+  -dry-run
+```
+
+### Configuring KKP
+
+After having mirrored all required Docker images, it's time to adjust the KKP configuration
+to point to the new images. For this the Helm values.yaml allows to override the
+Docker repository for all used images. This is true for the `kubermatic` chart as well as
+all other Helm charts.
+
+For example, Dex can be installed by overwriting `dex.image.repository` either in the
+`values.yaml` file or on the command line:
+
+```bash
+helm -n oauth upgrade \
+  --values myvalues.yaml \
+  --set "dex.image.repository=172.20.0.2:5000/dexidp/dex" \
+  oauth .
+```
+
+{{% notice note %}}
+When adjusting the `values.yaml`, do not use the same file for the image-loader, as it would
+attempt to mirror `172.20.0.2:5000/dexidp/dex` to `172.20.0.2:5000/dexidp/dex` (a no-op).
+Either provide the image-loader with a stock configuration or set the overridden image repositories
+via `--set` when using Helm.
+{{% /notice %}}
+
+Once the `values.yaml` has been updated, re-deploy all affected Helm charts.
+
+### Worker Nodes Behind a Proxy
+
+In situations where worker nodes will require a proxy to reach the internet, the datacenter specification for the
+Seed cluster must be updated. This can be found in the [Seed]({{< ref "../../concepts/seeds" >}}) CRD. Find the
+relevant seed via `kubectl`:
+
+```bash
+kubectl -n kubermatic get seeds
+#NAME        AGE
+#hamburg     143d
+#frankfurt   151d
+```
+
+You will then find the datacenter inside the `spec.datacenters` list of the right Seed. You need to set a couple
+of `node` settings:
 
 ```yaml
-...
-  gcp-westeurope:
-    location: "Europe West (Germany)"
-    seed: europe-west3-a
-    country: DE
-    provider: gcp
-    spec:
-      gcp:
-        region: europe-west3
-        zone_suffixes:
-        - a
-    node:
-      # Configure the address of the proxy
-      # It will be configured on all worker nodes. It results in the HTTP_PROXY & HTTPS_PROXY environment variable being set.
-      http_proxy: "http://172.20.0.2:3128"
-      # Worker nodes require access to a docker registry, in case it is only accessible using http or it uses a self signed certificate, they must be listed here
-      insecure_registries:
-        - 172.20.0.2:5000
-      # The kubelet requires the pause image, if its only accessible using a private registry, the image name must be configured here
-      pause_image: "172.20.0.2:5000/kubernetes/pause:3.1"
-      # ContainerLinux requires the hyperkube image, if its only accessible using a private registry, the image name must be configured here
-      hyperkube_image: "172.20.0.2:5000/kubernetes/hyperkube-amd64"
+spec:
+  datacenters:
+    example-dc:
+      location: Hamburg
+      country: DE
+      ...
+      node:
+        # Configure the address of the proxy
+        # It will be configured on all worker nodes. It results in the HTTP_PROXY & HTTPS_PROXY
+        # environment variables being set.
+        http_proxy: "http://172.20.0.2:3128"
+
+        # Worker nodes require access to a Docker registry; in case it is only accessible using
+        # plain HTTP or it uses a self-signed certificate, it must be listed here.
+        insecure_registries:
+          - "172.20.0.2:5000"
+
+        # The kubelet requires the pause image; if it's only accessible using a private registry,
+        # the image name must be configured here.
+        pause_image: "172.20.0.2:5000/kubernetes/pause:3.1"
+
+        # ContainerLinux requires the hyperkube image; if it's only accessible using a private
+        # registry, the image name must be configured here.
+        hyperkube_image: "172.20.0.2:5000/kubernetes/hyperkube-amd64"
 ```
+
+Edit your Seed either using `kubectl edit` or editing a local file and applying it with `kubectl apply`. From then
+on new nodes in the configured datacenter will use the new node settings.

--- a/content/kubermatic/v2.14/advanced/addons/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/addons/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Addons"
+title = "Addons"
 date = 2018-06-21T14:07:15+02:00
-weight = 110
+weight = 40
 
 +++
 
@@ -45,7 +45,7 @@ docker run --rm quay.io/kubermatic/api:KUBERMATIC_VERSION kubermatic-operator-ut
 #  namespace: kubermatic
 #spec:
 #  ...
-#  userCluster:
+#  userClusters:
 #    addons:
 #      kubernetes: ...
 #      openshift: ...
@@ -249,8 +249,8 @@ After applying above config the UI should look like below:
 ### Custom Addons
 
 All manifests and config files for the default addons are stored in a Docker image, whose name is configured
-in the KubermaticConfiguration at `spec.userCluster.addons.kubernetes.dockerRepository` and
-`spec.userCluster.addons.openshift.dockerRepository`. These default to `quay.io/kubermatic/addons` and
+in the KubermaticConfiguration at `spec.userClusters.addons.kubernetes.dockerRepository` and
+`spec.userClusters.addons.openshift.dockerRepository`. These default to `quay.io/kubermatic/addons` and
 `quay.io/kubermatic/openshift-addons`, respectively.
 
 #### Creating a Docker Image
@@ -318,7 +318,7 @@ for Kubernetes:
 
 ```yaml
 spec:
-  userCluster:
+  userClusters:
     addons:
       kubernetes:
         # Do not specify a tag here, as the KKP Operator will always use the KKP
@@ -330,7 +330,7 @@ You also need to add your new addon to the `defaultManifests`:
 
 ```yaml
 spec:
-  userCluster:
+  userClusters:
     addons:
       kubernetes:
         defaultManifests: |-

--- a/content/kubermatic/v2.14/advanced/custom_links/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/custom_links/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Global Settings"
+title = "Global Settings"
 date = 2018-06-21T14:07:15+02:00
 weight = 20
 

--- a/content/kubermatic/v2.14/advanced/custom_ui/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/custom_ui/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Customizing the Dashboard Theme"
+title = "Customizing the Dashboard"
 date = 2018-06-21T14:07:15+02:00
-weight = 40
+weight = 30
 
 +++
 
@@ -99,13 +99,7 @@ kubectl -n kubermatic cp kubermatic-dashboard-5b96d7f5df-mkmgh:/dist/assets/them
 ```
 
 ##### Docker
-<<<<<<< HEAD
 Assuming that the KKP Dashboard container name is `kubermatic-dashboard` you can copy themes to your `${HOME}/themes` directory using below command:
-||||||| parent of 307fb35... Add spell checking in CI/CD
-Assuming that the Kubermatic Dashboard container name is `kubermatic-dashboard` you can copy themes to your `${HOME}/themes` directory using below command:
-=======
-Assuming that the Kubermatic Dashboard container name is `kubermatic-dashboard` you can copy themes to your `${HOME}/themes` directory using below command:
->>>>>>> 307fb35... Add spell checking in CI/CD
 ```bash
 docker cp kubermatic-dashboard:/dist/assets/themes/. ~/themes
 ```

--- a/content/kubermatic/v2.14/advanced/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/dynamic_kubelet_config/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Dynamic Kubelet configuration"
 date = 2020-04-01T12:00:00+02:00
-weight = 55
+weight = 100
 
 +++
 

--- a/content/kubermatic/v2.14/advanced/offline_mode/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/offline_mode/_index.en.md
@@ -1,20 +1,118 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Offline Air Gapped Mode"
+title = "Offline Mode"
 date = 2018-04-28T12:07:15+02:00
-weight = 7
+weight = 120
 
 +++
 
+It's possible to run KKP in an airgapped/offline environment, by mirroring all required
+Docker images to a local Docker registry. The `image-loader` utility is provided to aid
+in this process.
+
+In general, to setup an airgapped system, the Docker images must be mirrored and the
+Helm charts / KubermaticConfiguration need to be adjusted to point to the new registry.
+
 ### Download All Required Images
 
-To aid in downloading all required images, KKP provides the `image-loader` CLI utility. It can be used like
-this:
+There are a number of sources for the Docker images used in a KKP setup:
+
+* The Docker images used by KKP itself (e.g. `quay.io/kubermatic/kubermatic`)
+* The images used by the various Helm charts used to deploy KKP (nginx, cert-manager,
+  Grafana, ...)
+* The images used for creating a usercluster control plane (the Kubernetes apiserver,
+  scheduler, metrics-server, ...).
+* The images referenced by cluster addons.
+
+To make it easier to collect all required images, the `image-loader` utility is provided.
+It will scan the Helm charts and uses the KKP code itself to determine all images that
+need to be mirrored. Once it has determined these, it will pull, re-tag and then push
+the images.
+
+To use it, provide it with the KubermaticConfiguration as a YAML file (if you are using
+the KKP Operator) and the `values.yaml` file used to install the Helm charts.
+
+The image-loader can be downloaded from the latest [GitHub release](https://github.com/kubermatic/kubermatic/releases)
+in the `tools` archive. It is important to use the image-loader that ships with the KKP
+version you're using, as this will ensure that it finds the same images actually used
+in the clusters later on.
+
+Download the latest KKP release itself too, because for mirroring the Helm charts you
+will need the Helm charts. Extract both the image-loader and the KKP release locally and
+then run the image-loader. Note that you need [Helm 3.x](https://helm.sh/) installed
+on your machine.
 
 ```bash
-image-loader \
-  -versions charts/kubermatic/static/master/versions.yaml \
+./image-loader \
+  -configuration-file mykubermatic.yaml \
+  -helm-values-file myhelmvalues.yaml \
+  -charts-path /path/to/the/extracte/charts \
   -registry 172.20.0.2:5000 \
-  -log-format=Console
+  -dry-run
+```
+
+Remove the `-dry-run` to let the tool actually download and push Docker images.
+
+#### Addons
+
+Note that by default, the image-loader will determine the configured addons Docker image
+from the KubermaticConfiguration, pull it down and then extract the addon manifests from
+the image, so that it can then scan them for Docker images to mirror.
+
+You can skip this step by pointing the image-loader to a local directory that contains
+all addons, like so:
+
+```bash
+./image-loader \
+  -configuration-file mykubermatic.yaml \
+  -helm-values-file myhelmvalues.yaml \
+  -charts-path /path/to/the/extracte/charts \
+  -addons-path /path/to/my/addons \
+  -registry 172.20.0.2:5000 \
+  -dry-run
+```
+
+### Configuring KKP
+
+After having mirrored all required Docker images, it's time to adjust the KKP configuration
+to point to the new images. For this the KubermaticConfiguration allows to override the
+Docker repository (but not the tag!) for all used images. Likewise, all Helm charts have
+options to reconfigure the repository as well.
+
+For example, Dex can be installed by overwriting `dex.image.repository` either in the
+`values.yaml` file or on the command line:
+
+```bash
+helm -n oauth upgrade \
+  --values myvalues.yaml \
+  --set "dex.image.repository=172.20.0.2:5000/dexidp/dex" \
+  oauth .
+```
+
+{{% notice note %}}
+When adjusting the `values.yaml`, do not use the same file for the image-loader, as it would
+attempt to mirror `172.20.0.2:5000/dexidp/dex` to `172.20.0.2:5000/dexidp/dex` (a no-op).
+Either provide the image-loader with a stock configuration or set the overridden image repositories
+via `--set` when using Helm.
+{{% /notice %}}
+
+Likewise, carefully go through the [KubermaticConfiguration]({{< ref "../../concepts/kubermaticconfiguration" >}})
+and adjust the `dockerRepository` fields:
+
+```yaml
+spec:
+  masterController:
+    dockerRepository: 172.20.0.2:5000/kubermatic/kubermatic
+  seedController:
+    dockerRepository: 172.20.0.2:5000/kubermatic/kubermatic
+  ui:
+    dockerRepository: 172.20.0.2:5000/kubermatic/dashboard
+  # etc.
+```
+
+Re-apply the updated configuration to make the KKP Operator reconcile the setup:
+
+```bash
+kubectl apply -f mykubermatic.yaml
 ```
 
 ### Worker Nodes Behind a Proxy

--- a/content/kubermatic/v2.14/advanced/oidc_auth/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/oidc_auth/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Share Clusters via Delegated OIDC Authentication"
 date = 2018-11-23T12:01:35+02:00
-weight = 70
+weight = 80
 
 +++
 

--- a/content/kubermatic/v2.14/advanced/oidc_config/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/oidc_config/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "OIDC Provider Configuration"
 date = 2018-06-21T14:07:15+02:00
-weight = 30
+weight = 70
 
 +++
 

--- a/content/kubermatic/v2.14/advanced/proxy_whitelisting/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/proxy_whitelisting/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Proxy Whitelisting"
+title = "Proxy Whitelisting"
 date = 2019-09-13T12:07:15+02:00
-weight = 90
+weight = 110
 
 +++
 

--- a/content/kubermatic/v2.14/advanced/user_settings/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/user_settings/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) User Settings"
+title = "User Settings"
 date = 2020-04-01T14:07:15+02:00
 weight = 10
 

--- a/content/kubermatic/v2.14/advanced/versions_updates/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/versions_updates/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Versions & Update Configuration"
 date = 2019-07-05T10:45:00+02:00
-weight = 80
+weight = 90
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/addons/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/addons/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Addons"
+title = "Addons"
 date = 2018-06-21T14:07:15+02:00
-weight = 110
+weight = 40
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/custom_links/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/custom_links/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Global Settings"
+title = "Global Settings"
 date = 2018-06-21T14:07:15+02:00
 weight = 20
 

--- a/content/kubermatic/v2.15/advanced/custom_ui/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/custom_ui/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Customizing the Dashboard Theme"
+title = "Customizing the Dashboard"
 date = 2018-06-21T14:07:15+02:00
-weight = 40
+weight = 30
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/dynamic_kubelet_config/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Dynamic Kubelet configuration"
 date = 2020-04-01T12:00:00+02:00
-weight = 55
+weight = 100
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/offline_mode/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/offline_mode/_index.en.md
@@ -1,20 +1,118 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Offline Mode"
+title = "Offline Mode"
 date = 2018-04-28T12:07:15+02:00
-weight = 7
+weight = 120
 
 +++
 
+It's possible to run KKP in an airgapped/offline environment, by mirroring all required
+Docker images to a local Docker registry. The `image-loader` utility is provided to aid
+in this process.
+
+In general, to setup an airgapped system, the Docker images must be mirrored and the
+Helm charts / KubermaticConfiguration need to be adjusted to point to the new registry.
+
 ### Download All Required Images
 
-To aid in downloading all required images, KKP provides the `image-loader` CLI utility. It can be used like
-this:
+There are a number of sources for the Docker images used in a KKP setup:
+
+* The Docker images used by KKP itself (e.g. `quay.io/kubermatic/kubermatic`)
+* The images used by the various Helm charts used to deploy KKP (nginx, cert-manager,
+  Grafana, ...)
+* The images used for creating a usercluster control plane (the Kubernetes apiserver,
+  scheduler, metrics-server, ...).
+* The images referenced by cluster addons.
+
+To make it easier to collect all required images, the `image-loader` utility is provided.
+It will scan the Helm charts and uses the KKP code itself to determine all images that
+need to be mirrored. Once it has determined these, it will pull, re-tag and then push
+the images.
+
+To use it, provide it with the KubermaticConfiguration as a YAML file (if you are using
+the KKP Operator) and the `values.yaml` file used to install the Helm charts.
+
+The image-loader can be downloaded from the latest [GitHub release](https://github.com/kubermatic/kubermatic/releases)
+in the `tools` archive. It is important to use the image-loader that ships with the KKP
+version you're using, as this will ensure that it finds the same images actually used
+in the clusters later on.
+
+Download the latest KKP release itself too, because for mirroring the Helm charts you
+will need the Helm charts. Extract both the image-loader and the KKP release locally and
+then run the image-loader. Note that you need [Helm 3.x](https://helm.sh/) installed
+on your machine.
 
 ```bash
-image-loader \
-  -versions charts/kubermatic/static/master/versions.yaml \
+./image-loader \
+  -configuration-file mykubermatic.yaml \
+  -helm-values-file myhelmvalues.yaml \
+  -charts-path /path/to/the/extracte/charts \
   -registry 172.20.0.2:5000 \
-  -log-format=Console
+  -dry-run
+```
+
+Remove the `-dry-run` to let the tool actually download and push Docker images.
+
+#### Addons
+
+Note that by default, the image-loader will determine the configured addons Docker image
+from the KubermaticConfiguration, pull it down and then extract the addon manifests from
+the image, so that it can then scan them for Docker images to mirror.
+
+You can skip this step by pointing the image-loader to a local directory that contains
+all addons, like so:
+
+```bash
+./image-loader \
+  -configuration-file mykubermatic.yaml \
+  -helm-values-file myhelmvalues.yaml \
+  -charts-path /path/to/the/extracte/charts \
+  -addons-path /path/to/my/addons \
+  -registry 172.20.0.2:5000 \
+  -dry-run
+```
+
+### Configuring KKP
+
+After having mirrored all required Docker images, it's time to adjust the KKP configuration
+to point to the new images. For this the KubermaticConfiguration allows to override the
+Docker repository (but not the tag!) for all used images. Likewise, all Helm charts have
+options to reconfigure the repository as well.
+
+For example, Dex can be installed by overwriting `dex.image.repository` either in the
+`values.yaml` file or on the command line:
+
+```bash
+helm -n oauth upgrade \
+  --values myvalues.yaml \
+  --set "dex.image.repository=172.20.0.2:5000/dexidp/dex" \
+  oauth .
+```
+
+{{% notice note %}}
+When adjusting the `values.yaml`, do not use the same file for the image-loader, as it would
+attempt to mirror `172.20.0.2:5000/dexidp/dex` to `172.20.0.2:5000/dexidp/dex` (a no-op).
+Either provide the image-loader with a stock configuration or set the overridden image repositories
+via `--set` when using Helm.
+{{% /notice %}}
+
+Likewise, carefully go through the [KubermaticConfiguration]({{< ref "../../concepts/kubermaticconfiguration" >}})
+and adjust the `dockerRepository` fields:
+
+```yaml
+spec:
+  masterController:
+    dockerRepository: 172.20.0.2:5000/kubermatic/kubermatic
+  seedController:
+    dockerRepository: 172.20.0.2:5000/kubermatic/kubermatic
+  ui:
+    dockerRepository: 172.20.0.2:5000/kubermatic/dashboard
+  # etc.
+```
+
+Re-apply the updated configuration to make the KKP Operator reconcile the setup:
+
+```bash
+kubectl apply -f mykubermatic.yaml
 ```
 
 ### Worker Nodes Behind a Proxy

--- a/content/kubermatic/v2.15/advanced/oidc_auth/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/oidc_auth/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Share Clusters via Delegated OIDC Authentication"
 date = 2018-11-23T12:01:35+02:00
-weight = 70
+weight = 80
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/oidc_config/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/oidc_config/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "OIDC Provider Configuration"
 date = 2018-06-21T14:07:15+02:00
-weight = 30
+weight = 70
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/proxy_whitelisting/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/proxy_whitelisting/_index.en.md
@@ -1,7 +1,7 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Proxy Whitelisting"
+title = "Proxy Whitelisting"
 date = 2019-09-13T12:07:15+02:00
-weight = 90
+weight = 110
 
 +++
 

--- a/content/kubermatic/v2.15/advanced/user_settings/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/user_settings/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic Kubernetes Platform (KKP) User Settings"
+title = "User Settings"
 date = 2020-04-01T14:07:15+02:00
 weight = 10
 

--- a/content/kubermatic/v2.15/advanced/versions_updates/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/versions_updates/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Versions & Update Configuration"
 date = 2019-07-05T10:45:00+02:00
-weight = 80
+weight = 90
 
 +++
 


### PR DESCRIPTION
The image-loader in KKP has been extended and the documentation should reflect that. This PR

- removes the super redundant "Kubermatic Kubernetes Platform (KKP) " prefix from the chapters in master, 2.15 and 2.14 docs
- 2.13 has just the minimum number of adjustments to bring it up-to-date