### PR TITLE
Stay on the same page when switching between product versions

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,4 +1,4 @@
-<nav id="sidebar" class="{{if $.Site.Params.showVisitedLinks }}showVisitedLinks{{end}}">
+<nav id="sidebar" class="{{ if $.Site.Params.showVisitedLinks }}showVisitedLinks{{ end }}">
   {{ $currentNode := . }}
   {{ $showvisitedlinks := .Site.Params.showVisitedLinks }}
   {{ $productSection := .FirstSection.Section }}
@@ -7,130 +7,133 @@
     <div id="header">
       {{ partial "logo.html" . }}
     </div>
-    {{if not .Site.Params.disableSearch}}
+    {{ if not .Site.Params.disableSearch }}
       {{ partial "search.html" . }}
-    {{end}}
-    {{with $.Site.Data.products}}
+    {{ end }}
+    {{ with $.Site.Data.products }}
     <div class="products-toogle">
       <div class="products-toogle-select">
         <label for="product-select" class="products-toogle-label">Product</label>
         <select id="product-select" onchange="location = this.value;">
-        {{range $key, $value := .}}
-          {{$release := (cond (gt (len .versions) 1) (index .versions 1) (index .versions 0)).release}}
-          <option value="{{printf "/%s/%s/" $key $release | relURL}}"{{if in $.RelPermalink $key}} selected{{end}}>{{.name}}</option>
-        {{end}}
+          {{ range $key, $value := . }}
+            {{ $release := (cond (gt (len .versions) 1) (index .versions 1) (index .versions 0)).release }}
+            <option value="{{ printf "/%s/%s/" $key $release | relURL }}"{{ if in $.RelPermalink $key }} selected{{ end }}>{{ .name }}</option>
+          {{ end }}
         </select>
       </div>
-      {{with $product}}
+      {{ with $product }}
       <div class="products-toogle-select">
         <label for="version-select" class="products-toogle-label">Version</label>
         <select id="version-select" onchange="location = this.value;">
-        {{range .versions}}
-          {{template "optionInDifferentVersion" dict "root" $ "sect" . "productSection" $productSection "version" .}}
-        {{end}}
+          {{ range .versions }}
+            {{ template "optionInDifferentVersion" dict "root" $ "sect" . "productSection" $productSection "version" . }}
+          {{ end }}
         </select>
       </div>
-      {{end}}
+      {{ end }}
     </div>
-    {{end}}
+    {{ end }}
   </div>
-    <div class="highlightable">
+
+  <div class="highlightable">
     <ul class="topics">
-      {{with $product}}
-        {{range .versions}}
-          {{if in $.RelPermalink .release}}
-            {{$path := print "/" $productSection "/" .release}}
-            {{$docVersion := $.Site.GetPage $path}}
-            {{if eq .Site.Params.ordersectionsby "title"}}
-              {{range $docVersion.Sections.ByTitle}}
-                {{template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
-              {{end}}
-            {{else}}
-              {{range $docVersion.Sections.ByWeight}}
-                {{template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
-              {{end}}
-            {{end}}
-          {{end}}
-        {{end}}
-      {{end}}
+      {{ with $product }}
+        {{ range .versions }}
+          {{ if in $.RelPermalink .release }}
+            {{ $path := print "/" $productSection "/" .release }}
+            {{ $docVersion := $.Site.GetPage $path }}
+            {{ if eq .Site.Params.ordersectionsby "title" }}
+              {{ range $docVersion.Sections.ByTitle }}
+                {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+              {{ end }}
+            {{ else }}
+              {{ range $docVersion.Sections.ByWeight }}
+                {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
     </ul>
 
     {{ $disableShortcutsTitle := .Site.Params.DisableShortcutsTitle}}
-    {{with .Site.Menus.shortcuts}}
-      <section id="shortcuts">
-        <h3>{{ if not $disableShortcutsTitle}}{{ T "Shortcuts-Title"}}{{ end }}</h3>
-        <ul>
-          {{ range sort . "Weight"}}
-              <li>
-                  {{.Pre}}<a class="padding" href="{{.URL | absLangURL }}">{{safeHTML .Name}}</a>{{.Post}}
-              </li>
-          {{end}}
-        </ul>
-      </section>
+    {{ with .Site.Menus.shortcuts }}
+    <section id="shortcuts">
+      <h3>{{ if not $disableShortcutsTitle}}{{ T "Shortcuts-Title" }}{{ end }}</h3>
+      <ul>
+        {{ range sort . "Weight"}}
+        <li>{{ .Pre }}<a class="padding" href="{{ .URL | absLangURL }}">{{ safeHTML .Name }}</a>{{ .Post }}</li>
+        {{end}}
+      </ul>
+    </section>
     {{end}}
-
   </div>
+
   <section id="footer">
-    {{partial "menu-footer" .}}
+    {{ partial "menu-footer" . }}
   </section>
 </nav>
 
 <!-- templates -->
 {{ define "section-tree-nav" }}
-{{ $showvisitedlinks := .showvisitedlinks }}
-{{ $currentNode := .currentnode }}
- {{with .sect}}
-  {{if .IsSection}}
-    {{safeHTML .Params.head}}
-    <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item
-        {{if .IsAncestor $currentNode }}parent{{end}}
-        {{with .File}}{{$f := .}}{{with $currentNode.File}}{{if eq $f.UniqueID .UniqueID}}active{{end}}{{end}}{{end}}
-        {{if .Params.alwaysopen}}parent{{end}}
+  {{ $showvisitedlinks := .showvisitedlinks }}
+  {{ $currentNode := .currentnode }}
+
+  {{ with .sect }}
+    {{ if .IsSection }}
+      {{ safeHTML .Params.head }}
+      <li data-nav-id="{{ .RelPermalink }}" title="{{ .Title }}" class="dd-item
+        {{ if .IsAncestor $currentNode  }}parent{{ end }}
+        {{ with .File }}{{ $f := . }}{{ with $currentNode.File }}{{ if eq $f.UniqueID .UniqueID }}active{{ end }}{{ end }}{{ end }}
+        {{ if .Params.alwaysopen }}parent{{ end }}
         ">
-      <a href="{{.RelPermalink}}">
-          {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
-          {{ if $showvisitedlinks}}
-            <i class="fas fa-check read-icon"></i>
-          {{ end }}
-      </a>
-      {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
-      {{ if ne $numberOfPages 0 }}
+        <a href="{{ .RelPermalink }}">
+          {{ safeHTML .Params.Pre }}
+          {{ or .Params.menuTitle .LinkTitle .Title }}
+          {{ safeHTML .Params.Post }}
+          {{ if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}
+        </a>
+
+        {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
+        {{ if ne $numberOfPages 0 }}
         <ul>
           {{ $currentNode.Scratch.Set "pages" .Pages }}
           {{ if .Sections}}
             {{ $currentNode.Scratch.Set "pages" (.Pages | union .Sections) }}
-          {{end}}
+          {{ end }}
           {{ $pages := ($currentNode.Scratch.Get "pages") }}
 
-        {{if eq .Site.Params.ordersectionsby "title"}}
-          {{ range $pages.ByTitle }}
-            {{ if and .Params.hidden (not $.showhidden) }}
-            {{else}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
-            {{end}}
+          {{ if eq .Site.Params.ordersectionsby "title" }}
+            {{ range $pages.ByTitle }}
+              {{ if and .Params.hidden (not $.showhidden) }}
+              {{ else }}
+                {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+              {{ end }}
+            {{ end }}
+          {{ else }}
+            {{ range $pages.ByWeight }}
+              {{ if and .Params.hidden (not $.showhidden) }}
+              {{ else }}
+                {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+              {{ end }}
+            {{ end }}
           {{ end }}
-        {{else}}
-          {{ range $pages.ByWeight }}
-            {{ if and .Params.hidden (not $.showhidden) }}
-            {{else}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
-            {{end}}
-          {{ end }}
-        {{end}}
         </ul>
-      {{ end }}
-    </li>
-  {{else}}
-    {{ if not .Params.Hidden }}
-      <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{with .File}}{{$f := .}}{{with $currentNode.File}}{{if eq $f.UniqueID .UniqueID}}active{{end}}{{end}}{{end}}">
-        <a href="{{ .RelPermalink}}">
-        {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
-        {{if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}
-        </a>
+        {{ end }}
       </li>
-     {{ end }}
-  {{end}}
- {{ end }}
+    {{ else }}
+      {{ if not .Params.Hidden }}
+        <li data-nav-id="{{ .RelPermalink }}" title="{{ .Title }}" class="dd-item {{ with .File }}{{ $f := . }}{{ with $currentNode.File }}{{ if eq $f.UniqueID .UniqueID }}active{{ end }}{{ end }}{{ end }}">
+          <a href="{{ .RelPermalink }}">
+            {{ safeHTML .Params.Pre }}
+            {{ or .Params.menuTitle .LinkTitle .Title }}
+            {{ safeHTML .Params.Post }}
+            {{ if $showvisitedlinks }}<i class="fas fa-check read-icon"></i>{{ end }}
+          </a>
+        </li>
+      {{ end }}
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 {{- define "optionInDifferentVersion" -}}
@@ -142,9 +145,9 @@
   {{- $productPathPrefix := path.Join $productSection $version.release -}}
 
   <option
-    value="{{- template "findBestMatchInVersion" dict "root" $ "page" $.Page "product" $productSection "release" $version.release -}}"
+    value="{{ template "findBestMatchInVersion" dict "root" $ "page" $.Page "product" $productSection "release" $version.release }}"
     {{- if in $.RelPermalink $version.release }} selected{{ end -}}
-  >{{- $version.name -}}</option>
+  >{{ $version.name }}</option>
 {{- end -}}
 
 {{- define "findBestMatchInVersion" -}}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,15 +1,14 @@
 <nav id="sidebar" class="{{if $.Site.Params.showVisitedLinks }}showVisitedLinks{{end}}">
-
-{{ $currentNode := . }}
-{{ $showvisitedlinks := .Site.Params.showVisitedLinks }}
-{{ $productSection := .FirstSection.Section }}
-{{ $product := index $.Site.Data.products $productSection}}
+  {{ $currentNode := . }}
+  {{ $showvisitedlinks := .Site.Params.showVisitedLinks }}
+  {{ $productSection := .FirstSection.Section }}
+  {{ $product := index $.Site.Data.products $productSection}}
   <div id="header-wrapper">
     <div id="header">
       {{ partial "logo.html" . }}
     </div>
     {{if not .Site.Params.disableSearch}}
-        {{ partial "search.html" . }}
+      {{ partial "search.html" . }}
     {{end}}
     {{with $.Site.Data.products}}
     <div class="products-toogle">
@@ -17,7 +16,7 @@
         <label for="product-select" class="products-toogle-label">Product</label>
         <select id="product-select" onchange="location = this.value;">
         {{range $key, $value := .}}
-        {{$release := (cond (gt (len .versions) 1) (index .versions 1) (index .versions 0)).release}}
+          {{$release := (cond (gt (len .versions) 1) (index .versions 1) (index .versions 0)).release}}
           <option value="{{printf "/%s/%s/" $key $release | relURL}}"{{if in $.RelPermalink $key}} selected{{end}}>{{.name}}</option>
         {{end}}
         </select>
@@ -27,7 +26,7 @@
         <label for="version-select" class="products-toogle-label">Version</label>
         <select id="version-select" onchange="location = this.value;">
         {{range .versions}}
-        <option value="{{printf "/%s/%s/" $productSection .release | relURL}}"{{if in $.RelPermalink .release}} selected{{end}}>{{.name}}</option>
+          {{template "optionInDifferentVersion" dict "root" $ "sect" . "productSection" $productSection "version" .}}
         {{end}}
         </select>
       </div>
@@ -126,10 +125,85 @@
       <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{with .File}}{{$f := .}}{{with $currentNode.File}}{{if eq $f.UniqueID .UniqueID}}active{{end}}{{end}}{{end}}">
         <a href="{{ .RelPermalink}}">
         {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
-        {{ if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}
+        {{if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}
         </a>
-    </li>
+      </li>
      {{ end }}
   {{end}}
  {{ end }}
 {{ end }}
+
+{{- define "optionInDifferentVersion" -}}
+  {{- $ := .root -}}
+  {{- $productSection := .productSection -}}
+  {{- $version := .version -}}
+
+  {{/* create a prefix like "kubermatic/v2.14" */}}
+  {{- $productPathPrefix := path.Join $productSection $version.release -}}
+
+  <option
+    value="{{- template "findBestMatchInVersion" dict "root" $ "page" $.Page "product" $productSection "release" $version.release -}}"
+    {{- if in $.RelPermalink $version.release }} selected{{ end -}}
+  >{{- $version.name -}}</option>
+{{- end -}}
+
+{{- define "findBestMatchInVersion" -}}
+  {{- $ := .root -}}
+  {{- $page := .page -}}
+  {{- $productSection := .product -}}
+  {{- $release := .release -}}
+
+  {{/* create a prefix like "kubermatic/v2.14" */}}
+  {{- $productPathPrefix := path.Join $productSection $release -}}
+
+  {{/* strip product and version from the path (i.e. remove the first two path elements) */}}
+  {{- $relFilePath := path.Join (after 2 (split $page.File "/")) -}}
+  {{- $absFilePath := path.Join $productPathPrefix $relFilePath -}}
+
+  {{- if fileExists $absFilePath -}}
+    {{- ($.GetPage $absFilePath).RelPermalink -}}
+  {{- else -}}
+    {{/* If this is not a section, try the section instead */}}
+    {{- if not $page.IsSection -}}
+      {{- $relFilePathEn := path.Join (path.Dir $relFilePath) "_index.en.md" -}}
+      {{- $absFilePathEn := path.Join $productPathPrefix $relFilePathEn -}}
+
+      {{- if fileExists $absFilePathEn -}}
+        {{- ($.GetPage $absFilePathEn).RelPermalink -}}
+      {{- else -}}
+        {{/* Try the same thing again, but for non-localized products */}}
+        {{- $relFilePath := path.Join (path.Dir $relFilePath) "_index.md" -}}
+        {{- $absFilePath := path.Join $productPathPrefix $relFilePath -}}
+        {{- if fileExists $relFilePath -}}
+          {{- ($.GetPage $absFilePath).RelPermalink -}}
+        {{- else -}}
+          {{- template "walkSectionsUp" dict "root" $ "productPathPrefix" $productPathPrefix "start" $relFilePath -}}
+        {{- end -}}
+      {{- end -}}
+    {{- else -}}
+      {{- template "walkSectionsUp" dict "root" $ "productPathPrefix" $productPathPrefix "start" $relFilePath -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  This function takes a product-relative path like "section/section/section/_index.en.md"
+  and walks the path up until it finds a matching file in the productPathPrefix.
+*/}}
+{{- define "walkSectionsUp" -}}
+  {{- $ := .root -}}
+  {{- $productPathPrefix := .productPathPrefix -}}
+  {{- $start := path.Dir .start -}}
+  {{- $indexFile := path.Join $productPathPrefix $start "_index.en.md" -}}
+
+  {{- if fileExists $indexFile -}}
+    {{- ($.GetPage $indexFile).RelPermalink -}}
+  {{- else -}}
+    {{- $indexFile := path.Join $productPathPrefix $start "_index.md" -}}
+    {{- if fileExists $indexFile -}}
+      {{- ($.GetPage $indexFile).RelPermalink -}}
+    {{- else -}}
+      {{- template "walkSectionsUp" dict "root" $ "productPathPrefix" $productPathPrefix "start" $start -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
Previously, our code for the product version selector was very simple: Everytime someone changes the version, they are loading that version's homepage. That is bad UX.

This PR makes the version switch a bit more clever:

* If the current page exists in the other version, stay on the page.
* If the current page is not a section (i.e. it's not a `_index.en.md` file), then try the section (e.g. when on `kubermatic/v2.15/requirements/cloud_provider/_azure.md`, try `kubermatic/v2.15/requirements/cloud_provider/_index.en.md`).
* Otherwise, check the parent sections until we find one that does exist. This will stop at the latest when reaching a product's homepage.

One could call this "best effort" file matching. The result looks like this, for example:

![screenshot-2020-11-03-155608](https://user-images.githubusercontent.com/127499/98000743-1e6f5700-1ded-11eb-9118-b2d0b22d596a.png)

Thanks to Go's templating syntax, the code looks horribly complicated. This is the best I can offer.

And since I mutated the `menu.html` so much, I opted to also harmonize the whitespace insie the templating syntax. Sorry, I could not resist the urge.