### PR TITLE
Fix typo

### DIFF
--- a/content/kubermatic/v2.15/upgrading/2.14_to_2.15/chart_migration/_index.en.md
+++ b/content/kubermatic/v2.15/upgrading/2.14_to_2.15/chart_migration/_index.en.md
@@ -168,7 +168,7 @@ Once the Helm chart is gone, it's time to perform a clean installation of the ne
 The first step for that is to add new Kubermatic CRDs:
 
 ```bash
-kubectl apply -f charts/kubematic/crd/
+kubectl apply -f charts/kubermatic/crd/
 ```
 
 To prevent Kubermatic from rejecting existing clusters, make sure to apply the Seeds before installing


### PR DESCRIPTION
There's a typo in the chart_migration chapter for upgrading from 2.14 to 2.15