### PR TITLE
Fix make preview errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ DOCKER_BIN := $(shell which docker)
 preview:
 	docker run -it --name kubermatic-docs --rm \
 		-p 1313:1313 \
-		-v `pwd`:/docs quay.io/kubermatic/hugo:0.71.1-0 \
-		 bash -c 'cd docs; hugo server -D -F --bind 0.0.0.0'
+		-v `pwd`:/docs quay.io/kubermatic/hugo:0.75.1-0 \
+		 bash -c 'cd /docs; hugo server -D -F --bind 0.0.0.0'
 
 .PHONY: runbook
 runbook:


### PR DESCRIPTION
Running `make preview` on `master` returns the following errors:

```
docker run -it --name kubermatic-docs --rm \
	-p 1313:1313 \
	-v `pwd`:/docs quay.io/kubermatic/hugo:0.71.1-0 \
	 bash -c 'cd docs; hugo server -D -F --bind 0.0.0.0'
Building sites … ERROR 2021/04/22 07:44:46 render of "taxonomyTerm" failed: execute of template failed: template: _default/list.html:1:3: executing "_default/list.html" at <partial "header.html" .>: error calling partial: "/docs/layouts/partials/header.html:10:28": execute of template failed: template: partials/header.html:10:28: executing "partials/header.html" at <len $versions>: error calling len: reflect: call of reflect.Value.Type on zero Value
Built in 576 ms
Error: Error building site: failed to render pages: render of "taxonomyTerm" failed: execute of template failed: template: _default/list.html:1:3: executing "_default/list.html" at <partial "header.html" .>: error calling partial: "/docs/layouts/partials/header.html:10:28": execute of template failed: template: partials/header.html:10:28: executing "partials/header.html" at <len $versions>: error calling len: reflect: call of reflect.Value.Type on zero Value
make: *** [Makefile:7: preview] Error 255
```

As per [`netlify.toml`](https://github.com/kubermatic/docs/blob/c616d4f8633dcf757a0a8a5af87f722abb889ad9/netlify.toml#L1-L2), we're using Hugo 0.75.1, however, the `preview` Make target uses 0.71.1. The target works again after bumping the version to 0.75.1.
