### PR TITLE
Add operator upgrade documentation for v2.17

### DIFF
--- a/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/_index.en.md
+++ b/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/_index.en.md
@@ -1,6 +1,6 @@
 +++
 title = "Upgrading from 2.16 to 2.17"
-date = 2020-06-09T11:09:15+02:00
+date = 2021-04-22T17:33:39+02:00
 weight = 90
 
 +++
@@ -23,7 +23,21 @@ Note that the following customization options are not yet supported in the Kuber
 * Node and Pod affinities, node selectors for the KKP components
 * Worker goroutine count for the KKP components
 
-Depending on your chosen installation method, a number of upgrade paths are documented:
+## End of support for CoreOS Container Linux
 
-* [Upgrade from Helm-based installations]({{< ref "." >}})
+KKP 2.17 completely dropped support for CoreOS Container Linux, since it is
+end-of-life since May 2020 and no longer receives updates.
+Before upgrading your KKP installation be sure that none of the user clusters
+is still using CoreOS operating system.
+
+You can find some information about how to handle the migration
+[here](../../guides/kkp_os_support/coreos_eos).
+
+## Upgrade paths
+
+Depending on the installation method you have to chose one of the following
+upgrade paths:
+
+* [Upgrade from Chart-based installations]({{< ref "./chart_migration" >}})
 * [Upgrade from Operator-based installations]({{< ref "./kubermatic_operator" >}})
+

--- a/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/_index.en.md
+++ b/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/_index.en.md
@@ -1,0 +1,29 @@
++++
+title = "Upgrading from 2.16 to 2.17"
+date = 2020-06-09T11:09:15+02:00
+weight = 90
+
++++
+
+## [EE] End of support for `kubermatic` Helm Chart
+
+After the Kubermatic Operator has been introduced as a beta in version 2.14, it is now the recommended way of
+installing and managing KKP. This means that the `kubermatic` Helm chart was deprecated as of
+version 2.15 and starting from version 2.17 it is not supported any longer.
+
+The Kubermatic Operator does not support previously deprecated features like the `datacenters.yaml`
+or the full feature set of the `kubermatic` chart's customization options. Instead, datacenters
+have to be converted to `Seed` resources, while the chart configuration must be converted to a
+`KubermaticConfiguration`. The Kubermatic Installer offers commands to perform these conversions
+automatically.
+
+Note that the following customization options are not yet supported in the Kubermatic Operator:
+
+* `maxParallelReconcile` (always defaults to `10`)
+* Node and Pod affinities, node selectors for the KKP components
+* Worker goroutine count for the KKP components
+
+Depending on your chosen installation method, a number of upgrade paths are documented:
+
+* [Upgrade from Helm-based installations]({{< ref "." >}})
+* [Upgrade from Operator-based installations]({{< ref "./kubermatic_operator" >}})

--- a/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/kubermatic_operator/_index.en.md
+++ b/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/kubermatic_operator/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Upgrading KKP Operator"
-date = 2020-06-09T11:09:15+02:00
-weight = 10
+date = 2021-04-22T17:33:39+02:00
+weight = 30
 
 +++
 
@@ -70,7 +70,8 @@ Take the `nodeport-proxy`'s EXTERNAL IP, in this case `34.89.181.151`, and updat
 `*.<seedname>.kubermatic.example.com` to point to this new IP.
 
 It will take some time for the DNS changes to propagate to every user, so it is recommended to leave the old
-nodeport-proxy in place for a period of time (e.g. a week), before finally removing it:
+nodeport-proxy in place for a period of time (e.g. a few days to be
+conservative), before finally removing it:
 
 **Helm 3**
 

--- a/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/kubermatic_operator/_index.en.md
+++ b/content/kubermatic/v2.17/tutorials_howtos/upgrading/upgrade_from_2.16_to_2.17/kubermatic_operator/_index.en.md
@@ -1,0 +1,89 @@
++++
+title = "Upgrading KKP Operator"
+date = 2020-06-09T11:09:15+02:00
+weight = 10
+
++++
+
+Upgrading a KKP setup that is already managed by the Operator is as simple as
+updating the Helm charts and following the [general upgrade notes]({{< ref "../" >}}).
+
+## Upgrade Procedure
+
+Download the [latest 2.17 release](https://github.com/kubermatic/kubermatic/releases) from GitHub
+(make sure to choose the right version, CE for the Community or EE for the Enterprise Edition) and
+extract the archive locally.
+
+```bash
+wget https://github.com/kubermatic/kubermatic/releases/download/v2.17.0/kubermatic-ee-v2.17.0-linux-amd64.tar.gz
+tar -xzvf kubermatic-ce-v2.17.0-linux-amd64.tar.gz
+```
+
+Run the installer to perform the upgrade using the `kubermatic.yaml` and `values.yaml` you used to create the platform.
+
+```bash
+./kubermatic-installer deploy --config kubermatic.yaml --helm-values values.yaml --migrate-cert-manager
+```
+
+Note that the `--migrate-cert-manager` flag is necessary for the migration to cert-manager `1.2.0` to succeed.
+It will trigger an automatic migration of all `Certificate` resources from
+version `v1alpha1` to `v1` (find more details [here](https://github.com/kubermatic/kubermatic/pull/6739)).
+
+
+The Operator will automatically update the KKP Seed Controller Manager on every seed cluster.
+Manually upgrade all other charts you might have installed as part of the monitoring or logging
+stacks.
+
+## Migrating from the `nodeport-proxy` Helm Chart
+
+{{% notice info %}}
+The operator installs the `nodeport-proxy` by default. This step is required only
+for installations where `nodeport-proxy` was originally installed by Helm chart
+and it was not migrated yet as part of the migration to the operator.
+{{% /notice %}}
+
+The `nodeport-proxy` Helm chart has been deprecated in 2.15, the proxy however is still a required component
+of any Kubermatic setup, but is now managed by the Kubermatic Operator (similar to how it manages seed clusters).
+
+The migration to the operator-managed nodeport-proxy is relatively simple. The operator by default creates the
+new nodeport-proxy inside the Kubermatic namespace (`kubermatic` by default), whereas the old proxy was
+living in the `nodeport-proxy` namespace. Due to this, no naming conflicts can occur and in fact, both proxies
+can co-exist in the same cluster.
+
+The only important aspect is where the DNS record for the seed cluster is pointing. To migrate from the old
+to new nodeport-proxy, all that needs to be done is switch the DNS record to the new LoadBalancer service. The
+new services uses the same ports, so it does not matter what service a user is reaching.
+
+To migrate, find the new LoadBalancer service's public endpoint:
+
+```bash
+kubectl -n kubermatic get svc
+#NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                          AGE
+#kubermatic-api         NodePort       10.47.248.61    <none>          80:32486/TCP,8085:32223/TCP                      216d
+#kubermatic-dashboard   NodePort       10.47.247.32    <none>          80:32382/TCP                                     128d
+#kubermatic-ui          NodePort       10.47.240.175   <none>          80:31585/TCP                                     216d
+#nodeport-proxy         LoadBalancer   10.47.254.72    34.89.181.151   32180:32428/TCP,30168:30535/TCP,8002:30791/TCP   182d
+#seed-webhook           ClusterIP      10.47.249.0     <none>          443/TCP                                          216d
+```
+
+Take the `nodeport-proxy`'s EXTERNAL IP, in this case `34.89.181.151`, and update your DNS record for
+`*.<seedname>.kubermatic.example.com` to point to this new IP.
+
+It will take some time for the DNS changes to propagate to every user, so it is recommended to leave the old
+nodeport-proxy in place for a period of time (e.g. a week), before finally removing it:
+
+**Helm 3**
+
+```bash
+helm --namespace nodeport-proxy delete nodeport-proxy
+kubectl delete ns nodeport-proxy
+```
+
+**Helm 2**
+
+```bash
+helm --tiller-namespace kubermatic delete --purge nodeport-proxy
+kubectl delete ns nodeport-proxy
+```
+
+These steps need to be performed on all seed clusters.


### PR DESCRIPTION
This PR adds the documentation for upgrading KKP to v2.17 on operator-based installations.

ref: https://github.com/kubermatic/docs/issues/647