### PR TITLE
Use convert-kubeconfig command instead of referencing external script

### DIFF
--- a/content/kubermatic/master/guides/installation/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/master/guides/installation/add_seed_cluster_CE/_index.en.md
@@ -105,9 +105,12 @@ try to talk to local token helper programs like `aws-iam-authenticator` for AWS 
 These kubeconfig files **will not work** for setting up Seeds.
 {{% /notice %}}
 
-The Kubermatic repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/master/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in Kubermatic. The script will create
-a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
-the kubeconfig file. Afterwards the file can be used in KKP.
+The `kubermatic-installer` tool provides a command `convert-kubeconfig` that can be used to prepare a kubeconfig for
+usage in Kubermatic. The script will create a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role
+and then put the ServiceAccount's token into the kubeconfig file. Afterwards the file can be used in KKP.
+```bash
+./kubermatic-installer convert-kubeconfig <ORIGINAL-KUBECONFIG-FILE> > my-kubeconfig-file
+```
 
 The Seed resource itself needs to be called `kubermatic` (for the Community Edition) and needs to reference the new
 kubeconfig Secret like so:

--- a/content/kubermatic/master/guides/installation/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/master/guides/installation/add_seed_cluster_EE/_index.en.md
@@ -106,9 +106,12 @@ try to talk to local token helper programs like `aws-iam-authenticator` for AWS 
 These kubeconfig files **will not work** for setting up Seeds.
 {{% /notice %}}
 
-The KKP repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/master/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in KKP. The script will create
-a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
-the kubeconfig file. Afterwards the file can be used in KKP.
+The `kubermatic-installer` tool provides a command `convert-kubeconfig` that can be used to prepare a kubeconfig for
+usage in Kubermatic. The script will create a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role
+and then put the ServiceAccount's token into the kubeconfig file. Afterwards the file can be used in KKP.
+```bash
+./kubermatic-installer convert-kubeconfig <ORIGINAL-KUBECONFIG-FILE> > my-kubeconfig-file
+```
 
 The Seed resource then needs to reference the new kubeconfig Secret like so:
 

--- a/content/kubermatic/v2.17/guides/installation/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/v2.17/guides/installation/add_seed_cluster_CE/_index.en.md
@@ -105,9 +105,12 @@ try to talk to local token helper programs like `aws-iam-authenticator` for AWS 
 These kubeconfig files **will not work** for setting up Seeds.
 {{% /notice %}}
 
-The Kubermatic repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/master/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in Kubermatic. The script will create
-a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
-the kubeconfig file. Afterwards the file can be used in KKP.
+The `kubermatic-installer` tool provides a command `convert-kubeconfig` that can be used to prepare a kubeconfig for
+usage in Kubermatic. The script will create a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role
+and then put the ServiceAccount's token into the kubeconfig file. Afterwards the file can be used in KKP.
+```bash
+./kubermatic-installer convert-kubeconfig <ORIGINAL-KUBECONFIG-FILE> > my-kubeconfig-file
+```
 
 The Seed resource itself needs to be called `kubermatic` (for the Community Edition) and needs to reference the new
 kubeconfig Secret like so:

--- a/content/kubermatic/v2.17/guides/installation/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/v2.17/guides/installation/add_seed_cluster_EE/_index.en.md
@@ -106,9 +106,12 @@ try to talk to local token helper programs like `aws-iam-authenticator` for AWS 
 These kubeconfig files **will not work** for setting up Seeds.
 {{% /notice %}}
 
-The KKP repository provides a [script](https://github.com/kubermatic/kubermatic-installer/blob/master/kubeconfig-serviceaccounts.sh) that can be used to prepare a kubeconfig for usage in KKP. The script will create
-a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role and then put the ServiceAccount's token into
-the kubeconfig file. Afterwards the file can be used in KKP.
+The `kubermatic-installer` tool provides a command `convert-kubeconfig` that can be used to prepare a kubeconfig for
+usage in Kubermatic. The script will create a ServiceAccount in the seed cluster, bind it to the `cluster-admin` role
+and then put the ServiceAccount's token into the kubeconfig file. Afterwards the file can be used in KKP.
+```bash
+./kubermatic-installer convert-kubeconfig <ORIGINAL-KUBECONFIG-FILE> > my-kubeconfig-file
+```
 
 The Seed resource then needs to reference the new kubeconfig Secret like so:
 


### PR DESCRIPTION
The functionality of the original [script](https://github.com/kubermatic/kubermatic-installer/blob/master/kubeconfig-serviceaccounts.sh) was incorporated in the `kubermatic-installer` so this change removes the external reference and provides a direct usage example of the command.

(based on the info from @xrstf, the script won't be maintained and updated anymore).

Update is done in both CE/EE guides and in master + 2.17 version.

There is a related update of the original script (to make it work with latest yq) - kubermatic/kubermatic-installer/pull/136