### PR TITLE
kubeone: Update variable names for vsphere installation

### DIFF
--- a/content/kubeone/master/guides/credentials/_index.md
+++ b/content/kubeone/master/guides/credentials/_index.md
@@ -203,8 +203,8 @@ For the Terraform reference, please take a look at
 
 | Environment Variable | Description                         |
 | -------------------- | ----------------------------------- |
-| `VSPHERE_ADDRESS`    | The address of the vSphere instance |
-| `VSPHERE_USERNAME`   | The username of the vSphere user    |
+| `VSPHERE_SERVER`     | The address of the vSphere instance |
+| `VSPHERE_USER`       | The username of the vSphere user    |
 | `VSPHERE_PASSWORD`   | The password of the vSphere user    |
 
 #
@@ -227,8 +227,8 @@ cloud-config contains secrets and you want to keep secrets in a different file.
 The credentials file can look like the following one:
 
 ```yaml
-VSPHERE_ADDRESS: "<<VSPHERE_ADDRESS>>"
-VSPHERE_USERNAME: "<<VSPHERE_USERNAME>>"
+VSPHERE_SERVER: "<<VSPHERE_SERVER>>"
+VSPHERE_USER: "<<VSPHERE_USER>>"
 VSPHERE_PASSWORD: "<<VSPHERE_PASSWORD>>"
 cloudConfig: |
     <<VSPHERE_CLOUD_CONFIG>>

--- a/content/kubeone/master/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters/_index.en.md
@@ -329,8 +329,8 @@ For the Terraform reference, please take a look at
 
 | Environment Variable | Description                         |
 | -------------------- | ----------------------------------- |
-| `VSPHERE_ADDRESS`    | The address of the vSphere instance |
-| `VSPHERE_USERNAME`   | The username of the vSphere user    |
+| `VSPHERE_SERVER`     | The address of the vSphere instance |
+| `VSPHERE_USER`       | The username of the vSphere user    |
 | `VSPHERE_PASSWORD`   | The password of the vSphere user    |
 
 #

--- a/content/kubeone/v1.2/prerequisites/credentials.en.md
+++ b/content/kubeone/v1.2/prerequisites/credentials.en.md
@@ -204,8 +204,8 @@ For the Terraform reference, please take a look at
 
 | Environment Variable | Description                         |
 | -------------------- | ----------------------------------- |
-| `VSPHERE_ADDRESS`    | The address of the vSphere instance |
-| `VSPHERE_USERNAME`   | The username of the vSphere user    |
+| `VSPHERE_SERVER`     | The address of the vSphere instance |
+| `VSPHERE_USER`       | The username of the vSphere user    |
 | `VSPHERE_PASSWORD`   | The password of the vSphere user    |
 
 #
@@ -228,8 +228,8 @@ cloud-config contains secrets and you want to keep secrets in a different file.
 The credentials file can look like the following one:
 
 ```yaml
-VSPHERE_ADDRESS: "<<VSPHERE_ADDRESS>>"
-VSPHERE_USERNAME: "<<VSPHERE_USERNAME>>"
+VSPHERE_SERVER: "<<VSPHERE_SERVER>>"
+VSPHERE_USER: "<<VSPHERE_USER>>"
 VSPHERE_PASSWORD: "<<VSPHERE_PASSWORD>>"
 cloudConfig: |
     <<VSPHERE_CLOUD_CONFIG>>

--- a/content/kubeone/v1.3/guides/credentials/_index.md
+++ b/content/kubeone/v1.3/guides/credentials/_index.md
@@ -203,8 +203,8 @@ For the Terraform reference, please take a look at
 
 | Environment Variable | Description                         |
 | -------------------- | ----------------------------------- |
-| `VSPHERE_ADDRESS`    | The address of the vSphere instance |
-| `VSPHERE_USERNAME`   | The username of the vSphere user    |
+| `VSPHERE_SERVER`     | The address of the vSphere instance |
+| `VSPHERE_USER`       | The username of the vSphere user    |
 | `VSPHERE_PASSWORD`   | The password of the vSphere user    |
 
 #
@@ -227,8 +227,8 @@ cloud-config contains secrets and you want to keep secrets in a different file.
 The credentials file can look like the following one:
 
 ```yaml
-VSPHERE_ADDRESS: "<<VSPHERE_ADDRESS>>"
-VSPHERE_USERNAME: "<<VSPHERE_USERNAME>>"
+VSPHERE_SERVER: "<<VSPHERE_SERVER>>"
+VSPHERE_USER: "<<VSPHERE_USER>>"
 VSPHERE_PASSWORD: "<<VSPHERE_PASSWORD>>"
 cloudConfig: |
     <<VSPHERE_CLOUD_CONFIG>>

--- a/content/kubeone/v1.3/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/v1.3/tutorials/creating_clusters/_index.en.md
@@ -329,8 +329,8 @@ For the Terraform reference, please take a look at
 
 | Environment Variable | Description                         |
 | -------------------- | ----------------------------------- |
-| `VSPHERE_ADDRESS`    | The address of the vSphere instance |
-| `VSPHERE_USERNAME`   | The username of the vSphere user    |
+| `VSPHERE_SERVER`     | The address of the vSphere instance |
+| `VSPHERE_USER`       | The username of the vSphere user    |
 | `VSPHERE_PASSWORD`   | The password of the vSphere user    |
 
 #


### PR DESCRIPTION
Update terraform credentials (env.variables) to match with expected provider names.

https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs#argument-reference

Updated in master, 1.3 and 1.2 versions.

Note: values are correct in https://github.com/kubermatic/kubeone/blob/master/examples/terraform/vsphere/README.md