### PR TITLE
Remove optional comment for cluster field in seed

### DIFF
--- a/content/kubermatic/master/data/seed.yaml
+++ b/content/kubermatic/master/data/seed.yaml
@@ -174,9 +174,7 @@ spec:
         vsphere:
           # If set to true, disables the TLS certificate check against the endpoint.
           allow_insecure: false
-          # Optional: The name of the vSphere cluster to use.
-          # Cluster is deprecated and may be removed in future releases as it is
-          # currently ignored.
+          # The name of the vSphere cluster to use.
           # The cluster hosting the VMs will be the same VM used as a template is
           # located.
           cluster: ""

--- a/content/kubermatic/v2.17/data/seed.yaml
+++ b/content/kubermatic/v2.17/data/seed.yaml
@@ -174,9 +174,7 @@ spec:
         vsphere:
           # If set to true, disables the TLS certificate check against the endpoint.
           allow_insecure: false
-          # Optional: The name of the vSphere cluster to use.
-          # Cluster is deprecated and may be removed in future releases as it is
-          # currently ignored.
+          # The name of the vSphere cluster to use.
           # The cluster hosting the VMs will be the same VM used as a template is
           # located.
           cluster: ""


### PR DESCRIPTION
We have discovered that having a vsphere seed config without a cluster field does not work and lead to a situation
that initial machine deployment is not provisioned at all.

Without providing it, following error is present:
```
failed to create initial MachineDeployment: admission webhook "machine-controller.kubermatic.io-machinedeployments" denied the request: validation failed: failed to get cluster: : cluster '' not found
```

Fixes #723.