### PR TITLE
Rollout md fix typo

### DIFF
--- a/content/kubeone/master/cheat_sheets/rollout_machinedeployment/_index.en.md
+++ b/content/kubeone/master/cheat_sheets/rollout_machinedeployment/_index.en.md
@@ -4,18 +4,18 @@ date = 2021-06-07T15:00:00+02:00
 weight = 25
 +++
 
-## To rolling restart a single machineDeploment
+## To rolling restart a single machineDeployment
 
 ```shell
 forceRestartAnnotations="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"forceRestart\":\"$(date +%N)\"}}}}}"
-kubectl patch machinedeployment <NAME> --type=merge -p $forceRestartAnnotations 
+kubectl patch machinedeployment -n kube-system <NAME> --type=merge -p $forceRestartAnnotations 
 ```
 
-## To rolling restart all machineDeploments
+## To rolling restart all machineDeployments
 
 ```shell
 forceRestartAnnotations="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"forceRestart\":\"$(date +%N)\"}}}}}"
-for md in $(kubectl get machinedeployments --no-headers | awk '{print $1}'); do
-  kubectl patch machinedeployment $md --type=merge -p $forceRestartAnnotations
+for md in $(kubectl get machinedeployments -n kube-system --no-headers | awk '{print $1}'); do
+  kubectl patch machinedeployment -n kube-system $md --type=merge -p $forceRestartAnnotations
 done
 ```


### PR DESCRIPTION
Typo fixed and `kube-system` namespace added to the kubectl commands.