### PR TITLE
fix featureGates format in docs

### DIFF
--- a/content/kubermatic/master/cheat_sheets/etcd/etcd-launcher/_index.en.md
+++ b/content/kubermatic/master/cheat_sheets/etcd/etcd-launcher/_index.en.md
@@ -36,7 +36,8 @@ metadata:
 spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    - "EtcdLauncher=true"
+    EtcdLauncher
+      enabled: true
 ```
 
 Next, simply apply the updated CRD:


### PR DESCRIPTION
The previously documented format did nothing in KKP 2.17.2, but I found this working format in the kubermatic/mla repo's README.md. Supposedly the format changed at some point without this doc page being updated to reflect that change.