### PR TITLE
fix featureGates format in etcd-launcher docs

### DIFF
--- a/content/kubermatic/master/cheat_sheets/etcd/etcd-launcher/_index.en.md
+++ b/content/kubermatic/master/cheat_sheets/etcd/etcd-launcher/_index.en.md
@@ -36,7 +36,8 @@ metadata:
 spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    - "EtcdLauncher=true"
+    EtcdLauncher:
+      enabled: true
 ```
 
 Next, simply apply the updated CRD:


### PR DESCRIPTION
The previously used format did not appear to work in the latest KKP version.
Supposedly the format changed at some point without this doc page being
updated to reflect that change.

Signed-off-by: Sandro Mathys <sandro@mathys.io>