### PR TITLE
add namespace and fix typo in rolling restart script

### DIFF
--- a/content/kubeone/v1.3/cheat_sheets/rollout_machinedeployment/_index.en.md
+++ b/content/kubeone/v1.3/cheat_sheets/rollout_machinedeployment/_index.en.md
@@ -4,18 +4,18 @@ date = 2021-06-07T15:00:00+02:00
 weight = 25
 +++
 
-## To rolling restart a single machineDeploment
+## To rolling restart a single machineDeployment
 
 ```shell
 forceRestartAnnotations="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"forceRestart\":\"$(date +%N)\"}}}}}"
-kubectl patch machinedeployment <NAME> --type=merge -p $forceRestartAnnotations 
+kubectl patch machinedeployment -n kube-system <NAME> --type=merge -p $forceRestartAnnotations 
 ```
 
-## To rolling restart all machineDeploments
+## To rolling restart all machineDeployments
 
 ```shell
 forceRestartAnnotations="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"forceRestart\":\"$(date +%N)\"}}}}}"
-for md in $(kubectl get machinedeployments --no-headers | awk '{print $1}'); do
-  kubectl patch machinedeployment $md --type=merge -p $forceRestartAnnotations
+for md in $(kubectl get machinedeployments -n kube-system --no-headers | awk '{print $1}'); do
+  kubectl patch machinedeployment -n kube-system $md --type=merge -p $forceRestartAnnotations
 done
 ```


### PR DESCRIPTION
Fixes rolling restart script and typo for kubeone 1.3