### PR TITLE
Fix links to requirements and upgrade notes in CE installation

### DIFF
--- a/content/kubermatic/master/guides/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/master/guides/installation/install_kkp_CE/_index.en.md
@@ -17,13 +17,13 @@ This chapter explains the installation procedure of KKP into a pre-existing Kube
 
 ## Requirements
 
-Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "." >}})
+Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "../../../architecture/requirements" >}})
 and make yourself familiar with the requirements for your chosen cloud provider.
 
 For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
 
 {{% notice warning %}}
-This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "." >}}) for more information on
+This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "../../../tutorials_howtos/upgrading" >}}) for more information on
 migrating existing installations to the Kubermatic Installer.
 {{% /notice %}}
 

--- a/content/kubermatic/v2.18/guides/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/v2.18/guides/installation/install_kkp_CE/_index.en.md
@@ -17,13 +17,13 @@ This chapter explains the installation procedure of KKP into a pre-existing Kube
 
 ## Requirements
 
-Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "." >}})
+Before installing, make sure your Kubernetes cluster meets the [minimal requirements]({{< ref "../../../architecture/requirements" >}})
 and make yourself familiar with the requirements for your chosen cloud provider.
 
 For this guide you will have to have `kubectl` and [Helm](https://www.helm.sh/) (version 3) installed locally.
 
 {{% notice warning %}}
-This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "." >}}) for more information on
+This guide assumes a clean installation into an empty cluster. Please refer to the [upgrade notes]({{< ref "../../../tutorials_howtos/upgrading" >}}) for more information on
 migrating existing installations to the Kubermatic Installer.
 {{% /notice %}}
 


### PR DESCRIPTION
These links are correct in the EE installation document, but are not working in the CE version of the document.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>