### PR TITLE
Remove helm2 references

### DIFF
--- a/content/kubermatic/master/guides/installation/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/master/guides/installation/add_seed_cluster_CE/_index.en.md
@@ -15,20 +15,6 @@ the same namespace. It is however not possible to use the same cluster for multi
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Install KKP Dependencies
-
-Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
-will improve the setup experience further.
-
-If you're using Helm 2, install Tiller into the seed cluster first:
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
 ## Configure Cluster Backups 
 
 KKP performs regular backups of user clusters by snapshotting the etcd of each cluster. Default configuration uses in-cluster object storage provided by [Minio](https://min.io). It can be installed using `minio` Helm chart provided with the KKP installer. 
@@ -92,13 +78,6 @@ After configuring the required options, you can install the charts:
 ```bash
 helm --namespace minio upgrade --install --wait --values /path/to/your/helm-values.yaml minio charts/minio/
 helm --namespace kube-system upgrade --install --wait --values /path/to/your/helm-values.yaml s3-exporter charts/s3-exporter/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace kube-system s3-exporter charts/s3-exporter/
 ```
 
 ## Add CRDs for kubermatic components in the seed cluster

--- a/content/kubermatic/master/guides/installation/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/master/guides/installation/add_seed_cluster_EE/_index.en.md
@@ -16,20 +16,6 @@ the same namespace. It is however not possible to use the same cluster for multi
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Install KKP Dependencies
-
-Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
-will improve the setup experience further.
-
-If you're using Helm 2, install Tiller into the seed cluster first:
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
 ## Configure Cluster Backups 
 
 KKP performs regular backups of user clusters by snapshotting the etcd of each cluster. Default configuration uses in-cluster object storage provided by [Minio](https://min.io). It can be installed using `minio` Helm chart provided with the KKP installer. 
@@ -93,13 +79,6 @@ After configuring the required options, you can install the charts:
 ```bash
 helm --namespace minio upgrade --install --wait --values /path/to/your/helm-values.yaml minio charts/minio/
 helm --namespace kube-system upgrade --install --wait --values /path/to/your/helm-values.yaml s3-exporter charts/s3-exporter/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace kube-system s3-exporter charts/s3-exporter/
 ```
 
 ## Add CRDs for kubermatic components in seed cluster

--- a/content/kubermatic/master/guides/kkp_security/securing_system_services/_index.en.md
+++ b/content/kubermatic/master/guides/kkp_security/securing_system_services/_index.en.md
@@ -63,12 +63,6 @@ this:
 helm --namespace oauth upgrade --install --wait --values /path/to/your/helm-values.yaml oauth charts/oauth/
 ```
 
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace oauth oauth charts/oauth/
-```
-
 ### OAuth2-Proxy (IAP)
 
 Now that you have setup Dex, you need to configure OAuth2-Proxy to sit in front of the system services and use it
@@ -131,12 +125,6 @@ With all this configured, it's now time to install/upgrade the `iap` Helm chart:
 
 ```bash
 helm --namespace iap upgrade --install --wait --values /path/to/your/helm-values.yaml iap charts/iap/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace iap iap charts/iap/
 ```
 
 This will create one Ingress per deployment you configured. If all your Ingress hosts are subdomains of your

--- a/content/kubermatic/master/guides/monitoring_logging_alerting/master_seed/installation/_index.en.md
+++ b/content/kubermatic/master/guides/monitoring_logging_alerting/master_seed/installation/_index.en.md
@@ -88,18 +88,6 @@ helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm
 helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml blackbox-exporter charts/monitoring/blackbox-exporter/
 ```
 
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring prometheus charts/monitoring/prometheus/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring alertmanager charts/monitoring/alertmanager/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring node-exporter charts/monitoring/node-exporter/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring kube-state-metrics charts/monitoring/kube-state-metrics/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring grafana charts/monitoring/grafana/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring karma charts/monitoring/karma/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring blackbox-exporter charts/monitoring/blackbox-exporter/
-```
-
 ### Going Further
 
 The charts have a lot more options to tweak, like `alertmanager.config` or `karma.config` to control how and which
@@ -179,11 +167,4 @@ With this file prepared, we can now install all required charts:
 ```bash
 helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml promtail charts/logging/promtail/
 helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml loki charts/logging/loki/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace logging promtail charts/logging/promtail/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace logging loki charts/logging/loki/
 ```

--- a/content/kubermatic/master/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
@@ -152,12 +152,6 @@ After all values are set up, it's time to update the KKP master cluster. Update 
 helm --namespace oauth upgrade --install --wait --values values.yaml oauth charts/oauth/
 ```
 
-**Helm 2**
-
-```bash
-helm upgrade --install --wait --timeout 300 --values values.yaml --namespace oauth oauth charts/oauth/
-```
-
 Now that the issuer is available, update the `KubermaticConfiguration`:
 
 ```bash

--- a/content/kubermatic/master/tutorials_howtos/upgrading/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/upgrading/_index.en.md
@@ -105,7 +105,7 @@ helm --namespace kubermatic upgrade --install --wait --values values.yaml kuberm
 helm --namespace kubermatic upgrade --install --wait --values values.yaml kubermatic charts/kubermatic/
 ```
 
-**Helm 2**
+**Helm 2 (not supported since v2.18.0)**
 
 ```bash
 helm upgrade --install --wait --values values.yaml --namespace cert-manager cert-manager charts/cert-manager/

--- a/content/kubermatic/v2.18/guides/installation/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/v2.18/guides/installation/add_seed_cluster_CE/_index.en.md
@@ -15,20 +15,6 @@ the same namespace. It is however not possible to use the same cluster for multi
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Install KKP Dependencies
-
-Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
-will improve the setup experience further.
-
-If you're using Helm 2, install Tiller into the seed cluster first:
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
 ## Configure Cluster Backups 
 
 KKP performs regular backups of user clusters by snapshotting the etcd of each cluster. Default configuration uses in-cluster object storage provided by [Minio](https://min.io). It can be installed using `minio` Helm chart provided with the KKP installer. 
@@ -92,13 +78,6 @@ After configuring the required options, you can install the charts:
 ```bash
 helm --namespace minio upgrade --install --wait --values /path/to/your/helm-values.yaml minio charts/minio/
 helm --namespace kube-system upgrade --install --wait --values /path/to/your/helm-values.yaml s3-exporter charts/s3-exporter/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace kube-system s3-exporter charts/s3-exporter/
 ```
 
 ## Add CRDs for kubermatic components in the seed cluster

--- a/content/kubermatic/v2.18/guides/installation/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/v2.18/guides/installation/add_seed_cluster_EE/_index.en.md
@@ -16,20 +16,6 @@ the same namespace. It is however not possible to use the same cluster for multi
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Install KKP Dependencies
-
-Compared to master clusters, seed clusters are still mostly manually installed. Future versions of KKP
-will improve the setup experience further.
-
-If you're using Helm 2, install Tiller into the seed cluster first:
-
-```bash
-kubectl create namespace kubermatic
-kubectl create serviceaccount -n kubermatic tiller
-kubectl create clusterrolebinding tiller-cluster-role --clusterrole=cluster-admin --serviceaccount=kubermatic:tiller
-helm --service-account tiller --tiller-namespace kubermatic init
-```
-
 ## Configure Cluster Backups 
 
 KKP performs regular backups of user clusters by snapshotting the etcd of each cluster. Default configuration uses in-cluster object storage provided by [Minio](https://min.io). It can be installed using `minio` Helm chart provided with the KKP installer. 
@@ -93,13 +79,6 @@ After configuring the required options, you can install the charts:
 ```bash
 helm --namespace minio upgrade --install --wait --values /path/to/your/helm-values.yaml minio charts/minio/
 helm --namespace kube-system upgrade --install --wait --values /path/to/your/helm-values.yaml s3-exporter charts/s3-exporter/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace minio minio charts/minio/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace kube-system s3-exporter charts/s3-exporter/
 ```
 
 ## Add CRDs for kubermatic components in seed cluster

--- a/content/kubermatic/v2.18/guides/kkp_security/securing_system_services/_index.en.md
+++ b/content/kubermatic/v2.18/guides/kkp_security/securing_system_services/_index.en.md
@@ -63,12 +63,6 @@ this:
 helm --namespace oauth upgrade --install --wait --values /path/to/your/helm-values.yaml oauth charts/oauth/
 ```
 
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace oauth oauth charts/oauth/
-```
-
 ### OAuth2-Proxy (IAP)
 
 Now that you have setup Dex, you need to configure OAuth2-Proxy to sit in front of the system services and use it
@@ -131,12 +125,6 @@ With all this configured, it's now time to install/upgrade the `iap` Helm chart:
 
 ```bash
 helm --namespace iap upgrade --install --wait --values /path/to/your/helm-values.yaml iap charts/iap/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace iap iap charts/iap/
 ```
 
 This will create one Ingress per deployment you configured. If all your Ingress hosts are subdomains of your

--- a/content/kubermatic/v2.18/guides/monitoring_logging_alerting/master_seed/installation/_index.en.md
+++ b/content/kubermatic/v2.18/guides/monitoring_logging_alerting/master_seed/installation/_index.en.md
@@ -88,18 +88,6 @@ helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm
 helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml blackbox-exporter charts/monitoring/blackbox-exporter/
 ```
 
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring prometheus charts/monitoring/prometheus/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring alertmanager charts/monitoring/alertmanager/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring node-exporter charts/monitoring/node-exporter/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring kube-state-metrics charts/monitoring/kube-state-metrics/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring grafana charts/monitoring/grafana/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring karma charts/monitoring/karma/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace monitoring blackbox-exporter charts/monitoring/blackbox-exporter/
-```
-
 ### Going Further
 
 The charts have a lot more options to tweak, like `alertmanager.config` or `karma.config` to control how and which
@@ -179,11 +167,4 @@ With this file prepared, we can now install all required charts:
 ```bash
 helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml promtail charts/logging/promtail/
 helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml loki charts/logging/loki/
-```
-
-**Helm 2**
-
-```bash
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace logging promtail charts/logging/promtail/
-helm --tiller-namespace kubermatic upgrade --install --values /path/to/your/helm-values.yaml --namespace logging loki charts/logging/loki/
 ```

--- a/content/kubermatic/v2.18/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
+++ b/content/kubermatic/v2.18/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
@@ -152,12 +152,6 @@ After all values are set up, it's time to update the KKP master cluster. Update 
 helm --namespace oauth upgrade --install --wait --values values.yaml oauth charts/oauth/
 ```
 
-**Helm 2**
-
-```bash
-helm upgrade --install --wait --timeout 300 --values values.yaml --namespace oauth oauth charts/oauth/
-```
-
 Now that the issuer is available, update the `KubermaticConfiguration`:
 
 ```bash

--- a/content/kubermatic/v2.18/tutorials_howtos/upgrading/_index.en.md
+++ b/content/kubermatic/v2.18/tutorials_howtos/upgrading/_index.en.md
@@ -105,7 +105,7 @@ helm --namespace kubermatic upgrade --install --wait --values values.yaml kuberm
 helm --namespace kubermatic upgrade --install --wait --values values.yaml kubermatic charts/kubermatic/
 ```
 
-**Helm 2**
+**Helm 2 (not supported since v2.18.0)**
 
 ```bash
 helm upgrade --install --wait --values values.yaml --namespace cert-manager cert-manager charts/cert-manager/


### PR DESCRIPTION
Since KKP V2.18 we do not support helm 2 anymore. This PR remove helm 2 references from the documentation.