### PR TITLE
Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,8 +7,6 @@ aliases:
     - moelsayed
     - xmudrii
     - xrstf
-    - youssefazrak
-    - irozzo-1A
 
   team-ui:
     - kgroschoff

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,6 @@
 aliases:
   team-lifecycle:
+    - embik
     - kron4eg
     - mlavacca
     - moadqassem


### PR DESCRIPTION
I tend to make a few PRs to kubermatic/docs, so adding myself (Marvin) as an owner.

In addition, I've cleaned up OWNERS_ALIASES for people that left the company. Corresponding kubermatic/kubermatic PRs:

- https://github.com/kubermatic/kubermatic/pull/7995
- https://github.com/kubermatic/kubermatic/pull/7637