### PR TITLE
Add admissionPlugins documentation for custom admission plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ tutorials-tests/cypress/fixtures
 
 # IDE specific files
 .idea/
+
+# Hugo
+.hugo_build.lock

--- a/content/kubermatic/master/guides/admission_plugins/_index.en.md
+++ b/content/kubermatic/master/guides/admission_plugins/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Admission plugins configuration"
+title = "Admission Plugins Configuration"
 date = 2021-02-05T14:07:15+02:00
 weight = 150
 
@@ -33,7 +33,7 @@ UI wizard.
 ![Admission Plugin Selection](/img/kubermatic/master/ui/admission_plugins.png?height=400px&classes=shadow,border "Admission Plugin Selection")
 
 
-### PodNodeSelector configuration
+### PodNodeSelector Configuration
 Selecting `PodNodeSelector` plugin expands an additional view for the plugin configuration.
 
 ![Admission Plugin Configuration](/img/kubermatic/master/ui/admission_plugin_configuration.png?classes=shadow,border "Admission Plugin Configuration")
@@ -42,3 +42,20 @@ In this view you can define selector for namespaces that have no label selector 
 `NodeSelector` for the cluster, as well as whitelist for each namespace.
 Every pod created in the `production` namespace will be injected the NodeSelector `env=production`
 Every pod in the `development` namespace will inherit the `clusterDefaultNodeSelector`, in this case `env=development`.
+
+### Additional Admission Plugins
+
+In addition to the admission plugins enabled by default or enabled as a managed KKP feature, KKP supports adding a list of admission plugins through the KKP API. This is limited to admission plugins that do not need additional configuration files or flags passed to the Kubernetes API server, for example [`AlwaysPullImages`](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages) or [`SecurityContextDeny`](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny) (which is recommended if there is no security policy enforcement (PSPs or OPA Gatekeeper) in the cluster).
+
+{{% notice note %}}
+Custom admission plugins cannot be validated by KKP and there is a risk of unintended consequences when enabling some admission plugins. Make sure you test and validate your list of admission plugins on test user clusters before enabling them on production environments.
+{{% /notice %}}
+
+This can achieved by setting or updating the field `spec.admissionPlugins` in the API for cluster resources. This field is a list, so it would look something like this:
+
+```yaml
+spec:
+  admissionPlugins:
+    - AlwaysPullImages
+    - SecurityContextDeny
+```


### PR DESCRIPTION
We introduced a field `spec.admissionPlugins` quite a while ago that offers a flexible way to append admission plugins, but we never surfaced that in the documentation. For easy resolution of https://github.com/kubermatic/edgematic/issues/52, we can document this and thus, help users that have custom needs for their admission plugin list.

Fixes: https://github.com/kubermatic/edgematic/issues/52

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>