### PR TITLE
Fix typo in KKP user documentation headline

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/administration/kkp_user/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/administration/kkp_user/_index.en.md
@@ -28,7 +28,7 @@ After the installation of Kubermatic Kubernetes Platform the first account that 
 
 The account is then capable of setting admin permissions via the [dashboard]({{< ref "../admin_panel/administrators" >}}) .
 
-# Granting admin permission via kubeclt
+# Granting admin permission via kubectl
 
 Make sure the account logged in once at the Kubermatic Dashboard.
 


### PR DESCRIPTION
I found a small typo in #824 that I missed during review. `kubeclt`-> `kubectl`. 