### PR TITLE
Minor KubeOne docs fixes

### DIFF
--- a/content/kubeone/master/guides/autoscaler_addon/_index.en.md
+++ b/content/kubeone/master/guides/autoscaler_addon/_index.en.md
@@ -11,7 +11,7 @@ Cluster Autoscaler is a Kubernetes component that automatically adjusts the size
 ## The Prerequisites
 
 Using the Kubernetes Cluster Autoscaler in the KubeOne cluster requires some prerequisites to be met, which are:
-* KubeOne 1.3.1 or newer is required
+* KubeOne 1.3.2 or newer is required
 * The worker nodes need to be managed by the Kubermatic machine-controller. Therefore, we recommend checking the [concepts][concepts] document to learn more about how Cluster-API and Kubermatic [machine-controller][machine-controller] work
 * A Kubernetes cluster running Kubernetes v1.19 or newer is required
 

--- a/content/kubeone/master/guides/registry_configuration/_index.en.md
+++ b/content/kubeone/master/guides/registry_configuration/_index.en.md
@@ -115,7 +115,7 @@ possible alternatives that should be used **ONLY** in the case when you are
 **NOT** able to use the approach described above.
 {{% /notice %}}
 
-{{% notice warning %}}
+{{% notice note %}}
 We plan on introducing a new registry mirrors functionality in KubeOne 1.4 as
 an alternative to the overwrite registry functionality. The new functionality
 will be able to override only specific registries such as `docker.io`.

--- a/content/kubeone/v1.3/guides/autoscaler_addon/_index.en.md
+++ b/content/kubeone/v1.3/guides/autoscaler_addon/_index.en.md
@@ -11,7 +11,7 @@ Cluster Autoscaler is a Kubernetes component that automatically adjusts the size
 ## The Prerequisites
 
 Using the Kubernetes Cluster Autoscaler in the KubeOne cluster requires some prerequisites to be met, which are:
-* KubeOne 1.3.1 or newer is required
+* KubeOne 1.3.2 or newer is required
 * The worker nodes need to be managed by the Kubermatic machine-controller. Therefore, we recommend checking the [concepts][concepts] document to learn more about how Cluster-API and Kubermatic [machine-controller][machine-controller] work
 * A Kubernetes cluster running Kubernetes v1.19 or newer is required
 

--- a/content/kubeone/v1.3/guides/registry_configuration/_index.en.md
+++ b/content/kubeone/v1.3/guides/registry_configuration/_index.en.md
@@ -115,7 +115,7 @@ possible alternatives that should be used **ONLY** in the case when you are
 **NOT** able to use the approach described above.
 {{% /notice %}}
 
-{{% notice warning %}}
+{{% notice note %}}
 We plan on introducing a new registry mirrors functionality in KubeOne 1.4 as
 an alternative to the overwrite registry functionality. The new functionality
 will be able to override only specific registries such as `docker.io`.


### PR DESCRIPTION
* Replace the KubeOne 1.3.1 release with 1.3.2, because 1.3.1 was not released successfully
* Fix note formatting in the overwrite registry guide

/assign @kron4eg 