### PR TITLE
Use https for kubeone.io

### DIFF
--- a/content/kubeone/master/guides/getting_kubeone/_index.en.md
+++ b/content/kubeone/master/guides/getting_kubeone/_index.en.md
@@ -9,14 +9,14 @@ enableToc = true
 The fastest way to get KubeOne is to use our installation script:
 
 ```
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The installation script downloads the release archive from GitHub, installs
 the KubeOne binary in your `/usr/local/bin` directory and unpacks the example
 Terraform configs in your current working directory. If you want to inspect the
 script before running it, you can use a command such as
-`curl -sfL get.kubeone.io | less` or check it on [GitHub][github-script].
+`curl -sfL https://get.kubeone.io | less` or check it on [GitHub][github-script].
 
 ## Downloading a binary from GitHub Releases
 

--- a/content/kubeone/master/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters/_index.en.md
@@ -97,7 +97,7 @@ The easiest way to download KubeOne is to use our installation script.
 The following command will download and run the script:
 
 ```shell
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The script downloads the latest version of KubeOne from GitHub, and unpacks it

--- a/content/kubeone/master/tutorials/creating_clusters_baremetal/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters_baremetal/_index.en.md
@@ -100,7 +100,7 @@ The easiest way to download KubeOne is to use our installation script.
 The following command will download and run the script:
 
 ```shell
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The script downloads the latest version of KubeOne from GitHub, and unpacks it

--- a/content/kubeone/master/tutorials/creating_clusters_eks_d/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters_eks_d/_index.en.md
@@ -123,7 +123,7 @@ The easiest way to download KubeOne is to use our installation script.
 The following command will download and run the script:
 
 ```shell
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The script downloads the latest version of KubeOne from GitHub, and unpacks it

--- a/content/kubeone/v1.0/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.0/getting_kubeone/_index.en.md
@@ -10,14 +10,14 @@ enableToc = true
 The fastest way to get KubeOne is to use our installation script:
 
 ```
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The installation script downloads the release archive from GitHub, installs
 the KubeOne binary in your `/usr/local/bin` directory and unpacks the example
 Terraform configs in your current working directory. If you want to inspect the
 script before running it, you can use a command such as
-`curl -sfL get.kubeone.io | less` or check it on [GitHub][github-script].
+`curl -sfL https://get.kubeone.io | less` or check it on [GitHub][github-script].
 
 ## Downloading a binary from GitHub Releases
 

--- a/content/kubeone/v1.2/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.2/getting_kubeone/_index.en.md
@@ -10,14 +10,14 @@ enableToc = true
 The fastest way to get KubeOne is to use our installation script:
 
 ```
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The installation script downloads the release archive from GitHub, installs
 the KubeOne binary in your `/usr/local/bin` directory and unpacks the example
 Terraform configs in your current working directory. If you want to inspect the
 script before running it, you can use a command such as
-`curl -sfL get.kubeone.io | less` or check it on [GitHub][github-script].
+`curl -sfL https://get.kubeone.io | less` or check it on [GitHub][github-script].
 
 ## Downloading a binary from GitHub Releases
 

--- a/content/kubeone/v1.3/guides/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.3/guides/getting_kubeone/_index.en.md
@@ -9,14 +9,14 @@ enableToc = true
 The fastest way to get KubeOne is to use our installation script:
 
 ```
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The installation script downloads the release archive from GitHub, installs
 the KubeOne binary in your `/usr/local/bin` directory and unpacks the example
 Terraform configs in your current working directory. If you want to inspect the
 script before running it, you can use a command such as
-`curl -sfL get.kubeone.io | less` or check it on [GitHub][github-script].
+`curl -sfL https://get.kubeone.io | less` or check it on [GitHub][github-script].
 
 ## Downloading a binary from GitHub Releases
 

--- a/content/kubeone/v1.3/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/v1.3/tutorials/creating_clusters/_index.en.md
@@ -97,7 +97,7 @@ The easiest way to download KubeOne is to use our installation script.
 The following command will download and run the script:
 
 ```shell
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The script downloads the latest version of KubeOne from GitHub, and unpacks it

--- a/content/kubeone/v1.3/tutorials/creating_clusters_baremetal/_index.en.md
+++ b/content/kubeone/v1.3/tutorials/creating_clusters_baremetal/_index.en.md
@@ -100,7 +100,7 @@ The easiest way to download KubeOne is to use our installation script.
 The following command will download and run the script:
 
 ```shell
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The script downloads the latest version of KubeOne from GitHub, and unpacks it

--- a/content/kubeone/v1.3/tutorials/creating_clusters_eks_d/_index.en.md
+++ b/content/kubeone/v1.3/tutorials/creating_clusters_eks_d/_index.en.md
@@ -123,7 +123,7 @@ The easiest way to download KubeOne is to use our installation script.
 The following command will download and run the script:
 
 ```shell
-curl -sfL get.kubeone.io | sh
+curl -sfL https://get.kubeone.io | sh
 ```
 
 The script downloads the latest version of KubeOne from GitHub, and unpacks it


### PR DESCRIPTION
The install shell script for kubeone should be fetched using https.
Made possible by https://github.com/kubermatic/website/pull/1767