### PR TITLE
Use empty map for datacenters example in Seed installation

### DIFF
--- a/content/kubermatic/master/installation/install_kkp_CE/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/master/installation/install_kkp_CE/add_seed_cluster_CE/_index.en.md
@@ -141,7 +141,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/master/installation/install_kkp_EE/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/master/installation/install_kkp_EE/add_seed_cluster_EE/_index.en.md
@@ -140,7 +140,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/v2.16/installation/add_seed_cluster/_index.en.md
+++ b/content/kubermatic/v2.16/installation/add_seed_cluster/_index.en.md
@@ -159,7 +159,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/v2.16/installation/add_seed_cluster_ee/_index.en.md
+++ b/content/kubermatic/v2.16/installation/add_seed_cluster_ee/_index.en.md
@@ -150,7 +150,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/v2.17/guides/installation/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/v2.17/guides/installation/add_seed_cluster_CE/_index.en.md
@@ -154,7 +154,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/v2.17/guides/installation/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/v2.17/guides/installation/add_seed_cluster_EE/_index.en.md
@@ -153,7 +153,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/v2.18/guides/installation/add_seed_cluster_CE/_index.en.md
+++ b/content/kubermatic/v2.18/guides/installation/add_seed_cluster_CE/_index.en.md
@@ -141,7 +141,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:

--- a/content/kubermatic/v2.18/guides/installation/add_seed_cluster_EE/_index.en.md
+++ b/content/kubermatic/v2.18/guides/installation/add_seed_cluster_EE/_index.en.md
@@ -140,7 +140,7 @@ spec:
   location: Hamburg
 
   # list of datacenters where this seed cluster is allowed to create clusters in
-  datacenters: []
+  datacenters: {}
 
   # reference to the kubeconfig to use when connecting to this seed cluster
   kubeconfig:


### PR DESCRIPTION
Our docs give `datacenters: []` in the example `Seed` resource. That field is a map at least since v2.16 (https://github.com/kubermatic/kubermatic/blob/release/v2.16/pkg/crd/kubermatic/v1/datacenter.go#L80) and the example YAML fails webhook validation as it's invalid.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>