### PR TITLE
mla: build helm dependency before installing promtail and loki

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/monitoring_logging_alerting/master_seed/installation/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/monitoring_logging_alerting/master_seed/installation/_index.en.md
@@ -165,6 +165,9 @@ With this file prepared, we can now install all required charts:
 **Helm 3**
 
 ```bash
+helm dependency build charts/logging/promtail
 helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml promtail charts/logging/promtail/
+
+helm dependency build charts/logging/loki/
 helm --namespace logging upgrade --install --wait --values /path/to/your/helm-values.yaml loki charts/logging/loki/
 ```


### PR DESCRIPTION
These 2 charts use upstream charts as dependencies. if we not build the dependencies before installing the chart, we got the following error:
   
`Error: found in Chart.yaml, but missing in charts/ directory: promtail`
