### PR TITLE
Update the KubeOne docs to use the v1beta2 API instead of v1beta1

### DIFF
--- a/content/kubeone/master/examples/addons_calico_vxlan/_index.en.md
+++ b/content/kubeone/master/examples/addons_calico_vxlan/_index.en.md
@@ -23,11 +23,11 @@ documentation how to find MTU size for your cluster https://docs.projectcalico.o
 ## Example AWS kubeone config
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: 1.18.5
+  kubernetes: 1.22.5
 
 cloudProvider:
   aws: {}

--- a/content/kubeone/master/guides/addons/_index.en.md
+++ b/content/kubeone/master/guides/addons/_index.en.md
@@ -62,10 +62,10 @@ To enable addons, you need to modify the KubeOne cluster configuration to add
 the `addons` config:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.20.1
+  kubernetes: 1.22.5
 cloudProvider:
   aws: {}
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
@@ -108,23 +108,16 @@ like:
 
 To activate the embedded addons, the user needs to use the new [Addons API][addons-api].
 
-{{% notice warning %}}
-The addons directory must exist even if you plan to only use embedded addons
-without providing your custom addons. This is a known bug and can be tracked on
-[GitHub](https://github.com/kubermatic/kubeone/issues/1496).
-{{% /notice %}}
-
 Example:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.20.1
+  kubernetes: 1.22.5
 
 addons:
   enable: true
-  path: "./addons"
   addons:
   - name: cluster-autoscaler
   - name: unattended-upgrades
@@ -150,10 +143,10 @@ To delete embedded addon from the cluster, use the new `delete` field from the
 [Addons API][addons-api].
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.20.1
+  kubernetes: 1.22.5
 
 addons:
   enable: true
@@ -185,10 +178,10 @@ you can use it to override globally defined parameters.
 {{% /notice %}}
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.20.1
+  kubernetes: 1.22.5
 
 addons:
   enable: true
@@ -247,7 +240,7 @@ the [`addons`][addons] directory.
 [sprig-docs]: http://masterminds.github.io/sprig/
 [sprig-b64enc]: http://masterminds.github.io/sprig/encoding.html
 [addons]: https://github.com/kubermatic/kubeone/tree/master/addons
-[addons-api]: {{< ref "../../references/kubeone_cluster_v1beta1/#addons" >}}
+[addons-api]: {{< ref "../../references/kubeone_cluster_v1beta2/#addons" >}}
 [embed-docs]: https://pkg.go.dev/embed
 [addons-list-url]: https://github.com/kubermatic/kubeone/tree/master/addons
 [backups_restic]: https://github.com/kubermatic/kubeone/tree/master/addons/backups-restic

--- a/content/kubeone/master/guides/autoscaler_addon/_index.en.md
+++ b/content/kubeone/master/guides/autoscaler_addon/_index.en.md
@@ -31,18 +31,14 @@ The manifest should look like the following:
 
 kubeone.yaml
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.22.2'   ## kubernetes version
+  kubernetes: '1.22.5'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:
   enable: true
-    # Path to the addons directory.
-   # We will not use this directory in this tutorial, but the directory must exist regardless.
-  # In case when the relative path is provided, the path is relative to the KubeOne configuration file.
-  path: “./addons"
   addons:
   - name: cluster-autoscaler
 ```

--- a/content/kubeone/master/guides/ccm_csi_migration/_index.en.md
+++ b/content/kubeone/master/guides/ccm_csi_migration/_index.en.md
@@ -130,7 +130,7 @@ You must set `.cloudProvider.external` to `true`, so KubeOne can deploy
 external CCM and CSI. For example:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
   kubernetes: 1.22.1
@@ -161,10 +161,10 @@ to the `cloudConfig`. The CSI configuration is provided using the `csiConfig`
 field, for example:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.22.1
+  kubernetes: 1.22.5
 cloudProvider:
   openstack: {}
   external: true

--- a/content/kubeone/master/guides/containerd_migration/_index.en.md
+++ b/content/kubeone/master/guides/containerd_migration/_index.en.md
@@ -31,7 +31,7 @@ explicitly specify the containerd as a container runtime in the config.
 For this please use `containerRuntime.containerd` field as shown below.
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:

--- a/content/kubeone/master/guides/encryption_providers/_index.en.md
+++ b/content/kubeone/master/guides/encryption_providers/_index.en.md
@@ -31,11 +31,11 @@ To enable Encryption Providers support, the following section is added to the
 KubeOne Cluster configuration manifest:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.18.6'
+  kubernetes: '1.22.5'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -79,11 +79,11 @@ To disable this feature, simply set the `enable` option to `false` and upgrade
 your cluster with the `--force-upgrade` flag:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.18.6'
+  kubernetes: '1.22.5'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -137,11 +137,11 @@ To use custom configuration, you simply add them inline to your KubeOne cluster
 configuration manifest:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.18.6'
+  kubernetes: '1.22.5'
 features:
   encryptionProviders:
     enable: true
@@ -172,11 +172,11 @@ Kubernetes communicates with the KMS Encryption Provider through a unix socket. 
 An example of custom encryption providers configuration to enable AWS Encryption Provider would look like this:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: kms-test
 versions:
-  kubernetes: '1.18.6'
+  kubernetes: '1.22.5'
 cloudProvider:
   aws: {}
 features:

--- a/content/kubeone/master/guides/manual_cluster_recovery/_index.en.md
+++ b/content/kubeone/master/guides/manual_cluster_recovery/_index.en.md
@@ -205,7 +205,7 @@ The information about the instances are located in the `.controlPlane.hosts`
 part of the configuration manifest:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: demo-cluster
 controlPlane:

--- a/content/kubeone/master/guides/proxy/_index.en.md
+++ b/content/kubeone/master/guides/proxy/_index.en.md
@@ -7,7 +7,7 @@ enableToc = true
 Annotated example config with enabled PROXY support:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: demo-cluster
 ...

--- a/content/kubeone/master/guides/registry_configuration/_index.en.md
+++ b/content/kubeone/master/guides/registry_configuration/_index.en.md
@@ -58,7 +58,7 @@ to use (without the `v` prefix), as well as, replace the `TARGET_REGISTRY` with
 the address to your image registry.
 
 ```
-KUBERNETES_VERSION=1.22.4 TARGET_REGISTRY=127.0.0.1:5000 ./image-loader.sh
+KUBERNETES_VERSION=1.22.5 TARGET_REGISTRY=127.0.0.1:5000 ./image-loader.sh
 ```
 
 The preloading process can take a several minutes, depending on your
@@ -73,7 +73,7 @@ stanza to your KubeOne configuration file, such as:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.22.4
+  kubernetes: 1.22.5
 cloudProvider:
   aws: {}
 registryConfiguration:
@@ -133,7 +133,7 @@ when updating KubeOne, or otherwise, you might end up with a non-working
 cluster.
 {{% /notice %}}
 
-[regconfig-api]: {{< ref "../../references/kubeone_cluster_v1beta1#registryconfiguration" >}}
+[regconfig-api]: {{< ref "../../references/kubeone_cluster_v1beta2#registryconfiguration" >}}
 [docker-reg-guide]: https://docs.docker.com/registry/
 [img-loader]: https://github.com/kubermatic/kubeone/blob/master/hack/image-loader.sh
 [override-addons]: {{< ref "../addons#overriding-embedded-eddons" >}}

--- a/content/kubeone/master/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters/_index.en.md
@@ -115,7 +115,7 @@ you're not required to keep to them.
 ```shell
 ...
 Kubermatic KubeOne has been installed into /usr/local/bin/kubeone
-Terraform example configs, addons, and helper scripts have been downloaded into the ./kubeone_1.2.0-beta.1_linux_amd64 directory
+Terraform example configs, addons, and helper scripts have been downloaded into the ./kubeone_1.4.0_linux_amd64 directory
 ```
 
 You can confirm that KubeOne has been installed successfully by running the
@@ -139,13 +139,13 @@ KubeOne requires Terraform 1.0 or newer. You can download it from the
 browser, or use `cURL` such as:
 
 ```shell
-curl -LO https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_linux_amd64.zip
+curl -LO https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_linux_amd64.zip
 ```
 
 Once you download the archive, unzip it:
 
 ```shell
-unzip terraform_1.0.0_linux_amd64.zip
+unzip terraform_1.1.3_linux_amd64.zip
 ```
 
 Finally, move the unpacked `terraform` binary to somewhere in your `PATH`.
@@ -385,7 +385,7 @@ created while installing KubeOne in the Step 1. For example (the directory
 name depends on the latest KubeOne version):
 
 ```shell
-cd ./kubeone_1.2.0-beta.1_linux_amd64/examples/terraform
+cd ./kubeone_1.4.0_linux_amd64/examples/terraform
 ```
 
 In this directory, you can find a subdirectory for each supported provider.
@@ -555,10 +555,10 @@ supported provider.
 {{< tabs name="Manifests" >}}
 {{% tab name="AWS" %}}
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   aws: {}
 ```
@@ -595,10 +595,10 @@ Please check the [Production Recommendations]({{< ref "../../cheat_sheets/produc
 document for more details.
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   azure: {}
   cloudConfig: |
@@ -627,10 +627,10 @@ The CCM provides additional cluster features, such as LoadBalancer Services,
 and fetches information about nodes from the API.
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   digitalocean: {}
   external: true
@@ -642,10 +642,10 @@ nodes are across multiple availability zones. We deploy control plane hosts
 in multiple AZs by default in our example Terraform configs.
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   gce: {}
   cloudConfig: |
@@ -669,10 +669,10 @@ used.
 The Hetzner CCM fetches information about nodes from the API.
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   hetzner: {}
   external: true
@@ -689,7 +689,7 @@ replace the placeholder values.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.21.8
+  kubernetes: '1.22.5'
 cloudProvider:
   nutanix: {}
 addons:
@@ -708,10 +708,10 @@ addons:
 cloud-config section.**
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   openstack: {}
   cloudConfig: |
@@ -735,11 +735,11 @@ The Packet CCM fetches information about nodes from the API.
 colliding with the Packet private network which is `10.0.0.0/8`.**
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: "1.20.4"
+  kubernetes: "1.22.5"
 
 cloudProvider:
   packet: {}
@@ -756,10 +756,10 @@ cloud-config section. The `vsphere-ccm-credentials` Secret is created
 automatically by KubeOne as of v1.0.4.**
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   vsphere: {}
   cloudConfig: |
@@ -793,13 +793,17 @@ In the following table, you can find a list of supported Kubernetes version
 for latest KubeOne versions (you can run `kubeone version` to find the version
 that you're running).
 
-| KubeOne version | 1.21       | 1.20       | 1.19 | 1.18 | 1.17 |
-| --------------- | ---------- | ---------- | ---- | ---- | ---- |
-| v1.2+           | ✓ | ✓ | ✓    | ✓    | -   |
-| v1.0+           | - | - | ✓    | ✓    | ✓\*\*   |
+| KubeOne version | 1.23  | 1.22  | 1.21  | 1.20\*  | 1.19\*\* |
+| --------------- | ----- | ----- | ----- | ------- | -------- |
+| v1.4+           | ✓     | ✓     | ✓     | ✓       | -        |
+| v1.3+           | -     | ✓     | ✓     | ✓       | ✓        |
+| v1.2+           | -     | -     | ✓     | ✓       | ✓        |
 
-\*\* Kubernetes 1.17 has reached End-of-Life (EOL) and is not recommended
-for new clusters
+\* Kubernetes 1.20 is scheduled to reach End-of-Life (EOL) on February 2021.
+Using a newer Kubernetes version is strongly recommended.
+
+\*\* Kubernetes 1.19 has already reached End-of-Life (EOL) and is not
+recommended for newly-created clusters.
 
 Now, we're ready to provision the cluster! This is done by running the
 `kubeone apply` command and providing it the configuration manifest and the

--- a/content/kubeone/master/tutorials/creating_clusters_baremetal/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters_baremetal/_index.en.md
@@ -118,7 +118,7 @@ you're not required to keep to them.
 ```shell
 ...
 Kubermatic KubeOne has been installed into /usr/local/bin/kubeone
-Terraform example configs, addons, and helper scripts have been downloaded into the ./kubeone_1.2.0-beta.1_linux_amd64 directory
+Terraform example configs, addons, and helper scripts have been downloaded into the ./kubeone_1.4.0_linux_amd64 directory
 ```
 
 You can confirm that KubeOne has been installed successfully by running the
@@ -222,11 +222,11 @@ You can find more information about load balancing at [HA load balancing][ha-loa
 Below you find an example reference about the minimum necessary information for a bare metal deployment.
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: bm-cluster
 versions:
-  kubernetes: '1.20.4'
+  kubernetes: '1.22.5'
 cloudProvider:
   none: {}
 
@@ -264,13 +264,17 @@ In the following table, you can find a list of supported Kubernetes version
 for latest KubeOne versions (you can run `kubeone version` to find the version
 that you're running).
 
-| KubeOne version | 1.21       | 1.20       | 1.19 | 1.18 | 1.17 |
-| --------------- | ---------- | ---------- | ---- | ---- | ---- |
-| v1.2+           | ✓ | ✓ | ✓    | ✓    | -   |
-| v1.0+           | - | - | ✓    | ✓    | ✓\*\*   |
+| KubeOne version | 1.23  | 1.22  | 1.21  | 1.20\*  | 1.19\*\* |
+| --------------- | ----- | ----- | ----- | ------- | -------- |
+| v1.4+           | ✓     | ✓     | ✓     | ✓       | -        |
+| v1.3+           | -     | ✓     | ✓     | ✓       | ✓        |
+| v1.2+           | -     | -     | ✓     | ✓       | ✓        |
 
-\*\* Kubernetes 1.17 has reached End-of-Life (EOL) and is not recommended
-for new clusters
+\* Kubernetes 1.20 is scheduled to reach End-of-Life (EOL) on February 2021.
+Using a newer Kubernetes version is strongly recommended.
+
+\*\* Kubernetes 1.19 has already reached End-of-Life (EOL) and is not
+recommended for newly-created clusters.
 
 Now, we're ready to provision the cluster! This is done by running the
 `kubeone apply` command and providing it the configuration manifest.

--- a/content/kubeone/master/tutorials/creating_clusters_oidc/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters_oidc/_index.en.md
@@ -44,11 +44,11 @@ Once Terraform has finished, we are left with a number of VMs and a LoadBalancer
 Kubermatic KubeOne will now take the output from Terraform and provision a Kubernetes cluster on it. Our KK1 configuration is rather simple at this stage, just as we like it:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.19.3'
+  kubernetes: '1.22.5'
 
 cloudProvider:
   hetzner: {}
@@ -318,11 +318,11 @@ Now, Dex reveals more information from the user identity it received from GitHub
 It's finally time to enable OIDC logins in Kubernetes. As mentioned previously, Kubermatic KubeOne does all the heavy lifting for us already, so the configuration is minimal:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.19.3'
+  kubernetes: '1.22.5'
 
 cloudProvider:
   hetzner: {}
@@ -463,11 +463,11 @@ ingress-nginx     Active   2h
 Now that we have readable user identifiers, audit logging makes much more sense. Let's enable it. Once again, KK1 does all the work for us:
 
 ```yaml
-apiVersion: kubeone.io/v1beta1
+apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.19.3'
+  kubernetes: '1.22.5'
 
 cloudProvider:
   hetzner: {}


### PR DESCRIPTION
Update the KubeOne docs to use the v1beta2 API instead of v1beta1.

Fixes https://github.com/kubermatic/kubeone/issues/1731

/assign @kron4eg 