### PR TITLE
Add deprecation notice to dynamic kubelet configuration

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
@@ -6,7 +6,7 @@ weight = 100
 +++
 
 {{% notice warning %}}
-Dynamic kubelet configuration is a deprecated feature in Kubernetes. It will no longer be supported in KKP after Kubernetes removes it. See [the upstream documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) for more details.
+Dynamic kubelet configuration is a deprecated feature in Kubernetes. It will no longer be supported in KKP after [Kubernetes removes it in v1.24](https://github.com/kubernetes/kubernetes/pull/106932). See [the upstream documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) for more details.
 {{% /notice %}}
 
 Dynamic kubelet configuration allows for live reconfiguration of some or all nodes' kubelet options.

--- a/content/kubermatic/master/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
@@ -5,6 +5,10 @@ weight = 100
 
 +++
 
+{{% notice warning %}}
+Dynamic kubelet configuration is a deprecated feature in Kubernetes. It will no longer be supported in KKP after Kubernetes removes it. See [the upstream documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) for more details.
+{{% /notice %}}
+
 Dynamic kubelet configuration allows for live reconfiguration of some or all nodes' kubelet options.
 
 ### See Also
@@ -20,6 +24,3 @@ To enable dynamic kubelet configuration, mark the `Dynamic kubelet config` check
 
 Normally these configmaps for different versions are created with a set of healthy default options by Kubermatic Kubernetes Platform's (KKP) default `kubelet-configmap` addon. However, if you want to customize the settings, you can replace the default addon with your own. You can also alter the `configSource` parameter of the Machine Deployment to point the kubelet to another config map - that way you can have multiple configurations for multiple sets of nodes.
 
-{{% notice warning %}}
-The dynamic kubelet configuration is a beta feature in both Kubernetes and KKP. Refer to the Kubenetes documentation for more information.
-{{% /notice %}}

--- a/content/kubermatic/v2.19/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
@@ -6,7 +6,7 @@ weight = 100
 +++
 
 {{% notice warning %}}
-Dynamic kubelet configuration is a deprecated feature in Kubernetes. It will no longer be supported in KKP after Kubernetes removes it. See [the upstream documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) for more details.
+Dynamic kubelet configuration is a deprecated feature in Kubernetes. It will no longer be supported in KKP after [Kubernetes removes it in v1.24](https://github.com/kubernetes/kubernetes/pull/106932). See [the upstream documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) for more details.
 {{% /notice %}}
 
 Dynamic kubelet configuration allows for live reconfiguration of some or all nodes' kubelet options.

--- a/content/kubermatic/v2.19/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/KKP_configuration/dynamic_kubelet_config/_index.en.md
@@ -5,6 +5,10 @@ weight = 100
 
 +++
 
+{{% notice warning %}}
+Dynamic kubelet configuration is a deprecated feature in Kubernetes. It will no longer be supported in KKP after Kubernetes removes it. See [the upstream documentation](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) for more details.
+{{% /notice %}}
+
 Dynamic kubelet configuration allows for live reconfiguration of some or all nodes' kubelet options.
 
 ### See Also
@@ -19,7 +23,3 @@ To enable dynamic kubelet configuration, mark the `Dynamic kubelet config` check
 ![Add Machine Deployment](/img/kubermatic/v2.19/ui/md_add.png?classes=shadow,border "Add Machine Deployment")
 
 Normally these configmaps for different versions are created with a set of healthy default options by Kubermatic Kubernetes Platform's (KKP) default `kubelet-configmap` addon. However, if you want to customize the settings, you can replace the default addon with your own. You can also alter the `configSource` parameter of the Machine Deployment to point the kubelet to another config map - that way you can have multiple configurations for multiple sets of nodes.
-
-{{% notice warning %}}
-The dynamic kubelet configuration is a beta feature in both Kubernetes and KKP. Refer to the Kubenetes documentation for more information.
-{{% /notice %}}


### PR DESCRIPTION
Dynamic kubelet configuration is deprecated upstream. This adds a note to the documentation and removes the note saying the feature is in beta.

I'm also adding it to 2.19 documentation so users are aware of it and this isn't hidden away in `master` only.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>