### PR TITLE
Corrected custom certificate configuration for nginx

### DIFF
--- a/content/kubermatic/v2.19/tutorials_howtos/KKP_configuration/custom_certificates/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/KKP_configuration/custom_certificates/_index.en.md
@@ -293,9 +293,10 @@ and then adjust your Helm `values.yaml` to configure nginx like so:
 
 ```yaml
 nginx:
-  extraArgs:
-    # The value of this flag is in the form "namespace/name".
-    - '--default-ssl-certificate=mynamespace/mysecret'
+  controller:
+    extraArgs:
+      # The value of this flag is in the form "namespace/name".
+      default-ssl-certificate: 'mynamespace/mysecret'
 ```
 
 Redeploy the `nginx-ingress-controller` Helm chart to enable the changes.


### PR DESCRIPTION
Corrected the custom certificate configuration for Ingress. See https://support.kubermatic.com/helpdesk/tickets/3508

The currently documented configuration will lead to nginx-controller crashes.