### PR TITLE
fix link inside tab

### DIFF
--- a/content/kubeone/v1.3/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/v1.3/tutorials/creating_clusters/_index.en.md
@@ -477,7 +477,7 @@ cloudProvider:
 **Make sure to replace the placeholder values with real values in the
 cloud-config section.**
 
-In the [Kubermatic documentation][azure-sa-setup]
+In the [Kubermatic documentation]({{< ref "../../architecture/requirements/machine_controller/azure" >}})
 you  can find more information regarding how to set up a service account.
 This service account is needed to proceed.
 
@@ -836,4 +836,3 @@ and recommendations.
 [unprovisioning-clusters]: {{< ref "../unprovisioning_clusters" >}}
 [production-recommendations]: {{< ref "../../cheat_sheets/production_recommendations" >}}
 [create-cluster-oidc]: {{< ref "../creating_clusters_oidc" >}}
-[azure-sa-setup]: {{< ref "../../architecture/requirements/machine_controller/azure" >}}


### PR DESCRIPTION
This was the only possible way I got this to work, as it seems you
cannot use Markdowns Reference-style Links with the tab shortcode.