### PR TITLE
Add OS_REGION_NAME

### DIFF
--- a/content/kubeone/master/tutorials/creating_clusters/_index.en.md
+++ b/content/kubeone/master/tutorials/creating_clusters/_index.en.md
@@ -324,6 +324,7 @@ infrastructure and for machine-controller to create the worker nodes.
 | `OS_AUTH_URL`        | The URL of OpenStack Identity Service |
 | `OS_USERNAME`        | The username of the OpenStack user    |
 | `OS_PASSWORD`        | The password of the OpenStack user    |
+| `OS_REGION_NAME`     | The name of the OpenStack region      |
 | `OS_DOMAIN_NAME`     | The name of the OpenStack domain      |
 | `OS_TENANT_ID`       | The ID of the OpenStack tenant        |
 | `OS_TENANT_NAME`     | The name of the OpenStack tenant      |


### PR DESCRIPTION
Without this variable, terraform will not be able to find the security
group it created which fails infrastructure creation.

@xmudrii let me know if I should also back-port this to v1.3 and v1.4 documentation. I am quite sure this is required in these as well for terraform to work