### PR TITLE
Update swagger.json for KKP 2.19 to 2.19.1 swagger

### DIFF
--- a/content/kubermatic/v2.19/data/swagger.json
+++ b/content/kubermatic/v2.19/data/swagger.json
@@ -13560,6 +13560,48 @@
         }
       }
     },
+    "/api/v2/projects/{project_id}/clusters/{cluster_id}/providers/nutanix/subnets": {
+      "get": {
+        "description": "Lists available Nutanix Subnets",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "nutanix"
+        ],
+        "operationId": "listNutanixSubnetsNoCredentials",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "ProjectID",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "ClusterID",
+            "name": "cluster_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NutanixSubnetList",
+            "schema": {
+              "$ref": "#/definitions/NutanixSubnetList"
+            }
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/v2/projects/{project_id}/clusters/{cluster_id}/providers/openstack/availabilityzones": {
       "get": {
         "description": "Lists availability zones from openstack",
@@ -17150,6 +17192,186 @@
         }
       }
     },
+    "/api/v2/providers/nutanix/{dc}/clusters": {
+      "get": {
+        "description": "List clusters from Nutanix",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "nutanix"
+        ],
+        "operationId": "listNutanixClusters",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "description": "KKP Datacenter to use for endpoint",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "NutanixUsername",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixPassword",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixProxyURL",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "Credential",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NutanixClusterList",
+            "schema": {
+              "$ref": "#/definitions/NutanixClusterList"
+            }
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/providers/nutanix/{dc}/projects": {
+      "get": {
+        "description": "List projects from Nutanix",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "nutanix"
+        ],
+        "operationId": "listNutanixProjects",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "description": "KKP Datacenter to use for endpoint",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "NutanixUsername",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixPassword",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixProxyURL",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "Credential",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NutanixProjectList",
+            "schema": {
+              "$ref": "#/definitions/NutanixProjectList"
+            }
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/providers/nutanix/{dc}/subnets": {
+      "get": {
+        "description": "List subnets from Nutanix",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "nutanix"
+        ],
+        "operationId": "listNutanixSubnets",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "DC",
+            "description": "KKP Datacenter to use for endpoint",
+            "name": "dc",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "NutanixUsername",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixPassword",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixProxyURL",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "Credential",
+            "in": "header"
+          },
+          {
+            "type": "string",
+            "name": "NutanixCluster",
+            "in": "header",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Project query parameter. Can be omitted to query subnets without project scope",
+            "name": "NutanixProject",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NutanixSubnetList",
+            "schema": {
+              "$ref": "#/definitions/NutanixSubnetList"
+            }
+          },
+          "default": {
+            "description": "errorResponse",
+            "schema": {
+              "$ref": "#/definitions/errorResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/v2/providers/vsphere/datastores": {
       "get": {
         "description": "Lists datastores from vsphere datacenter",
@@ -20578,6 +20800,9 @@
         "node": {
           "$ref": "#/definitions/NodeSettings"
         },
+        "nutanix": {
+          "$ref": "#/definitions/DatacenterSpecNutanix"
+        },
         "openstack": {
           "$ref": "#/definitions/DatacenterSpecOpenstack"
         },
@@ -20749,6 +20974,33 @@
           "description": "DNSPolicy represents the dns policy for the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',\n'Default' or 'None'. Defaults to \"ClusterFirst\". DNS parameters given in DNSConfig will be merged with the\npolicy selected with DNSPolicy.",
           "type": "string",
           "x-go-name": "DNSPolicy"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
+    "DatacenterSpecNutanix": {
+      "description": "NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.",
+      "type": "object",
+      "title": "DatacenterSpecNutanix describes a Nutanix datacenter.",
+      "properties": {
+        "allow_insecure": {
+          "description": "Optional: AllowInsecure allows to disable the TLS certificate check against the endpoint (defaults to false)",
+          "type": "boolean",
+          "x-go-name": "AllowInsecure"
+        },
+        "endpoint": {
+          "description": "Endpoint to use for accessing Nutanix Prism Central. No protocol or port should be passed,\nfor example \"nutanix.example.com\" or \"10.0.0.1\"",
+          "type": "string",
+          "x-go-name": "Endpoint"
+        },
+        "images": {
+          "$ref": "#/definitions/ImageList"
+        },
+        "port": {
+          "description": "Optional: Port to use when connecting to the Nutanix Prism Central endpoint (defaults to 9440)",
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "Port"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
@@ -24699,6 +24951,25 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
+    "NutanixCluster": {
+      "type": "object",
+      "title": "NutanixCluster represents a Nutanix cluster.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "NutanixClusterList": {
+      "type": "array",
+      "title": "NutanixClusterList represents an array of Nutanix clusters.",
+      "items": {
+        "$ref": "#/definitions/NutanixCluster"
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
     "NutanixNodeSpec": {
       "description": "NutanixNodeSpec nutanix specific node settings",
       "type": "object",
@@ -24742,6 +25013,53 @@
           "type": "string",
           "x-go-name": "SubnetName"
         }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "NutanixProject": {
+      "type": "object",
+      "title": "NutanixProject represents a Nutanix project.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "NutanixProjectList": {
+      "type": "array",
+      "title": "NutanixProjectList represents an array of Nutanix projects.",
+      "items": {
+        "$ref": "#/definitions/NutanixProject"
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "NutanixSubnet": {
+      "type": "object",
+      "title": "NutanixSubnet represents a Nutanix subnet.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "type": {
+          "type": "string",
+          "x-go-name": "Type"
+        },
+        "vlanID": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "VlanID"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "NutanixSubnetList": {
+      "type": "array",
+      "title": "NutanixSubnetList represents an array of Nutanix subnets.",
+      "items": {
+        "$ref": "#/definitions/NutanixSubnet"
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
     },


### PR DESCRIPTION
What it says on the title. Update the `swagger.json` we serve on KKP docs for 2.19 to what we have in 2.19.1 (new release). Only additional Nutanix API endpoints.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>