### PR TITLE
Download KubermaticConfiguration and Seeds during upgrade guide

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/upgrading/upgrade_from_2.19_to_2.20/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/upgrading/upgrade_from_2.19_to_2.20/_index.en.md
@@ -234,7 +234,7 @@ metadata:
   namespace: kubermatic
 ```
 
-use the `kubermatic-installer` as normal to upgrade to KKP 2.20:
+Use the `kubermatic-installer` as normal to upgrade to KKP 2.20:
 
 ```bash
 ./kubermatic-installer deploy

--- a/content/kubermatic/v2.20/tutorials_howtos/upgrading/upgrade_from_2.19_to_2.20/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/upgrading/upgrade_from_2.19_to_2.20/_index.en.md
@@ -234,7 +234,7 @@ metadata:
   namespace: kubermatic
 ```
 
-use the `kubermatic-installer` as normal to upgrade to KKP 2.20:
+Use the `kubermatic-installer` as normal to upgrade to KKP 2.20:
 
 ```bash
 ./kubermatic-installer deploy


### PR DESCRIPTION
The upgrade guide should suggest to download `KubermaticConfiguration` and `Seed` resources from the cluster to get their migrated version.