### PR TITLE
Update examples for KKP v2.20

### DIFF
--- a/content/kubermatic/master/cheat_sheets/etcd/etcd-launcher/_index.en.md
+++ b/content/kubermatic/master/cheat_sheets/etcd/etcd-launcher/_index.en.md
@@ -44,8 +44,7 @@ metadata:
 spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    EtcdLauncher:
-      enabled: true
+    EtcdLauncher: true
 ```
 
 Next, simply apply the updated CRD:

--- a/content/kubermatic/master/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
@@ -70,12 +70,10 @@ spec:
   featureGates:
     # exposes an HTTP endpoint for generating kubeconfig
     # for a cluster that will contain OIDC tokens
-    OIDCKubeCfgEndpoint:
-      enabled: true
+    OIDCKubeCfgEndpoint: true
     # configures the flags on the API server to use
     # OAuth2 identity providers
-    OpenIDAuthPlugin:
-      enabled: true
+    OpenIDAuthPlugin: true
 
   ui:
     # enable shared kubeconfig feature in the dashboard

--- a/content/kubermatic/master/tutorials_howtos/administration/admin_panel/presets_management/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/administration/admin_panel/presets_management/_index.en.md
@@ -37,7 +37,8 @@ kind: Preset
 metadata:
   name: example
 spec:
-  requiredEmailDomain: example.com
+  requiredEmails:
+  - example.com
   anexia:
     token:
   aws:
@@ -103,4 +104,4 @@ spec:
 ```
 
 This file defines credentials for all listed providers. The accessible name for this preset is `example`. Only users with
-`example.com` domain can see this preset. Lack of the `requiredEmailDomains` field makes the preset available for everyone.
+`example.com` domain can see this preset. Lack of the `requiredEmails` field makes the preset available for everyone.

--- a/content/kubermatic/master/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -34,8 +34,8 @@ The datacenter structure contains the following fields:
     - and
     - `enforceAuditLogging` -- enforces audit logging on every cluster within the DC, ignoring cluster-specific settings.
     - `enforcePodSecurityPolicy` -- enforces pod security policy plugin on every clusters within the DC, ignoring cluster-specific settings
-    - `requiredEmailDomain` -- (deprecated since v2.13) Optional string. Limits the availability of the datacenter to users with email addresses in the given domain.
-    - `requiredEmailDomains` -- (since v2.13) Optional string array. Limits the availability of the datacenter to users with email addresses in the given domains.
+    - `requiredEmailDomains` -- (deprecated since v2.20) Optional string array. Limits the availability of the datacenter to users with email addresses in the given domains.
+    - `requiredEmails` -- (since v2.20) Optional string array. Limits the availability of the datacenter to users with email addresses in the given domains.
 
 Example specs for different providers:
 
@@ -60,11 +60,11 @@ Example specs for different providers:
     spec:
       openstack:
         # Authentication endpoint for Openstack, must be v3
-        auth_url: https://our-openstack-api/v3
-        availability_zone: zone-1
+        authURL: https://our-openstack-api/v3
+        availabilityZone: zone-1
         region: "region-1"
         # This DNS server will be set when KKP creates a network
-        dns_servers:
+        dnsServers:
         - "8.8.8.8"
         - "8.8.4.4"
         # Those are default images for nodes which will be shown in the Dashboard.
@@ -74,12 +74,12 @@ Example specs for different providers:
           coreos: "CoreOS"
         # Enforce the creation of floating IP's for new nodes
         # Available since v2.9.0
-        enforce_floating_ip: false
+        enforceFloatingIP: false
         # Gets mapped to the "manage-security-groups" setting in the cloud config.
         # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
         # Defaults to true
         # Available since v2.9.2
-        manage_security_groups: true
+        manageSecurityGroups: true
 
   #==================================
   #========== Digitalocean ==========
@@ -134,13 +134,13 @@ Example specs for different providers:
         datacenter: "Datacenter"
         datastore: "example-datastore"
         cluster: "example-cluster"
-        allow_insecure: true
-        root_path: "/Datacenter/vm/foo"
+        allowInsecure: true
+        rootPath: "/Datacenter/vm/foo"
         templates:
           ubuntu: "ubuntu-template"
           centos: "centos-template"
           coreos: "coreos-template"
-      requiredEmailDomains:
+      requiredEmails:
       - "kubermatic.com"
       - "example.com"
 
@@ -163,7 +163,7 @@ Example specs for different providers:
     spec:
       gcp:
         region: europe-west3
-        zone_suffixes:
+        zoneSuffixes:
         - c
 
   #==================================

--- a/content/kubermatic/master/tutorials_howtos/monitoring_logging_alerting/user_cluster/admin_guide/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/monitoring_logging_alerting/user_cluster/admin_guide/_index.en.md
@@ -122,13 +122,12 @@ metadata:
   namespace: kubermatic
 spec:
   featureGates:
-    UserClusterMLA:
-      enabled: true
+    UserClusterMLA: true
 ```
 
 ### Enabling MLA Stack in a Seed
 
-Since the MLA stack has to be manually installed into every KKP Seed Cluster, it is necessary to explicitly enable it on the Seed Cluster level after it is installed. This can be done via `mla.user_cluster_mla_enabled` option of the `Seed` Custom Resource / API object, e.g.:
+Since the MLA stack has to be manually installed into every KKP Seed Cluster, it is necessary to explicitly enable it on the Seed Cluster level after it is installed. This can be done via `mla.userClusterMLAEnabled` option of the `Seed` Custom Resource / API object, e.g.:
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -138,7 +137,7 @@ metadata:
   namespace: kubermatic
 spec:
   mla:
-    user_cluster_mla_enabled: true
+    userClusterMLAEnabled: true
 ```
 
 ### Admin Panel Configuration
@@ -401,7 +400,7 @@ In order to uninstall the User Cluster MLA stack from a seed cluster (and all us
 
 ### Disabling the User Cluster MLA in Seed Configuration
 
-In order to disable the User Cluster MLA feature for a Seed Cluster, set the `mla.user_cluster_mla_enabled` option of the `Seed` Custom Resource / API object to `false`, e.g.:
+In order to disable the User Cluster MLA feature for a Seed Cluster, set the `mla.userClusterMLAEnabled` option of the `Seed` Custom Resource / API object to `false`, e.g.:
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -411,7 +410,7 @@ metadata:
   namespace: kubermatic
 spec:
   mla:
-    user_cluster_mla_enabled: false
+    userClusterMLAEnabled: false
 ```
 
 ### Removing the User Cluster MLA Components

--- a/content/kubermatic/master/tutorials_howtos/networking/cni_cluster_network/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/networking/cni_cluster_network/_index.en.md
@@ -167,8 +167,7 @@ metadata:
   namespace: kubermatic
 spec:
   featureGates:
-    KonnectivityService:
-      enabled: true
+    KonnectivityService: true
 ```
 
 All existing clusters started before enabling `KonnectivityService` feature gate will continue using OpenVPN.

--- a/content/kubermatic/master/tutorials_howtos/networking/expose_strategies/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/networking/expose_strategies/_index.en.md
@@ -32,8 +32,7 @@ metadata:
 spec:
   exposeStrategy: NodePort
   featureGates:
-    TunnelingExposeStrategy:
-      enabled: true
+    TunnelingExposeStrategy: true
 ``` 
 
 The valid values for `exposeStrategy` are:
@@ -100,8 +99,7 @@ metadata:
 spec:
   exposeStrategy: Tunneling
   featureGates:
-    TunnelingExposeStrategy:
-      enabled: true
+    TunnelingExposeStrategy: true
 ```
 
 The current limitations of this strategy are:

--- a/content/kubermatic/master/tutorials_howtos/operating_system_manager/usage/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/operating_system_manager/usage/_index.en.md
@@ -22,8 +22,7 @@ metadata:
 spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    OperatingSystemManager:
-      enabled: true
+    OperatingSystemManager: true
 ```
 
 **NOTE:** This doesn't enable or deploy OSM on the user cluster. It just ensures that all the required resources/pre-requisites are deployed on the seed.

--- a/content/kubermatic/v2.20/cheat_sheets/etcd/etcd-launcher/_index.en.md
+++ b/content/kubermatic/v2.20/cheat_sheets/etcd/etcd-launcher/_index.en.md
@@ -45,8 +45,7 @@ metadata:
 spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    EtcdLauncher:
-      enabled: true
+    EtcdLauncher: true
 ```
 
 Next, simply apply the updated CRD:

--- a/content/kubermatic/v2.20/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/OIDC_Provider_Configuration/share _clusters_via_delegated_OIDC_authentication/_index.en.md
@@ -70,12 +70,10 @@ spec:
   featureGates:
     # exposes an HTTP endpoint for generating kubeconfig
     # for a cluster that will contain OIDC tokens
-    OIDCKubeCfgEndpoint:
-      enabled: true
+    OIDCKubeCfgEndpoint: true
     # configures the flags on the API server to use
     # OAuth2 identity providers
-    OpenIDAuthPlugin:
-      enabled: true
+    OpenIDAuthPlugin: true
 
   ui:
     # enable shared kubeconfig feature in the dashboard

--- a/content/kubermatic/v2.20/tutorials_howtos/administration/admin_panel/presets_management/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/administration/admin_panel/presets_management/_index.en.md
@@ -37,7 +37,8 @@ kind: Preset
 metadata:
   name: example
 spec:
-  requiredEmailDomain: example.com
+  requiredEmails:
+  - example.com
   anexia:
     token:
   aws:
@@ -103,4 +104,4 @@ spec:
 ```
 
 This file defines credentials for all listed providers. The accessible name for this preset is `example`. Only users with
-`example.com` domain can see this preset. Lack of the `requiredEmailDomains` field makes the preset available for everyone.
+`example.com` domain can see this preset. Lack of the `requiredEmails` field makes the preset available for everyone.

--- a/content/kubermatic/v2.20/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -60,11 +60,11 @@ Example specs for different providers:
     spec:
       openstack:
         # Authentication endpoint for Openstack, must be v3
-        auth_url: https://our-openstack-api/v3
-        availability_zone: zone-1
+        authURL: https://our-openstack-api/v3
+        availabilityZone: zone-1
         region: "region-1"
         # This DNS server will be set when KKP creates a network
-        dns_servers:
+        dnsServers:
         - "8.8.8.8"
         - "8.8.4.4"
         # Those are default images for nodes which will be shown in the Dashboard.
@@ -74,12 +74,12 @@ Example specs for different providers:
           coreos: "CoreOS"
         # Enforce the creation of floating IP's for new nodes
         # Available since v2.9.0
-        enforce_floating_ip: false
+        enforceFloatingIP: false
         # Gets mapped to the "manage-security-groups" setting in the cloud config.
         # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
         # Defaults to true
         # Available since v2.9.2
-        manage_security_groups: true
+        manageSecurityGroups: true
 
   #==================================
   #========== Digitalocean ==========
@@ -134,8 +134,8 @@ Example specs for different providers:
         datacenter: "Datacenter"
         datastore: "example-datastore"
         cluster: "example-cluster"
-        allow_insecure: true
-        root_path: "/Datacenter/vm/foo"
+        allowInsecure: true
+        rootPath: "/Datacenter/vm/foo"
         templates:
           ubuntu: "ubuntu-template"
           centos: "centos-template"
@@ -163,7 +163,7 @@ Example specs for different providers:
     spec:
       gcp:
         region: europe-west3
-        zone_suffixes:
+        zoneSuffixes:
         - c
 
   #==================================

--- a/content/kubermatic/v2.20/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -34,8 +34,8 @@ The datacenter structure contains the following fields:
     - and
     - `enforceAuditLogging` -- enforces audit logging on every cluster within the DC, ignoring cluster-specific settings.
     - `enforcePodSecurityPolicy` -- enforces pod security policy plugin on every clusters within the DC, ignoring cluster-specific settings
-    - `requiredEmailDomain` -- (deprecated since v2.13) Optional string. Limits the availability of the datacenter to users with email addresses in the given domain.
-    - `requiredEmailDomains` -- (since v2.13) Optional string array. Limits the availability of the datacenter to users with email addresses in the given domains.
+    - `requiredEmailDomains` -- (deprecated since v2.20) Optional string array. Limits the availability of the datacenter to users with email addresses in the given domains.
+    - `requiredEmails` -- (since v2.20) Optional string array. Limits the availability of the datacenter to users with email addresses in the given domains.
 
 Example specs for different providers:
 
@@ -140,7 +140,7 @@ Example specs for different providers:
           ubuntu: "ubuntu-template"
           centos: "centos-template"
           coreos: "coreos-template"
-      requiredEmailDomains:
+      requiredEmails:
       - "kubermatic.com"
       - "example.com"
 

--- a/content/kubermatic/v2.20/tutorials_howtos/monitoring_logging_alerting/user_cluster/admin_guide/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/monitoring_logging_alerting/user_cluster/admin_guide/_index.en.md
@@ -127,7 +127,7 @@ spec:
 
 ### Enabling MLA Stack in a Seed
 
-Since the MLA stack has to be manually installed into every KKP Seed Cluster, it is necessary to explicitly enable it on the Seed Cluster level after it is installed. This can be done via `mla.user_cluster_mla_enabled` option of the `Seed` Custom Resource / API object, e.g.:
+Since the MLA stack has to be manually installed into every KKP Seed Cluster, it is necessary to explicitly enable it on the Seed Cluster level after it is installed. This can be done via `mla.userClusterMLAEnabled` option of the `Seed` Custom Resource / API object, e.g.:
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -137,7 +137,7 @@ metadata:
   namespace: kubermatic
 spec:
   mla:
-    user_cluster_mla_enabled: true
+    userClusterMLAEnabled: true
 ```
 
 ### Admin Panel Configuration
@@ -400,7 +400,7 @@ In order to uninstall the User Cluster MLA stack from a seed cluster (and all us
 
 ### Disabling the User Cluster MLA in Seed Configuration
 
-In order to disable the User Cluster MLA feature for a Seed Cluster, set the `mla.user_cluster_mla_enabled` option of the `Seed` Custom Resource / API object to `false`, e.g.:
+In order to disable the User Cluster MLA feature for a Seed Cluster, set the `mla.userClusterMLAEnabled` option of the `Seed` Custom Resource / API object to `false`, e.g.:
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -410,7 +410,7 @@ metadata:
   namespace: kubermatic
 spec:
   mla:
-    user_cluster_mla_enabled: false
+    userClusterMLAEnabled: false
 ```
 
 ### Removing the User Cluster MLA Components

--- a/content/kubermatic/v2.20/tutorials_howtos/monitoring_logging_alerting/user_cluster/admin_guide/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/monitoring_logging_alerting/user_cluster/admin_guide/_index.en.md
@@ -122,8 +122,7 @@ metadata:
   namespace: kubermatic
 spec:
   featureGates:
-    UserClusterMLA:
-      enabled: true
+    UserClusterMLA: true
 ```
 
 ### Enabling MLA Stack in a Seed

--- a/content/kubermatic/v2.20/tutorials_howtos/networking/cni_cluster_network/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/networking/cni_cluster_network/_index.en.md
@@ -165,8 +165,7 @@ metadata:
   namespace: kubermatic
 spec:
   featureGates:
-    KonnectivityService:
-      enabled: true
+    KonnectivityService: true
 ```
 
 All existing clusters started before enabling `KonnectivityService` feature gate will continue using OpenVPN.

--- a/content/kubermatic/v2.20/tutorials_howtos/networking/expose_strategies/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/networking/expose_strategies/_index.en.md
@@ -32,8 +32,7 @@ metadata:
 spec:
   exposeStrategy: NodePort
   featureGates:
-    TunnelingExposeStrategy:
-      enabled: true
+    TunnelingExposeStrategy: true
 ``` 
 
 The valid values for `exposeStrategy` are:
@@ -100,8 +99,7 @@ metadata:
 spec:
   exposeStrategy: Tunneling
   featureGates:
-    TunnelingExposeStrategy:
-      enabled: true
+    TunnelingExposeStrategy: true
 ```
 
 The current limitations of this strategy are:

--- a/content/kubermatic/v2.20/tutorials_howtos/operating_system_manager/usage/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/operating_system_manager/usage/_index.en.md
@@ -22,8 +22,7 @@ metadata:
 spec:
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    OperatingSystemManager:
-      enabled: true
+    OperatingSystemManager: true
 ```
 
 **NOTE:** This doesn't enable or deploy OSM on the user cluster. It just ensures that all the required resources/pre-requisites are deployed on the seed.


### PR DESCRIPTION
Updated some examples to include the changes to the CRDs introduced in KKP v2.20.0:
* Change `KubermaticConfiguration.spec.featureGates` to `object (keys:string, values:boolean)`
* Use `requiredEmails` instead of `requiredEmailDomains`
* Use `userClusterMLAEnabled` instead of `user_cluster_mla_enabled`