### PR TITLE
Reference correct secret for backup/restore S3 credentials

### DIFF
--- a/content/kubermatic/v2.18/cheat_sheets/etcd/backup-and-restore/_index.en.md
+++ b/content/kubermatic/v2.18/cheat_sheets/etcd/backup-and-restore/_index.en.md
@@ -67,7 +67,7 @@ The new containers expect that the S3 backend is SSL enabled. Unfortunately, the
 
 ### S3 Credentials and Settings
 
-The new controllers will use the credentials from the secret `kube-system/s3-credentials` similar to the legacy backup controller.
+The new controllers will use credentials from the secret `kube-system/backup-s3`.
 
 However, when using the new containers, creating an additional ConfigMap with the S3 backend settings is required:
 
@@ -176,7 +176,7 @@ Once this resource is created, the controller will reconcile it and apply the fo
 - Delete the etcd Statefulset and Volumes.
 - Set the `EtcdClusterInitialized` cluster condition to false.
 - Unpause the cluster and wait until the cluster controller has recreated the etcd Statefulset. 
-- During the etcd Statefulset recreation, the etcd-launcher will detect the active restore resources and will download the backup from the S3 backend based on the credentials from the `kube-system/s3-credentials` secret and the information from the `kube-system/s3-settings` configmap. 
+- During the etcd Statefulset recreation, the etcd-launcher will detect the active restore resources and will download the backup from the S3 backend based on the credentials from the `kube-system/backup-s3` secret and the information from the `kube-system/s3-settings` configmap. 
 - Once the backup is downloaded successfully, the etcd-launcher will restore the backup and restart the etcd ring.
 - Once the etcd cluster is recovered and quorum is achieved, the `EtcdClusterInitialized` cluster condition to true. At this point the 
 

--- a/content/kubermatic/v2.19/cheat_sheets/etcd/backup-and-restore/_index.en.md
+++ b/content/kubermatic/v2.19/cheat_sheets/etcd/backup-and-restore/_index.en.md
@@ -53,7 +53,7 @@ You can't have both `backupCleanupContainer` and `backupDeleteContainer` set. `b
 The new controllers will use the credentials setup in the Seed Backup destinations, depending on the destination used. 
 
 {{% notice note %}}
-Legacy credentials from `kube-system/s3-credentials` and the bucket details in `s3-settings` configmap is still supported, but deprecated. Please migrate to backup destinations.
+Legacy credentials from `kube-system/backup-s3` and the bucket details in `s3-settings` configmap is still supported, but deprecated. Please migrate to backup destinations.
 {{% /notice %}}
 
 ## Creating Backups
@@ -150,7 +150,7 @@ Once this resource is created, the controller will reconcile it and apply the fo
 - Delete the etcd Statefulset and Volumes.
 - Set the `EtcdClusterInitialized` cluster condition to false.
 - Unpause the cluster and wait until the cluster controller has recreated the etcd Statefulset. 
-- During the etcd Statefulset recreation, the etcd-launcher will detect the active restore resources and will download the backup from the S3 backend based on the credentials from the `kube-system/s3-credentials` secret and the information from the `kube-system/s3-settings` configmap. 
+- During the etcd Statefulset recreation, the etcd-launcher will detect the active restore resources and will download the backup from the S3 backend based on the credentials from the `kube-system/backup-s3` secret and the information from the `kube-system/s3-settings` configmap. 
 - Once the backup is downloaded successfully, the etcd-launcher will restore the backup and restart the etcd ring.
 - Once the etcd cluster is recovered and quorum is achieved, the `EtcdClusterInitialized` cluster condition to true.
 

--- a/content/kubermatic/v2.20/cheat_sheets/etcd/backup-and-restore/_index.en.md
+++ b/content/kubermatic/v2.20/cheat_sheets/etcd/backup-and-restore/_index.en.md
@@ -53,7 +53,7 @@ You can't have both `backupCleanupContainer` and `backupDeleteContainer` set. `b
 The new controllers will use the credentials setup in the Seed Backup destinations, depending on the destination used. 
 
 {{% notice note %}}
-Legacy credentials from `kube-system/s3-credentials` and the bucket details in `s3-settings` configmap is still supported, but deprecated. Please migrate to backup destinations.
+Legacy credentials from `kube-system/backup-s3` and the bucket details in `s3-settings` configmap is still supported, but deprecated. Please migrate to backup destinations.
 {{% /notice %}}
 
 ## Creating Backups


### PR DESCRIPTION
Fixes #850 

This was changed for KKP 2.18.0 in https://github.com/kubermatic/kubermatic/pull/7800 but never made it's way to the docs. So the documentation has been wrong for some time. Setting this straight, even though `master` does not even contain references to this anymore as it's removed in recent versions and depends on backup destinations. Our docs for older versions should still be correct.