### PR TITLE
fix default ClusterTemplate example

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
@@ -33,17 +33,17 @@ metadata:
     scope: seed
   name: seed-defaults
   namespace: kubermatic
+credential: ""
 spec:
-  spec:
   auditLogging: {}
   cloud:
-    bringyourown: {}
+    providerName: ""
     dc: byo-europe-west3-c
   clusterNetwork:
     dnsDomain: ""
     pods:
       cidrBlocks: []
-    proxyMode: ""
+    proxyMode: "ipvs"
     services:
       cidrBlocks: []
   componentsOverride:
@@ -55,6 +55,7 @@ spec:
     prometheus: {}
     scheduler:
       leaderElection: {}
+    nodePortProxyEnvoy: {}
   containerRuntime: containerd
   enableUserSSHKeyAgent: true
   exposeStrategy: Tunneling
@@ -65,4 +66,5 @@ spec:
   opaIntegration: {}
   version: 1.21.3
   humanReadableName: "SeedDefaults"
+  pause: false
 ```

--- a/content/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
@@ -33,17 +33,17 @@ metadata:
     scope: seed
   name: seed-defaults
   namespace: kubermatic
+credential: ""
 spec:
-  spec:
   auditLogging: {}
   cloud:
-    bringyourown: {}
+    providerName: ""
     dc: byo-europe-west3-c
   clusterNetwork:
     dnsDomain: ""
     pods:
       cidrBlocks: []
-    proxyMode: ""
+    proxyMode: "ipvs"
     services:
       cidrBlocks: []
   componentsOverride:
@@ -55,6 +55,7 @@ spec:
     prometheus: {}
     scheduler:
       leaderElection: {}
+    nodePortProxyEnvoy: {}
   containerRuntime: containerd
   enableUserSSHKeyAgent: true
   exposeStrategy: Tunneling
@@ -65,4 +66,5 @@ spec:
   opaIntegration: {}
   version: 1.21.3
   humanReadableName: "SeedDefaults"
+  pause: false
 ```


### PR DESCRIPTION
Some required values were missing and the template can not be created. 

```
error: error validating "13_seed-defaults.yaml": error validating data: [
ValidationError(ClusterTemplate.spec.cloud): missing required field "providerName" in io.k8c.kubermatic.v1.ClusterTemplate.spec.cloud, 
ValidationError(ClusterTemplate.spec.componentsOverride): missing required field "nodePortProxyEnvoy" in io.k8c.kubermatic.v1.ClusterTemplate.spec.componentsOverride, 
ValidationError(ClusterTemplate.spec): missing required field "pause" in io.k8c.kubermatic.v1.ClusterTemplate.spec, 
ValidationError(ClusterTemplate): missing required field "credential" in io.k8c.kubermatic.v1.ClusterTemplate]; 
if you choose to ignore these errors, turn validation off with --validate=false
```

Moreover, specifying a cloud (eg `bringyourown`) may lead to invalid cluster creation if the user selects another cloud provider.

