### PR TITLE
Attempt to fix automatic sync of CRD reference

### DIFF
--- a/hack/crd-ref-docs.yaml
+++ b/hack/crd-ref-docs.yaml
@@ -1,0 +1,13 @@
+render:
+# Version of Kubernetes to use when generating links to Kubernetes API documentation.
+  kubernetesVersion: 1.22
+
+processor:
+  ignoreFields:
+    - "TypeMeta$"
+    - "apiversion$"
+    - "kind$"
+  
+  ignoreTypes:
+    - "Quantity$"
+    - "Fake$"

--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -1,38 +1,23 @@
 #!/usr/bin/env bash
 
+set -euox pipefail
+
 cd $(dirname $0)/..
 
 SOURCE="${GOPATH}/src/github.com/kubermatic/kubermatic/pkg/apis/kubermatic/v1/"
 
 which crd-ref-docs >/dev/null || { 
-  echo "running go install github.com/elastic/crd-ref-docs@master in 5s... (ctrl-c to cancel)"
+  echo "running go install github.com/elastic/crd-ref-docs@v0.0.8 in 5s... (ctrl-c to cancel)"
   sleep 5
-  go install github.com/elastic/crd-ref-docs@master
+  go install github.com/elastic/crd-ref-docs@v0.0.8
 }
 
-configfile=$(mktemp)
-cat <<EOF >${configfile}
-render:
-# Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.22
-
-processor:
-  ignoreFields:
-    - "TypeMeta$"
-    - "apiversion$"
-    - "kind$"
-  
-  ignoreTypes:
-    - "Quantity$"
-    - "Fake$"
-EOF
-
-crd-ref-docs \
+${GOPATH}/bin/crd-ref-docs \
   --source-path "${SOURCE}" \
   --max-depth 10 \
   --renderer markdown \
   --templates-dir=hack/crd-templates \
-  --config ${configfile} \
+  --config hack/crd-ref-docs.yaml \
   --output-path content/kubermatic/master/references/crds/_index.en.md
 
 rm ${configfile}


### PR DESCRIPTION
I really love the automatic sync of CRD reference documentation introduced with #985 ... unfortunately it never worked. Because the script doesn't fail properly, we never noticed, but this error shows up in every log for `post-kubermatic-update-docs`:

https://public-prow.loodse.com/view/gs/prow-dev-public-data/logs/post-kubermatic-update-docs/1513931616148262912#1:build-log.txt%3A148

```
hack/render-crds.sh: line 30: crd-ref-docs: command not found
```

I'm not _entirely_ sure why it's happening, but I assume it's some `$PATH` issues within the CI job. The container image itself seems to be fine because I tested it there and it "just worked", but this fix seems to be the easiest way to get it working (fingers crossed).

This PR also:

- Adds `set -euox pipefail` so that the `hack/render-crds.sh` properly fails.
- Pins the version of `crd-ref-docs` we use to a specific version, that seems healthier than running the tip of a foreign repo in our CI.
- Puts the config file in git.