### PR TITLE
Remove 'rm' no longer necessary in hack/update-crds.sh

### DIFF
--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -19,5 +19,3 @@ ${GOPATH}/bin/crd-ref-docs \
   --templates-dir=hack/crd-templates \
   --config hack/crd-ref-docs.yaml \
   --output-path content/kubermatic/master/references/crds/_index.en.md
-
-rm ${configfile}


### PR DESCRIPTION
as per failed job https://public-prow.loodse.com/view/gs/prow-dev-public-data/logs/post-kubermatic-update-docs/1514166609994846208, I forgot to remove this from the script.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>

