### PR TITLE
fix KKP AWS Policy

### DIFF
--- a/content/kubermatic/master/architecture/support_policy/provider_support_matrix/AWS/aws.en.md
+++ b/content/kubermatic/master/architecture/support_policy/provider_support_matrix/AWS/aws.en.md
@@ -32,7 +32,8 @@ weight = 7
                 "iam:ListAttachedRolePolicies",
                 "iam:ListRolePolicies",
                 "iam:PassRole",
-                "iam:PutRolePolicy"
+                "iam:PutRolePolicy",
+                "iam:TagRole"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"
         },

--- a/content/kubermatic/v2.19/architecture/support_policy/provider_support_matrix/AWS/aws.en.md
+++ b/content/kubermatic/v2.19/architecture/support_policy/provider_support_matrix/AWS/aws.en.md
@@ -32,7 +32,8 @@ weight = 7
                 "iam:ListAttachedRolePolicies",
                 "iam:ListRolePolicies",
                 "iam:PassRole",
-                "iam:PutRolePolicy"
+                "iam:PutRolePolicy",
+                "iam:TagRole"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"
         },

--- a/content/kubermatic/v2.20/architecture/support_policy/provider_support_matrix/AWS/aws.en.md
+++ b/content/kubermatic/v2.20/architecture/support_policy/provider_support_matrix/AWS/aws.en.md
@@ -32,7 +32,8 @@ weight = 7
                 "iam:ListAttachedRolePolicies",
                 "iam:ListRolePolicies",
                 "iam:PassRole",
-                "iam:PutRolePolicy"
+                "iam:PutRolePolicy",
+                "iam:TagRole"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/kubernetes-*"
         },


### PR DESCRIPTION
Since the newly refactored AWS cloud provider, we need `iam:TagRole` permissions. This affects KKP 2.19+