### PR TITLE
Remove version requisite from autoscaler docs that is always given

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/KKP_autoscaler/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/KKP_autoscaler/_index.en.md
@@ -18,14 +18,6 @@ The Kubernetes Autoscaler in the KKP Cluster automatically scaled up/down when o
 * Some pods failed to run in the cluster due to insufficient resources.
 * There are nodes in the cluster that have been underutilised for an extended period (10 minutes by default) and can place their Pods on other existing nodes.
 
- 
-## The Pre-requisite
-
-Using a Kubernetes cluster autoscaler in the KKP cluster must meet specific minimum requirement:
-
-* Kubernetes cluster running Kubernetes v1.18 or newer is required.
-
-
 ## Installing Kubernetes Auto-scaler on KKP Cluster
 
 You can install Kubernetes autoscaler on a running KKP Cluster using the KKP addon mechanism, which is already built into the KKP Cluster dashboard.

--- a/content/kubermatic/v2.18/tutorials_howtos/KKP_autoscaler/_index.en.md
+++ b/content/kubermatic/v2.18/tutorials_howtos/KKP_autoscaler/_index.en.md
@@ -18,14 +18,6 @@ The Kubernetes Autoscaler in the KKP Cluster automatically scaled up/down when o
 * Some pods failed to run in the cluster due to insufficient resources.
 * There are nodes in the cluster that have been underutilised for an extended period (10 minutes by default) and can place their Pods on other existing nodes.
 
- 
-## The Pre-requisite
-
-Using a Kubernetes cluster autoscaler in the KKP cluster must meet specific minimum requirement:
-
-* Kubernetes cluster running Kubernetes v1.18 or newer is required.
-
-
 ## Installing Kubernetes Auto-scaler on KKP Cluster
 
 You can install Kubernetes autoscaler on a running KKP Cluster using the KKP addon mechanism, which is already built into the KKP Cluster dashboard.

--- a/content/kubermatic/v2.19/tutorials_howtos/KKP_autoscaler/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/KKP_autoscaler/_index.en.md
@@ -18,14 +18,6 @@ The Kubernetes Autoscaler in the KKP Cluster automatically scaled up/down when o
 * Some pods failed to run in the cluster due to insufficient resources.
 * There are nodes in the cluster that have been underutilised for an extended period (10 minutes by default) and can place their Pods on other existing nodes.
 
- 
-## The Pre-requisite
-
-Using a Kubernetes cluster autoscaler in the KKP cluster must meet specific minimum requirement:
-
-* Kubernetes cluster running Kubernetes v1.18 or newer is required.
-
-
 ## Installing Kubernetes Auto-scaler on KKP Cluster
 
 You can install Kubernetes autoscaler on a running KKP Cluster using the KKP addon mechanism, which is already built into the KKP Cluster dashboard.

--- a/content/kubermatic/v2.20/tutorials_howtos/KKP_autoscaler/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/KKP_autoscaler/_index.en.md
@@ -18,14 +18,6 @@ The Kubernetes Autoscaler in the KKP Cluster automatically scaled up/down when o
 * Some pods failed to run in the cluster due to insufficient resources.
 * There are nodes in the cluster that have been underutilised for an extended period (10 minutes by default) and can place their Pods on other existing nodes.
 
- 
-## The Pre-requisite
-
-Using a Kubernetes cluster autoscaler in the KKP cluster must meet specific minimum requirement:
-
-* Kubernetes cluster running Kubernetes v1.18 or newer is required.
-
-
 ## Installing Kubernetes Auto-scaler on KKP Cluster
 
 You can install Kubernetes autoscaler on a running KKP Cluster using the KKP addon mechanism, which is already built into the KKP Cluster dashboard.


### PR DESCRIPTION
None of the actively supported KKP versions support Kubernetes versions below 1.18 anymore. This note from the autoscaler docs is therefore not needed anymore. Let's remove it as kind of a housekeeping activity.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>