### PR TITLE
Use title case consistently across all pages

### DIFF
--- a/content/kubermatic/master/architecture/concept/kkp-concepts/cluster_templates/_index.en.md
+++ b/content/kubermatic/master/architecture/concept/kkp-concepts/cluster_templates/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cluster templates"
+title = "Cluster Templates"
 date = 2021-08-02T14:07:15+02:00
 weight = 1
 

--- a/content/kubermatic/master/cheat_sheets/_index.en.md
+++ b/content/kubermatic/master/cheat_sheets/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cheat sheets"
+title = "Cheat Sheets"
 date = 2020-02-10T11:07:15+02:00
 weight = 60
 +++

--- a/content/kubermatic/master/cheat_sheets/etcd/legacy_restore/_index.en.md
+++ b/content/kubermatic/master/cheat_sheets/etcd/legacy_restore/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Restoring from backup"
+title = "Restoring from Backup"
 date = 2018-07-24T12:07:15+02:00
 weight = 20
 
@@ -7,7 +7,7 @@ weight = 20
 
 ## Intro
 
-The etcd's of the user-clusters are being backed up on a configured interval.
+The etcds of the user-clusters are being backed up on a configured interval.
 This document will lead through the process of restoring a complete etcd StatefulSet from a single snapshot.
 
 ### Pausing the Cluster

--- a/content/kubermatic/master/cheat_sheets/etcd/replace_a_member/_index.en.md
+++ b/content/kubermatic/master/cheat_sheets/etcd/replace_a_member/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Replacing a member"
+title = "Replacing a Member"
 date = 2018-07-24T12:07:15+02:00
 weight = 10
 

--- a/content/kubermatic/master/installation/start_kkp/concepts/pipeline_definition/_index.en.md
+++ b/content/kubermatic/master/installation/start_kkp/concepts/pipeline_definition/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Delivery Pipeline description"
+title = "Delivery Pipeline Description"
 +++
 
 Automated pipeline was created in GitHub, GitLab or Bitbucket to automate all installation steps to have KKP up and running and

--- a/content/kubermatic/master/references/crds/_index.en.md
+++ b/content/kubermatic/master/references/crds/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic CRDs reference"
+title = "Kubermatic CRDs Reference"
 date = 2021-12-02T00:00:00
 weight = 40
 +++

--- a/content/kubermatic/master/tutorials_howtos/CCM_migration/CCM_migration_via_UI/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/CCM_migration/CCM_migration_via_UI/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "CCM migration via UI"
+title = "CCM Migration via UI"
 date = 2021-07-29T12:07:15+02:00
 weight = 10
 

--- a/content/kubermatic/master/tutorials_howtos/CCM_migration/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/CCM_migration/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "CCM migration"
+title = "CCM Migration"
 date = 2021-07-29T14:07:15+02:00
 weight = 12
 

--- a/content/kubermatic/master/tutorials_howtos/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/Deploy_your_application/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Deploy your application"
+title = "Deploy Your Application"
 date = 2020-02-21T12:07:15+02:00
 weight = 17
 +++

--- a/content/kubermatic/master/tutorials_howtos/cluster_templates/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/cluster_templates/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cluster templates"
+title = "Cluster Templates"
 date = 2021-08-02T14:07:15+02:00
 weight = 5
 

--- a/content/kubermatic/master/tutorials_howtos/manage_worker's_node/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/manage_worker's_node/_index.en.md
@@ -1,9 +1,9 @@
 +++
-title = "Manage Worker's Node"
+title = "Manage Worker Nodes"
 date = 2021-04-20T12:16:38+02:00
 weight = 2
 +++
 
-## Manage Worker's Node via UI and Command-Line
+## Manage Worker Nodes via UI and Command-Line
 
 This page describes worker node's management using both command lines and UI. 

--- a/content/kubermatic/master/tutorials_howtos/manage_worker's_node/ssh-access-to-worker-node/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/manage_worker's_node/ssh-access-to-worker-node/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "SSH access to worker nodes"
+title = "SSH Access to Worker Nodes"
 date = 2019-11-13T12:07:15+02:00
 weight = 90
 +++

--- a/content/kubermatic/master/tutorials_howtos/manage_worker's_node/via_command_line/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/manage_worker's_node/via_command_line/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Manage worker nodes via CLI"
+title = "Manage Worker Nodes via CLI"
 date = 2020-01-08T12:07:15+02:00
 weight = 16
 +++

--- a/content/kubermatic/master/tutorials_howtos/project_and_cluster_management/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/project_and_cluster_management/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Project and cluster management"
+title = "Project and Cluster Management"
 date = 2021-02-10T12:07:15+02:00
 weight = 1
 

--- a/content/kubermatic/master/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cluster defaulting"
+title = "Cluster Defaulting"
 date = 2021-08-02T14:07:15+02:00
 weight = 20
 

--- a/content/kubermatic/v2.20/architecture/concept/kkp-concepts/cluster_templates/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/concept/kkp-concepts/cluster_templates/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cluster templates"
+title = "Cluster Templates"
 date = 2021-08-02T14:07:15+02:00
 weight = 1
 

--- a/content/kubermatic/v2.20/cheat_sheets/_index.en.md
+++ b/content/kubermatic/v2.20/cheat_sheets/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cheat sheets"
+title = "Cheat Sheets"
 date = 2020-02-10T11:07:15+02:00
 weight = 60
 +++

--- a/content/kubermatic/v2.20/cheat_sheets/etcd/legacy_restore/_index.en.md
+++ b/content/kubermatic/v2.20/cheat_sheets/etcd/legacy_restore/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Restoring from backup"
+title = "Restoring from Backup"
 date = 2018-07-24T12:07:15+02:00
 weight = 20
 
@@ -7,7 +7,7 @@ weight = 20
 
 ## Intro
 
-The etcd's of the user-clusters are being backed up on a configured interval.
+The etcds of the user-clusters are being backed up on a configured interval.
 This document will lead through the process of restoring a complete etcd StatefulSet from a single snapshot.
 
 ### Pausing the Cluster

--- a/content/kubermatic/v2.20/installation/start_kkp/concepts/pipeline_definition/_index.en.md
+++ b/content/kubermatic/v2.20/installation/start_kkp/concepts/pipeline_definition/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Delivery Pipeline description"
+title = "Delivery Pipeline Description"
 +++
 
 Automated pipeline was created in GitHub, GitLab or Bitbucket to automate all installation steps to have KKP up and running and

--- a/content/kubermatic/v2.20/references/crds/_index.en.md
+++ b/content/kubermatic/v2.20/references/crds/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubermatic CRDs reference"
+title = "Kubermatic CRDs Reference"
 date = 2021-12-02T00:00:00
 weight = 40
 +++

--- a/content/kubermatic/v2.20/tutorials_howtos/CCM_migration/CCM_migration_via_UI/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/CCM_migration/CCM_migration_via_UI/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "CCM migration via UI"
+title = "CCM Migration via UI"
 date = 2021-07-29T12:07:15+02:00
 weight = 10
 

--- a/content/kubermatic/v2.20/tutorials_howtos/CCM_migration/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/CCM_migration/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "CCM migration"
+title = "CCM Migration"
 date = 2021-07-29T14:07:15+02:00
 weight = 12
 

--- a/content/kubermatic/v2.20/tutorials_howtos/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/Deploy_your_application/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Deploy your application"
+title = "Deploy Your Application"
 date = 2020-02-21T12:07:15+02:00
 weight = 17
 +++

--- a/content/kubermatic/v2.20/tutorials_howtos/cluster_templates/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/cluster_templates/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cluster templates"
+title = "Cluster Templates"
 date = 2021-08-02T14:07:15+02:00
 weight = 5
 

--- a/content/kubermatic/v2.20/tutorials_howtos/manage_worker's_node/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/manage_worker's_node/_index.en.md
@@ -1,9 +1,9 @@
 +++
-title = "Manage Worker's Node"
+title = "Manage Worker Nodes"
 date = 2021-04-20T12:16:38+02:00
 weight = 2
 +++
 
-## Manage Worker's Node via UI and Command-Line
+## Manage Worker Nodes via UI and Command-Line
 
 This page describes worker node's management using both command lines and UI. 

--- a/content/kubermatic/v2.20/tutorials_howtos/manage_worker's_node/ssh-access-to-worker-node/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/manage_worker's_node/ssh-access-to-worker-node/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "SSH access to worker nodes"
+title = "SSH Access to Worker Nodes"
 date = 2019-11-13T12:07:15+02:00
 weight = 90
 +++

--- a/content/kubermatic/v2.20/tutorials_howtos/manage_worker's_node/via_command_line/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/manage_worker's_node/via_command_line/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Manage worker nodes via CLI"
+title = "Manage Worker Nodes via CLI"
 date = 2020-01-08T12:07:15+02:00
 weight = 16
 +++

--- a/content/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Project and cluster management"
+title = "Project and Cluster Management"
 date = 2021-02-10T12:07:15+02:00
 weight = 1
 

--- a/content/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/cluster_defaulting/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Cluster defaulting"
+title = "Cluster Defaulting"
 date = 2021-08-02T14:07:15+02:00
 weight = 20
 

--- a/hack/crd-templates/gv_list.tpl
+++ b/hack/crd-templates/gv_list.tpl
@@ -1,7 +1,7 @@
 {{- define "gvList" -}}
 {{- $groupVersions := . -}}
 +++
-title = "Kubermatic CRDs reference"
+title = "Kubermatic CRDs Reference"
 date = 2021-12-02T00:00:00
 weight = 40
 +++


### PR DESCRIPTION
The king of all nitpick PRs, this one applies [title case](https://en.wikipedia.org/wiki/Title_case) across all documentation pages. Most of the page titles were already following this, but a few of them didn't. I fixed them because they were my ultimate pet peeve.

I've done this for `master` and 2.20, since that's the documentation people get to see by default when going to docs.kubermatic.com.