### PR TITLE
Remove note on vSphere 1.22 limitation in KKP 2.19 docs

### DIFF
--- a/content/kubermatic/v2.19/tutorials_howtos/CCM_migration/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/CCM_migration/_index.en.md
@@ -30,12 +30,6 @@ The CCM/CSI migration is supported only for the following providers so far:
 * Openstack
 * vSphere
 
-{{% notice note %}}
-The latest vSphere CSI driver [release](https://vsphere-csi-driver.sigs.k8s.io/releases/v2.3.0.html) does not support 
-Kubernetes 1.22, hence it is **not** possible to *upgrade* already migrated vSphere clusters to Kubernetes 1.22, *migrate*
-existing vSphere 1.22 clusters, and *create* new vSphere clusters with Kubernetes 1.22 (new clusters are by default controlled by the external CCM).
-{{% /notice %}}
-
 ### Enabling the external cloud provider
 
 The migration is specific per user cluster, meaning that it is activated by the `externalCloudProvider` feature in the


### PR DESCRIPTION
We added 1.22 support for vSphere in https://github.com/kubermatic/kubermatic/pull/8505. That was part of [KKP 2.19.0](https://github.com/kubermatic/kubermatic/blob/master/CHANGELOG.md#vmware-vsphere). As such, KKP 2.19 supports clusters with Kubernetes 1.22 on vSphere. We should remove this limitation from the 2.19 docs since it's not true.