### PR TITLE
Fixed REF_NOT_FOUND error for ref link encountered during build

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/Deploy_your_application/_index.en.md
@@ -6,7 +6,7 @@ weight = 17
 
 This tutorial demonstrates how to deploy your application to your cluster. We will deploy a hello world application to your cluster that responds with "Hello Kubernetes!" when you curl it.
 
-Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "/kubermatic/master/tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
+Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "../project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
 
 We are using a [hello-world app](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/master/hello-app) whose image is available at gcr.io/google-samples/node-hello:1.0.
 

--- a/content/kubermatic/v2.17/examples/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/v2.17/examples/Deploy_your_application/_index.en.md
@@ -6,7 +6,7 @@ weight = 110
 
 This tutorial demonstrates how to deploy your application to your cluster. We will deploy a hello world application to your cluster that responds with "Hello Kubernetes!" when you curl it.
 
-Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "/kubermatic/v2.17/tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
+Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "../../tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
 
 We are using a [hello-world app](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/master/hello-app) whose image is available at gcr.io/google-samples/node-hello:1.0.
 

--- a/content/kubermatic/v2.18/examples/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/v2.18/examples/Deploy_your_application/_index.en.md
@@ -6,7 +6,7 @@ weight = 110
 
 This tutorial demonstrates how to deploy your application to your cluster. We will deploy a hello world application to your cluster that responds with "Hello Kubernetes!" when you curl it.
 
-Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "/kubermatic/v2.18/tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
+Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "../../tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
 
 We are using a [hello-world app](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/master/hello-app) whose image is available at gcr.io/google-samples/node-hello:1.0.
 

--- a/content/kubermatic/v2.19/tutorials_howtos/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/Deploy_your_application/_index.en.md
@@ -6,7 +6,7 @@ weight = 17
 
 This tutorial demonstrates how to deploy your application to your cluster. We will deploy a hello world application to your cluster that responds with "Hello Kubernetes!" when you curl it.
 
-Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "/kubermatic/v2.19/tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
+Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "../project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
 
 We are using a [hello-world app](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/master/hello-app) whose image is available at gcr.io/google-samples/node-hello:1.0.
 

--- a/content/kubermatic/v2.20/tutorials_howtos/Deploy_your_application/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/Deploy_your_application/_index.en.md
@@ -6,7 +6,7 @@ weight = 17
 
 This tutorial demonstrates how to deploy your application to your cluster. We will deploy a hello world application to your cluster that responds with "Hello Kubernetes!" when you curl it.
 
-Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
+Log into Kubermatic Kubernetes Platform (KKP), then [create and connect to the cluster]({{< ref "../project_and_cluster_management/" >}}). For this tutorial, external IP is required which will be provided through the supported cloud providers. Be aware that some providers like DigitalOcean do not provide external IPs.
 
 We are using a [hello-world app](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/master/hello-app) whose image is available at gcr.io/google-samples/node-hello:1.0.
 


### PR DESCRIPTION
```
Building sites …
ERROR 2022/06/15 18:02:39 [en] REF_NOT_FOUND: Ref "/kubermatic/master/tutorials_howtos/project_and_cluster_management/" from page "kubermatic/master/tutorials_howtos/Deploy_your_application/_index.en.md": page not found
ERROR 2022/06/15 18:02:46 [en] REF_NOT_FOUND: Ref "/kubermatic/v2.17/tutorials_howtos/project_and_cluster_management/" from page "kubermatic/v2.17/examples/Deploy_your_application/_index.en.md": page not found
ERROR 2022/06/15 18:02:48 [en] REF_NOT_FOUND: Ref "/kubermatic/v2.18/tutorials_howtos/project_and_cluster_management/" from page "kubermatic/v2.18/examples/Deploy_your_application/_index.en.md": page not found
ERROR 2022/06/15 18:02:52 [en] REF_NOT_FOUND: Ref "/kubermatic/v2.19/tutorials_howtos/project_and_cluster_management/" from page "kubermatic/v2.19/tutorials_howtos/Deploy_your_application/_index.en.md": page not found
ERROR 2022/06/15 18:02:55 [en] REF_NOT_FOUND: Ref "/kubermatic/v2.20/tutorials_howtos/project_and_cluster_management/" from page
```

Signed-off-by: archups <archupsawant@gmail.com>