### PR TITLE
Add documentation on how to customize audit-logs sidecar 

### DIFF
--- a/content/kubermatic/master/tutorials_howtos/audit_logging/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/audit_logging/_index.en.md
@@ -90,7 +90,7 @@ spec:
         outputs:
           - Name: forward
             Match: *
-            Host: "fluentdd.audit-forward.svc.cluster.local"
+            Host: "fluentd.audit-forward.svc.cluster.local"
 ```
 
 This configures the fluentbit sidecar to flush incoming audit logs every 10 seconds, filters them by a string (`user@example.com`) and writes them to a fluentd service available in-cluster.

--- a/content/kubermatic/master/tutorials_howtos/audit_logging/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/audit_logging/_index.en.md
@@ -90,7 +90,7 @@ spec:
         outputs:
           - Name: forward
             Match: *
-            fluentdd.audit-forward.svc.cluster.local"
+            Host: "fluentdd.audit-forward.svc.cluster.local"
 ```
 
 This configures the fluentbit sidecar to flush incoming audit logs every 10 seconds, filters them by a string (`user@example.com`) and writes them to a fluentd service available in-cluster.

--- a/content/kubermatic/master/tutorials_howtos/audit_logging/_index.en.md
+++ b/content/kubermatic/master/tutorials_howtos/audit_logging/_index.en.md
@@ -93,7 +93,7 @@ spec:
             Host: "fluentd.audit-forward.svc.cluster.local"
 ```
 
-This configures the fluentbit sidecar to flush incoming audit logs every 10 seconds, filters them by a string (`user@example.com`) and writes them to a fluentd service available in-cluster.
+This configures the fluentbit sidecar to flush incoming audit logs every 10 seconds, filters them by a string (`user@example.com`) and writes them to a manually deployed fluentd service available in-cluster.
 
 #### User-Cluster Level Audit Logging
 


### PR DESCRIPTION
We added `spec.auditLogging.sidecar` to the ClusterSpec, which allows customizing fluentbit configuration. This can be mainly used to ship audit logs to an external system instead of writing it to standard output, something that might not be desired in regulated environments.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>