### PR TITLE
Update CE installation reference

### DIFF
--- a/content/kubermatic/master/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/master/installation/install_kkp_CE/_index.en.md
@@ -273,7 +273,7 @@ kubermatic.example.com.   IN   CNAME   myloadbalancer.example.com.
 #### Identity Aware Proxy
 
 It's a common step to later setup an identity-aware proxy (IAP) to
-[securely access other KKP components]({{< ref "." >}}) from the logging or monitoring
+[securely access other KKP components]({{< ref "../../architecture/concept/kkp-concepts/kkp_security/securing_system_services" >}}) from the logging or monitoring
 stacks. This involves setting up either individual DNS records per IAP deployment (one for Prometheus, one for Grafana, etc.)
 or simply creating a single **wildcard** record: `*.kubermatic.example.com`.
 


### PR DESCRIPTION
This link pointed towards itself, and now targets a location that supposedly fits the context.

Signed-off-by: jon r <jon@allmende.io>

In redoing a KubeOne + Kubermatic installation one and a half years later, I have found this dead link, which was still working the last time.

Is it correct that this is the intended target of the link?

It may be that this link is also broken in the other installation instructions, which I didn't check.