### PR TITLE
Generate the redirects to current stable version of the products

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,9 +12,14 @@ enableRobotsTXT = true
     mediaType = "application/json"
     isPlainText = true
     notAlternative = true
+  [outputFormats.Redirects]
+    baseName = "_redirects"
+    mediaType = "application/octet-stream"
+    isPlainText = true
+    notAlternative = true
 
 [outputs]
-home = ["HTML", "Search"]
+home = ["HTML", "Search", "Redirects"]
 section = ["HTML"]
 
 [params]

--- a/content/kubecarrier/_index.md
+++ b/content/kubecarrier/_index.md
@@ -1,4 +1,5 @@
 +++
-title = "Docs"
-
+title = "KubeCarrier Docs"
+description = "The operator of operators. Centrally manage all your services and applications across multiple clusters, clouds and regions with Kubernetes native API and tooling."
 +++
+The operator of operators. Centrally manage all your services and applications across multiple clusters, clouds and regions with Kubernetes native API and tooling.

--- a/content/kubeone/_index.md
+++ b/content/kubeone/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "KubeOne Docs"
-
+description = "Automate operations of a single Kubernetes cluster on your chosen cloud, on-prem, or edge environment."
 +++
+Automate operations of a single Kubernetes cluster on your chosen cloud, on-prem, or edge environment.

--- a/content/kubermatic/_index.md
+++ b/content/kubermatic/_index.md
@@ -1,4 +1,5 @@
 +++
-title = "Docs"
-
+title = "KKP Docs"
+description = "Automate multicloud, on-prem, and edge operations with a single management UI enabling you to deliver the cloud native transformation immediately."
 +++
+Automate multicloud, on-prem, and edge operations with a single management UI enabling you to deliver the cloud native transformation immediately.

--- a/layouts/_default/home.redirects
+++ b/layouts/_default/home.redirects
@@ -12,7 +12,7 @@ https://cranky-newton-4e6ed2.netlify.com/* https://docs.kubermatic.com/:splat 30
 
 {{- /* # Generate the redirects to stable version of the products */ -}}
 {{- $products := .Site.Data.products -}}
-{{- range $productName, $val := $products}}
+{{- range $productName, $val := $products -}}
 {{- $release := (cond (gt (len .versions) 1) (index .versions 1) (index .versions 0)).release -}}
 {{- with $.Site.GetPage (printf "/%s/%s" $productName $release)}}
 {{printf "/%s %s 301!" $productName .RelPermalink -}}

--- a/layouts/_default/home.redirects
+++ b/layouts/_default/home.redirects
@@ -9,3 +9,12 @@ https://cranky-newton-4e6ed2.netlify.com/* https://docs.kubermatic.com/:splat 30
 
 /kubermatic/master/cheat_sheets/alerting_runbook/* /kubermatic/master/cheat-sheets/alerting-runbook/:splat 301!
 /kubermatic/master/tutorials_howtos/oidc_provider_configuration/share-_clusters_via_delegated_oidc_authentication /kubermatic/master/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/ 301!
+
+{{- /* # Generate the redirects to stable version of the products */ -}}
+{{- $products := .Site.Data.products -}}
+{{- range $productName, $val := $products}}
+{{- $release := (cond (gt (len .versions) 1) (index .versions 1) (index .versions 0)).release -}}
+{{- with $.Site.GetPage (printf "/%s/%s" $productName $release)}}
+{{printf "/%s %s 301!" $productName .RelPermalink -}}
+{{end -}}
+{{- end -}}


### PR DESCRIPTION
/kubecarrier -> /kubecarrier/v0.3/
/kubeone -> /kubeone/v1.4/
/kubermatic -> /kubermatic/v2.20/