### PR TITLE
Mark metering page as enterprise feature via meta keyword

### DIFF
--- a/content/kubermatic/master/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/master/tutorials-howtos/metering/_index.en.md
@@ -1,7 +1,8 @@
 +++
-title = "Metering (EE)"
+title = "Metering"
 date = 2021-09-01T11:47:15+02:00
 weight = 16
+enterprise = true
 
 +++
 


### PR DESCRIPTION
We have a special key to mark pages as EE features. This uber nitpick changes the metering docs to use that.

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>