### PR TITLE
destroy base64 encoding of secret to prevent users from reusing it 

### DIFF
--- a/content/kubermatic/master/tutorials-howtos/encryption-at-rest/_index.en.md
+++ b/content/kubermatic/master/tutorials-howtos/encryption-at-rest/_index.en.md
@@ -67,7 +67,7 @@ spec:
     secretbox:
       keys:
         - name: encryption-key-2022-01
-          value: ynCl8otobs5NuHuS3TLghqwFXVpv6N//SE6ZVTimYok=
+          value: ynCl8otobs5NuHu$3TLghqwFXVpv6N//SE6ZVTimYok=
 ```
 
 ```


### PR DESCRIPTION
User might copy paste this config including the secret and forget to update the secret. 
That will give attackers chance to get the data since this secret is public. 
This PR destroys base64 encoding of the secret in the docs to prevent this potentially expensive mistake. 