### PR TITLE
Add KubeOne 1.5 to products.yaml

### DIFF
--- a/data/products.yaml
+++ b/data/products.yaml
@@ -37,6 +37,8 @@ kubeone:
   versions:
     - release: master
       name: master
+    - release: v1.5
+      name: v1.5
     - release: v1.4
       name: v1.4
     - release: v1.3


### PR DESCRIPTION
This PR adds KubeOne 1.5 to `products.yaml`.

This PR should be merged after releasing KubeOne 1.5 and merging #1179.

/hold