### PR TITLE
Exclude references/crds pages of KKP from search index

### DIFF
--- a/content/kubermatic/master/references/crds/_index.en.md
+++ b/content/kubermatic/master/references/crds/_index.en.md
@@ -2,6 +2,7 @@
 title = "Kubermatic CRDs Reference"
 date = 2021-12-02T00:00:00
 weight = 40
+searchExclude = true
 +++
 
 ## Packages

--- a/content/kubermatic/v2.20/references/crds/_index.en.md
+++ b/content/kubermatic/v2.20/references/crds/_index.en.md
@@ -2,6 +2,7 @@
 title = "Kubermatic CRDs Reference"
 date = 2021-12-02T00:00:00
 weight = 40
+searchExclude = true
 +++
 
 ## Packages

--- a/layouts/_default/home.search.json
+++ b/layouts/_default/home.search.json
@@ -4,7 +4,7 @@
 {{- $validVars := $.Param "search.vars" | default slice -}}
 {{- $validParams := $.Param "search.params" | default slice -}}
 {{/* Include What Pages? */}}
-{{- range $i, $hit := (where (where .Site.Pages "Kind" "section") "Params.ignore" "ne" true) -}}
+{{- range $i, $hit := (where (where .Site.Pages "Kind" "section") "Params.searchExclude" "ne" true) -}}
   {{- $dot := . -}}
   {{- if and $hit.Content (or (and ($hit.IsDescendant $section) (and (not $hit.Draft) (not $hit.Params.private))) $section.IsHome) -}}
     {{- $pathItems := split $hit.RelPermalink "/" -}}


### PR DESCRIPTION
The reason is exceeded limit of page content size for record in search index.
/assign @ahmedwaleedmalik 