### PR TITLE
Update KKP docs based on the recent feedback

### DIFF
--- a/content/kubermatic/master/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/master/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -62,6 +62,12 @@ helm --namespace mla upgrade --atomic --create-namespace --install mla-secrets c
 
 The above command will create two Secrets (one for MinIO, and one for Grafana), if you want to use your existing Secrets in the Cluster, you can disable the creation by modifying the [mla-secret value.yaml](https://github.com/kubermatic/mla/blob/main/config/mla-secrets/values.yaml#L17-L22)
 
+{{% notice warning %}}
+The `mla-secrets` chart should be installed **ONLY ONCE** when installing
+the MLA Stack for the first time. Installing/upgrading it afterwards will cause
+credentials to get rotated which can cause issues with the MLA Stack.
+{{% /notice %}}
+
 #### Deploy Seed Cluster Components
 
 After the secrets are created, the MLA stack can be deployed by using the helper script:

--- a/content/kubermatic/master/tutorials-howtos/upgrading/upgrade-from-2.19-to-2.20/_index.en.md
+++ b/content/kubermatic/master/tutorials-howtos/upgrading/upgrade-from-2.19-to-2.20/_index.en.md
@@ -251,3 +251,17 @@ kubectl get seed.kubermatic.k8c.io -n kubermatic <SEED NAME> -o yaml
 ```
 
 Clean up the metadata section as well so it only has `name` and `namespace` (or compare to your previous YAML files) before checking it into version control.
+
+## MLA Stack changes
+
+Due to some changes in the MLA stack, you might have to recreate some resources
+manually. 
+
+- If you're running into an issue with Helm failing to deploy `logging/loki`
+  and/or `logging/promtail` charts due to fields being immutable, manually
+  remove the old Loki StatefulSet and the old Promtail DaemonSet. After removing
+  those resources, run Helm again
+- If you're running into an issue that user-cluster-controller-manager is
+  failing to reconcile user cluster MLA Prometheus deployment in user clusters,
+  you need to manually remove the Prometheus deployment located in `mla-system`
+  namespace in each user cluster


### PR DESCRIPTION
This PR updates 2.18 to 2.19 upgrade document based on the recent feedback. This PR adds:

- note about removing the old Loki StatefulSet when upgrading the `logging/loki` Helm chart
- note about removing the user cluster MLA Prometheus deployment

/assing @wurbanski 

/hold
The following questions need to be answered first:

- Do we also need to remove the Promtail DaemonSet?
- Where we could add a note about the mla-secrets Helm chart?
- Do we need those notes in other upgrade documents?

Additionally, we need to copy this document to other versions.