### PR TITLE
KubeOne: add guides for creating vSphere template VMs

### DIFF
--- a/content/kubeone/main/guides/vsphere-template-vm/_index.en.md
+++ b/content/kubeone/main/guides/vsphere-template-vm/_index.en.md
@@ -1,0 +1,20 @@
++++
+title = "Creating vSphere Template VMs"
+date = 2022-10-31T12:00:00+02:00
+enableToc = false
++++
+
+This guide describes how to create templates VMs for vSphere to be used with
+Terraform, Kubermatic KubeOne, and Kubermatic machine-controller. This is an
+umbrella document — we have a dedicated guide for each operating system:
+
+- [Ubuntu]({{< ref "./ubuntu/" >}})
+- [CentOS 7]({{< ref "./centos/" >}})
+
+Guides for other operating systems will be added in the future.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}

--- a/content/kubeone/main/guides/vsphere-template-vm/centos/_index.en.md
+++ b/content/kubeone/main/guides/vsphere-template-vm/centos/_index.en.md
@@ -1,0 +1,219 @@
++++
+title = "CentOS 7 Template VM"
+date = 2022-10-31T12:00:00+02:00
+enableToc = true
++++
+
+This guide describes how to create a template VM for vSphere running CentOS 7.
+The template VM is supposed to be compatible with Terraform, Kubermatic KubeOne,
+and Kubermatic machine-controller.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}
+
+## Requirements
+
+You need to satisfy the following requirements before proceeding:
+
+* Have access to the vSphere API via `govc` and vCenter
+* Have the following tools installed on your local machine: `govc`, `qemu-img`,
+  and `virt-customize` (comes with the `libguestfs-tools` package)
+
+## Preparing Local Environment
+
+Before getting started, you should prepare your local environment by exporting
+`GOVC_` environment variables with the information about your vSphere setup:
+
+```shell
+export GOVC_URL="https://<url>"
+export GOVC_USERNAME="<username>"
+export GOVC_PASSWORD="<password>"
+export GOVC_INSECURE=false # set to true if you don't have a valid/trusted certificate
+export GOVC_DATASTORE="<datastore-name>"
+```
+
+## Downloading CentOS 7 VM
+
+We'll download CentOS 7 `qcow2` image. `qcow2` is a hard drive with preinstalled
+CentOS 7 that can be used for creating (vSphere) VMs. That being said, you don't
+need to install CentOS manually, that's already done for you.
+
+The `qcow2` image can be downloaded from the [official CentOS website][centos].
+Download the latest available `qcow2` file. At the time of writing this document,
+the latest available file is called `CentOS-7-x86_64-GenericCloud-2111.qcow2`.
+It's recommended to verify checksums, but we'll omit that because of brevity.
+
+[centos]: https://cloud.centos.org/centos/7/images/?C=M;O=D
+
+## Preparing and Uploading the CentOS qcow2 File
+
+The downloaded CentOS installation comes in `qcow2` format, however, we need
+VMDK format so that it can be used with vSphere. Additionally, we need to login
+to the VM to configure it. The installation comes with `root` and `centos` users,
+but neither has a password set, so it's not possible to login to the VM using
+those users.
+
+First, we'll set the password for the `root` user using the `virt-customize`
+tool:
+
+```shell
+sudo virt-customize -a CentOS-7-x86_64-GenericCloud-2111.qcow2 --root-password 'password:<insert-your-password-here>'
+```
+
+Customizing the VM might take a minute or two. Once that's done, we can convert
+the `qcow2` file to `vmdk` using `qemu-img`:
+
+```shell
+qemu-img convert -O vmdk -o subformat=streamOptimized "./CentOS-7-x86_64-GenericCloud-2111.qcow2" "CentOS-7-x86_64-GenericCloud-2111.vmdk"
+```
+
+Converting the image to vmdk might take several minutes. Finally, once that is
+done, we can upload the `vmdk` file to vSphere using `govc` or using vCenter.
+We'll use `govc` for purposes of this guide:
+
+```shell
+govc import.vmdk -dc=<datacenter-name> -pool=/<datacenter-name>/host/<cluster-name>/Resources -ds=<datastore-name> "./CentOS-7-x86_64-GenericCloud-2111.vmdk"
+```
+
+That might take a few minutes depending on your internet connection speed.
+In the next step, we'll create a new vSphere VM using the uploaded `vmdk` file
+as the hard drive.
+
+## Creating a Template VM
+
+Go to vCenter and create a new Virtual Machine. You can name and place the
+VM however you prefer. When asked about compatibility, choose the latest
+available compatibility level. For Guest OS, choose Linux and CentOS 7 (64bit).
+
+When asked to customize the hardware, you should take the following steps:
+
+- remove the existing hard drive
+- click on **Add New Device** and choose **Existing Hard Disk**
+  - Find the uploaded `vmdk` file and then click on the **OK** button
+- choose **Client Device** for **New CD/DVD Drive** and ensure that 
+  **Device Mode** is set to **Passthrough Mode** for that CD/DVD drive
+
+Proceed with creating the VM. Once the VM is created, power it on and proceed
+to the next step.
+
+## Preparing the VM
+
+We'll configure the VM to be used as a template VM by KubeOne and
+machine-controller. Before proceeding, power on the VM via vCenter and open
+the Web Console or connect to the VM via SSH.
+
+Once the VM is booted, you'll see a prompt to enter credentials in the Web
+Console. Login with username `root` and use the password that you've chosen
+earlier.
+
+As a first step, make sure that the VM is up-to-date:
+
+```shell
+yum update
+```
+
+Next, ensure that you have the following packages installed:
+
+```shell
+yum install \
+  cloud-init \
+  open-vm-tools \
+  curl \
+  wget \
+  sudo \
+  vim \
+  epel-release
+```
+
+Once the `epel-release` package is installed, you can install `pip` which
+will be used later:
+
+```shell
+yum install python2-pip
+```
+
+Ensure that a service for VMware Tools is enabled and started:
+
+```shell
+systemctl enable --now vmtoolsd
+```
+
+CentOS 7 comes with an old version of cloud-init which does **not** support
+VMware Tools as a datasource for cloud-config. We'll download a vSphere
+datastore plugin from VMware that extends cloud-init in a way that it can be
+used with VMware Tools. The project is called [cloud-init-guestinfo] and it's
+available on GitHub. The project is archived because it has been integrated
+into cloud-init, but as mentioned, CentOS 7 is using an older cloud-init version
+without this datasource plugin.
+
+[cloud-init-guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
+
+The easiest way to install the latest version of this datasource plugin is by
+using the install script:
+
+```shell
+curl -sSL https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo/master/install.sh | sh -
+```
+
+The script will use `pip` (which we installed earlier) to download needed
+dependencies and install the cloud-init datasource plugin.
+
+If there are any additional adjustments that you want to make to the VM, you
+should do those adjustments now before proceeding.
+
+As a final step, we'll cleanup the VM so that it can be used as a template.
+First, remove generated SSH host keys. They'll be regenerated upon the next
+boot:
+
+```shell
+rm -f /etc/ssh/ssh_host_*
+```
+
+Then, remove logs from `/var/log` and installation logs from the `/root`
+directory:
+
+```shell
+find /var/log -type f -exec truncate --size=0 {} \;
+rm -f /root/anaconda-ks.cfg /root/original-ks.cfg
+```
+
+We can also cleanup temporary directories:
+
+```shell
+rm -rf /tmp/* /var/tmp/*
+```
+
+To make sure VMs are provisioned from the template correctly, we also have to
+reset the seed and machine-id:
+
+```shell
+rm -f /var/lib/systemd/random-seed
+echo -n > /etc/machine-id
+```
+
+Finally, to make sure that cloud-init works as expected, it's recommended to
+clean the cloud-init data:
+
+```shell
+cloud-init clean
+cloud-init clean -l
+```
+
+Finally, power off the VM:
+
+```shell
+poweroff
+```
+
+{{% notice note %}}
+If you ever boot the template VM again, you will need to repeat the cleanup
+steps again.
+{{% /notice %}}
+
+## Conclusion
+
+The VM configuration is now completely done and the VM can be used as a 
+template VM for both Terraform and machine-controller.

--- a/content/kubeone/main/guides/vsphere-template-vm/centos/_index.en.md
+++ b/content/kubeone/main/guides/vsphere-template-vm/centos/_index.en.md
@@ -161,18 +161,50 @@ curl -sSL https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo/m
 The script will use `pip` (which we installed earlier) to download needed
 dependencies and install the cloud-init datasource plugin.
 
+Once the datasource plugin is installed, we need to adjust the plugin's
+configuration to allow using it alongside with the integrated NoCloud datasource
+plugin. The NoCloud datasource plugin is required by Kubermatic
+machine-controller. Open the following configuration file in a text editor of
+your choice:
+
+```shell
+vi /etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+```
+
+Replace `datasource_list: [ "VMwareGuestInfo" ]` with the following line:
+
+```yaml
+datasource_list: [ "VMwareGuestInfo", "NoCloud" ]
+```
+
 If there are any additional adjustments that you want to make to the VM, you
 should do those adjustments now before proceeding.
 
 As a final step, we'll cleanup the VM so that it can be used as a template.
-First, remove generated SSH host keys. They'll be regenerated upon the next
+
+First, we'll ensure that there's no hardcoded MAC address in the network
+configuration. Run `ip addr` and note the name of your network interface,
+for example `eth0`. Locate and open a network configuration file for your
+network interface. Network configuration files are located in
+`/etc/sysconfig/network-scripts` and are named as `ifcfg-<interface-name>`.
+For example:
+
+```shell
+vi /etc/sysconfig/network-scripts/ifcfg-eth0
+```
+
+Locate the line starting with `HWADDR=...`. If there's such line, remove it
+completely, then save the file and close the text editor. If there's no such
+line, you don't need to take any action and can just close the text editor.
+
+Then, remove generated SSH host keys. They'll be regenerated upon the next
 boot:
 
 ```shell
 rm -f /etc/ssh/ssh_host_*
 ```
 
-Then, remove logs from `/var/log` and installation logs from the `/root`
+Proceed to remove logs from `/var/log` and installation logs from the `/root`
 directory:
 
 ```shell

--- a/content/kubeone/main/guides/vsphere-template-vm/ubuntu/_index.en.md
+++ b/content/kubeone/main/guides/vsphere-template-vm/ubuntu/_index.en.md
@@ -1,0 +1,267 @@
++++
+title = "Ubuntu Template VM"
+date = 2022-10-31T12:00:00+02:00
+enableToc = true
++++
+
+This guide describes how to create a template VM for vSphere running Ubuntu.
+The template VM is supposed to be compatible with Terraform, Kubermatic KubeOne,
+and Kubermatic machine-controller.
+
+This guide has been tested with Ubuntu 22.04 and vSphere 7.0. Using other
+versions of Ubuntu and/or vSphere might require some adjustments to the guide.
+Concretely speaking, older Ubuntu versions might come with cloud-init not
+compatible with vSphere and vApp. This might require taking addition steps to
+get it working.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}
+
+## Requirements
+
+You need to satisfy the following requirements before proceeding:
+
+* Have access to the vSphere API via `govc` and vCenter
+* Have the `govc` tool installed on your local machine
+
+## Preparing Local Environment
+
+Before getting started, you should prepare your local environment by exporting
+`GOVC_` environment variables with the information about your vSphere setup:
+
+```shell
+export GOVC_URL="https://<url>"
+export GOVC_USERNAME="<username>"
+export GOVC_PASSWORD="<password>"
+export GOVC_INSECURE=false # set to true if you don't have a valid/trusted certificate
+export GOVC_DATASTORE="<datastore-name>"
+```
+
+## Downloading an Ubuntu 22.04 VM
+
+Ubuntu has dedicated [cloud images] built to be used on cloud platforms and
+hypervisors such as vSphere. We'll use an OVA cloud image because it provides
+the best compatibility with vSphere. OVA provides preinstalled Ubuntu VM that
+can be uploaded to vSphere and used as such. That being said, you don't need
+to install Ubuntu manually, that's already done for you.
+
+The [following directory on the cloud images website][cloud-images-jammy]
+contains the latest images for Ubuntu 22.04 (Jammy Jellyfish). Find and download
+an OVA image from that directory or use the `curl` command below. The image
+should be named something like `jammy-server-cloudimg-amd64.ova`. It's
+recommended to verify checksums, but we'll omit that because of brevity.
+
+You can download the image using curl:
+
+```shell
+curl -LO https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.ova
+```
+
+## Preparing Configuration for the VM
+
+The next step is to extract the config from the downloaded OVA file and change
+it as described in this step. We want to ensure that we can login to the VM
+once we upload it to vSphere.
+
+The easiest way to extract the config is using `govc`. The following command
+will save the VM config to a file called `config.json`:
+
+```shell
+govc import.spec jammy-server-cloudimg-amd64.ova > config.json
+```
+
+Edit the `config.json` file in a text editor of your choice:
+- Set `DiskProvisioning` to `thin`
+  ```json
+  ...
+  "DiskProvisioning": "thin",
+  ...
+  ```
+- Set `password` in `PropertyMapping` to a password that you want to use to
+  login to the VM:
+  ```json
+  ...
+    "PropertyMapping": [
+      ...
+      {
+        "Key": "password",
+        "Value": "<your-password>"
+      }
+    ],
+    ...
+  ```
+- Set `Network` in `NetworkMapping` to the name of the network that you want
+  to use:
+  ```json
+  ...
+  "NetworkMapping": [
+    {
+      "Name": "VM Network",
+      "Network": "<network-name>"
+    }
+  ],
+  ...
+  ```
+- Ensure that following properties are configured as below:
+  ```json
+  ...
+  "MarkAsTemplate": false,
+  "PowerOn": false,
+  "InjectOvfEnv": false,
+  "WaitForIP": false,
+  "Name": null
+  ```
+
+With that done, save the file, close the text editor and proceed to the next
+step where we'll upload the VM to vSphere.
+
+## Uploading the VM to vSphere
+
+Now that the VM configuration is ready, we can upload the OVA file to vSphere.
+That can be done using `govc` or via vCenter. We'll use `govc` for purposes
+of this guide:
+
+```bash
+govc import.ova --options config.json jammy-server-cloudimg-amd64.ova
+```
+
+That might take a few minutes depending on your internet connection speed.
+After upload is done, you should be able to see a newly-created VM in the
+vCenter. Note the VM name as we will use it later — it should be something
+along `jammy-server-cloudimg-amd64`.
+
+Once the VM is uploaded, you'll need to upgrade the VM compatibility to version
+15 or newer (it's recommended to use the latest version). Go to vCenter, find
+the VM, right click on it in the right pane, go to the **Compatibility** menu
+and then click on **Upgrade VM Compatibility...**. This should open a pop-up
+window with a dropdown menu where you can choose the VM compatibility level.
+Choose the latest available level and then proceed to upgrade the VM.
+Once the VM is upgraded, go to the next step of this guide to prepare the VM
+to be used as a template VM by KubeOne.
+
+## Preparing the VM
+
+We'll configure the VM to be used as a template VM by KubeOne and
+machine-controller. Before proceeding, power on the VM via vCenter and open
+the Web Console or connect to the VM via SSH.
+
+Once the VM is booted, you'll see a prompt to enter credentials in the Web
+Console. Login with username `ubuntu` and use the password that you've chosen
+earlier when preparing the `config.json` file.
+
+For the sake of simplicity, switch to the `root` user:
+
+```shell
+sudo -i
+```
+
+As a first step, make sure that the VM is up-to-date:
+
+```shell
+apt-get update
+apt-get dist-upgrade -y
+```
+
+Next, ensure that you have cloud-init and VMware Tools installed:
+
+```shell
+apt-get install cloud-init open-vm-tools
+```
+
+Ensure that a service for VMware Tools is enabled and started:
+
+```shell
+systemctl enable --now vmtoolsd
+```
+
+For Ubuntu VMs, you need to take additional steps to ensure that each VM
+cloned from this template VM has unique IP and MAC addresses. More information
+about this can be found in [VMware KB82229].
+
+[VMware KB82229]: https://kb.vmware.com/s/article/82229
+
+Run the following command to reset the `machine-id` property of the VM:
+
+```shell
+echo -n > /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+```
+
+With that done, we need to configure networking for the VM. The following
+step assumes that you want to use DHCP for your VM. This might be different
+depending on your vSphere setup.
+
+List all files in the `/etc/netplan` directory. There should be a file named
+as `50-*.yaml`. Open that file with a text editor of your choice. Remove
+everything from that file and paste the following contents:
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    default:
+      match:
+        name: e*
+      dhcp4: yes
+      dhcp-identifier: mac
+```
+
+Save the file and exit the text editor. Finally, apply the network configuration
+and ensure that you still have network connectivity afterwards.
+
+```shell
+netplan apply
+```
+
+If there are any additional adjustments that you want to make to the VM, you
+should do those adjustments now before proceeding.
+
+To make sure the VM is fresh and can be used as a template, and that vApp
+works as expected, it's recommended to clean the cloud-init data:
+
+```shell
+cloud-init clean
+cloud-init clean -l
+```
+
+Finally, power off the VM:
+
+```shell
+poweroff
+```
+
+{{% notice note %}}
+If you ever boot the template VM again, you will need to repeat steps from
+deleting the machine-id to cleaning the cloud-init data again.
+{{% /notice %}}
+
+## Configuring the VM Properties and Enabling vApp
+
+There are few steps that you should take to ensure the VM will work correctly
+as a template for Terraform and machine-controller.
+
+First, right click on the VM in the right pane and select **Edit Settings...**.
+Ensure that **CD/DVD drive 1** is set to **Client Device**, then click on that
+drive and ensure that **Device Mode** is set to **Passthrough CD-ROM**. Click on
+**OK** button to confirm the changes.
+
+Finally, go to the **Configure** tab and then choose vApp Options. Click on 
+the **Edit** button and ensure that:
+- **Enable vApp options** is checked
+- **IP protocol** is set to the appropriate protocol
+- In the **OVF Details** tab, both **ISO image** and **VMware Tools** must be checked
+
+Confirm the changes by clicking on the **OK** button.
+
+## Conclusion
+
+The VM configuration is now completely done and the VM can be used as a 
+template VM for both Terraform and machine-controller.
+
+[cloud images]: https://cloud-images.ubuntu.com/
+[cloud-images-jammy]: https://cloud-images.ubuntu.com/jammy/current/

--- a/content/kubeone/v1.4/guides/vsphere-template-vm/_index.en.md
+++ b/content/kubeone/v1.4/guides/vsphere-template-vm/_index.en.md
@@ -1,0 +1,20 @@
++++
+title = "Creating vSphere Template VMs"
+date = 2022-10-31T12:00:00+02:00
+enableToc = false
++++
+
+This guide describes how to create templates VMs for vSphere to be used with
+Terraform, Kubermatic KubeOne, and Kubermatic machine-controller. This is an
+umbrella document — we have a dedicated guide for each operating system:
+
+- [Ubuntu]({{< ref "./ubuntu/" >}})
+- [CentOS 7]({{< ref "./centos/" >}})
+
+Guides for other operating systems will be added in the future.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}

--- a/content/kubeone/v1.4/guides/vsphere-template-vm/centos/_index.en.md
+++ b/content/kubeone/v1.4/guides/vsphere-template-vm/centos/_index.en.md
@@ -1,0 +1,251 @@
++++
+title = "CentOS 7 Template VM"
+date = 2022-10-31T12:00:00+02:00
+enableToc = true
++++
+
+This guide describes how to create a template VM for vSphere running CentOS 7.
+The template VM is supposed to be compatible with Terraform, Kubermatic KubeOne,
+and Kubermatic machine-controller.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}
+
+## Requirements
+
+You need to satisfy the following requirements before proceeding:
+
+* Have access to the vSphere API via `govc` and vCenter
+* Have the following tools installed on your local machine: `govc`, `qemu-img`,
+  and `virt-customize` (comes with the `libguestfs-tools` package)
+
+## Preparing Local Environment
+
+Before getting started, you should prepare your local environment by exporting
+`GOVC_` environment variables with the information about your vSphere setup:
+
+```shell
+export GOVC_URL="https://<url>"
+export GOVC_USERNAME="<username>"
+export GOVC_PASSWORD="<password>"
+export GOVC_INSECURE=false # set to true if you don't have a valid/trusted certificate
+export GOVC_DATASTORE="<datastore-name>"
+```
+
+## Downloading CentOS 7 VM
+
+We'll download CentOS 7 `qcow2` image. `qcow2` is a hard drive with preinstalled
+CentOS 7 that can be used for creating (vSphere) VMs. That being said, you don't
+need to install CentOS manually, that's already done for you.
+
+The `qcow2` image can be downloaded from the [official CentOS website][centos].
+Download the latest available `qcow2` file. At the time of writing this document,
+the latest available file is called `CentOS-7-x86_64-GenericCloud-2111.qcow2`.
+It's recommended to verify checksums, but we'll omit that because of brevity.
+
+[centos]: https://cloud.centos.org/centos/7/images/?C=M;O=D
+
+## Preparing and Uploading the CentOS qcow2 File
+
+The downloaded CentOS installation comes in `qcow2` format, however, we need
+VMDK format so that it can be used with vSphere. Additionally, we need to login
+to the VM to configure it. The installation comes with `root` and `centos` users,
+but neither has a password set, so it's not possible to login to the VM using
+those users.
+
+First, we'll set the password for the `root` user using the `virt-customize`
+tool:
+
+```shell
+sudo virt-customize -a CentOS-7-x86_64-GenericCloud-2111.qcow2 --root-password 'password:<insert-your-password-here>'
+```
+
+Customizing the VM might take a minute or two. Once that's done, we can convert
+the `qcow2` file to `vmdk` using `qemu-img`:
+
+```shell
+qemu-img convert -O vmdk -o subformat=streamOptimized "./CentOS-7-x86_64-GenericCloud-2111.qcow2" "CentOS-7-x86_64-GenericCloud-2111.vmdk"
+```
+
+Converting the image to vmdk might take several minutes. Finally, once that is
+done, we can upload the `vmdk` file to vSphere using `govc` or using vCenter.
+We'll use `govc` for purposes of this guide:
+
+```shell
+govc import.vmdk -dc=<datacenter-name> -pool=/<datacenter-name>/host/<cluster-name>/Resources -ds=<datastore-name> "./CentOS-7-x86_64-GenericCloud-2111.vmdk"
+```
+
+That might take a few minutes depending on your internet connection speed.
+In the next step, we'll create a new vSphere VM using the uploaded `vmdk` file
+as the hard drive.
+
+## Creating a Template VM
+
+Go to vCenter and create a new Virtual Machine. You can name and place the
+VM however you prefer. When asked about compatibility, choose the latest
+available compatibility level. For Guest OS, choose Linux and CentOS 7 (64bit).
+
+When asked to customize the hardware, you should take the following steps:
+
+- remove the existing hard drive
+- click on **Add New Device** and choose **Existing Hard Disk**
+  - Find the uploaded `vmdk` file and then click on the **OK** button
+- choose **Client Device** for **New CD/DVD Drive** and ensure that 
+  **Device Mode** is set to **Passthrough Mode** for that CD/DVD drive
+
+Proceed with creating the VM. Once the VM is created, power it on and proceed
+to the next step.
+
+## Preparing the VM
+
+We'll configure the VM to be used as a template VM by KubeOne and
+machine-controller. Before proceeding, power on the VM via vCenter and open
+the Web Console or connect to the VM via SSH.
+
+Once the VM is booted, you'll see a prompt to enter credentials in the Web
+Console. Login with username `root` and use the password that you've chosen
+earlier.
+
+As a first step, make sure that the VM is up-to-date:
+
+```shell
+yum update
+```
+
+Next, ensure that you have the following packages installed:
+
+```shell
+yum install \
+  cloud-init \
+  open-vm-tools \
+  curl \
+  wget \
+  sudo \
+  vim \
+  epel-release
+```
+
+Once the `epel-release` package is installed, you can install `pip` which
+will be used later:
+
+```shell
+yum install python2-pip
+```
+
+Ensure that a service for VMware Tools is enabled and started:
+
+```shell
+systemctl enable --now vmtoolsd
+```
+
+CentOS 7 comes with an old version of cloud-init which does **not** support
+VMware Tools as a datasource for cloud-config. We'll download a vSphere
+datastore plugin from VMware that extends cloud-init in a way that it can be
+used with VMware Tools. The project is called [cloud-init-guestinfo] and it's
+available on GitHub. The project is archived because it has been integrated
+into cloud-init, but as mentioned, CentOS 7 is using an older cloud-init version
+without this datasource plugin.
+
+[cloud-init-guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
+
+The easiest way to install the latest version of this datasource plugin is by
+using the install script:
+
+```shell
+curl -sSL https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo/master/install.sh | sh -
+```
+
+The script will use `pip` (which we installed earlier) to download needed
+dependencies and install the cloud-init datasource plugin.
+
+Once the datasource plugin is installed, we need to adjust the plugin's
+configuration to allow using it alongside with the integrated NoCloud datasource
+plugin. The NoCloud datasource plugin is required by Kubermatic
+machine-controller. Open the following configuration file in a text editor of
+your choice:
+
+```shell
+vi /etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+```
+
+Replace `datasource_list: [ "VMwareGuestInfo" ]` with the following line:
+
+```yaml
+datasource_list: [ "VMwareGuestInfo", "NoCloud" ]
+```
+
+If there are any additional adjustments that you want to make to the VM, you
+should do those adjustments now before proceeding.
+
+As a final step, we'll cleanup the VM so that it can be used as a template.
+
+First, we'll ensure that there's no hardcoded MAC address in the network
+configuration. Run `ip addr` and note the name of your network interface,
+for example `eth0`. Locate and open a network configuration file for your
+network interface. Network configuration files are located in
+`/etc/sysconfig/network-scripts` and are named as `ifcfg-<interface-name>`.
+For example:
+
+```shell
+vi /etc/sysconfig/network-scripts/ifcfg-eth0
+```
+
+Locate the line starting with `HWADDR=...`. If there's such line, remove it
+completely, then save the file and close the text editor. If there's no such
+line, you don't need to take any action and can just close the text editor.
+
+Then, remove generated SSH host keys. They'll be regenerated upon the next
+boot:
+
+```shell
+rm -f /etc/ssh/ssh_host_*
+```
+
+Proceed to remove logs from `/var/log` and installation logs from the `/root`
+directory:
+
+```shell
+find /var/log -type f -exec truncate --size=0 {} \;
+rm -f /root/anaconda-ks.cfg /root/original-ks.cfg
+```
+
+We can also cleanup temporary directories:
+
+```shell
+rm -rf /tmp/* /var/tmp/*
+```
+
+To make sure VMs are provisioned from the template correctly, we also have to
+reset the seed and machine-id:
+
+```shell
+rm -f /var/lib/systemd/random-seed
+echo -n > /etc/machine-id
+```
+
+Finally, to make sure that cloud-init works as expected, it's recommended to
+clean the cloud-init data:
+
+```shell
+cloud-init clean
+cloud-init clean -l
+```
+
+Finally, power off the VM:
+
+```shell
+poweroff
+```
+
+{{% notice note %}}
+If you ever boot the template VM again, you will need to repeat the cleanup
+steps again.
+{{% /notice %}}
+
+## Conclusion
+
+The VM configuration is now completely done and the VM can be used as a 
+template VM for both Terraform and machine-controller.

--- a/content/kubeone/v1.4/guides/vsphere-template-vm/ubuntu/_index.en.md
+++ b/content/kubeone/v1.4/guides/vsphere-template-vm/ubuntu/_index.en.md
@@ -1,0 +1,267 @@
++++
+title = "Ubuntu Template VM"
+date = 2022-10-31T12:00:00+02:00
+enableToc = true
++++
+
+This guide describes how to create a template VM for vSphere running Ubuntu.
+The template VM is supposed to be compatible with Terraform, Kubermatic KubeOne,
+and Kubermatic machine-controller.
+
+This guide has been tested with Ubuntu 22.04 and vSphere 7.0. Using other
+versions of Ubuntu and/or vSphere might require some adjustments to the guide.
+Concretely speaking, older Ubuntu versions might come with cloud-init not
+compatible with vSphere and vApp. This might require taking addition steps to
+get it working.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}
+
+## Requirements
+
+You need to satisfy the following requirements before proceeding:
+
+* Have access to the vSphere API via `govc` and vCenter
+* Have the `govc` tool installed on your local machine
+
+## Preparing Local Environment
+
+Before getting started, you should prepare your local environment by exporting
+`GOVC_` environment variables with the information about your vSphere setup:
+
+```shell
+export GOVC_URL="https://<url>"
+export GOVC_USERNAME="<username>"
+export GOVC_PASSWORD="<password>"
+export GOVC_INSECURE=false # set to true if you don't have a valid/trusted certificate
+export GOVC_DATASTORE="<datastore-name>"
+```
+
+## Downloading an Ubuntu 22.04 VM
+
+Ubuntu has dedicated [cloud images] built to be used on cloud platforms and
+hypervisors such as vSphere. We'll use an OVA cloud image because it provides
+the best compatibility with vSphere. OVA provides preinstalled Ubuntu VM that
+can be uploaded to vSphere and used as such. That being said, you don't need
+to install Ubuntu manually, that's already done for you.
+
+The [following directory on the cloud images website][cloud-images-jammy]
+contains the latest images for Ubuntu 22.04 (Jammy Jellyfish). Find and download
+an OVA image from that directory or use the `curl` command below. The image
+should be named something like `jammy-server-cloudimg-amd64.ova`. It's
+recommended to verify checksums, but we'll omit that because of brevity.
+
+You can download the image using curl:
+
+```shell
+curl -LO https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.ova
+```
+
+## Preparing Configuration for the VM
+
+The next step is to extract the config from the downloaded OVA file and change
+it as described in this step. We want to ensure that we can login to the VM
+once we upload it to vSphere.
+
+The easiest way to extract the config is using `govc`. The following command
+will save the VM config to a file called `config.json`:
+
+```shell
+govc import.spec jammy-server-cloudimg-amd64.ova > config.json
+```
+
+Edit the `config.json` file in a text editor of your choice:
+- Set `DiskProvisioning` to `thin`
+  ```json
+  ...
+  "DiskProvisioning": "thin",
+  ...
+  ```
+- Set `password` in `PropertyMapping` to a password that you want to use to
+  login to the VM:
+  ```json
+  ...
+    "PropertyMapping": [
+      ...
+      {
+        "Key": "password",
+        "Value": "<your-password>"
+      }
+    ],
+    ...
+  ```
+- Set `Network` in `NetworkMapping` to the name of the network that you want
+  to use:
+  ```json
+  ...
+  "NetworkMapping": [
+    {
+      "Name": "VM Network",
+      "Network": "<network-name>"
+    }
+  ],
+  ...
+  ```
+- Ensure that following properties are configured as below:
+  ```json
+  ...
+  "MarkAsTemplate": false,
+  "PowerOn": false,
+  "InjectOvfEnv": false,
+  "WaitForIP": false,
+  "Name": null
+  ```
+
+With that done, save the file, close the text editor and proceed to the next
+step where we'll upload the VM to vSphere.
+
+## Uploading the VM to vSphere
+
+Now that the VM configuration is ready, we can upload the OVA file to vSphere.
+That can be done using `govc` or via vCenter. We'll use `govc` for purposes
+of this guide:
+
+```bash
+govc import.ova --options config.json jammy-server-cloudimg-amd64.ova
+```
+
+That might take a few minutes depending on your internet connection speed.
+After upload is done, you should be able to see a newly-created VM in the
+vCenter. Note the VM name as we will use it later — it should be something
+along `jammy-server-cloudimg-amd64`.
+
+Once the VM is uploaded, you'll need to upgrade the VM compatibility to version
+15 or newer (it's recommended to use the latest version). Go to vCenter, find
+the VM, right click on it in the right pane, go to the **Compatibility** menu
+and then click on **Upgrade VM Compatibility...**. This should open a pop-up
+window with a dropdown menu where you can choose the VM compatibility level.
+Choose the latest available level and then proceed to upgrade the VM.
+Once the VM is upgraded, go to the next step of this guide to prepare the VM
+to be used as a template VM by KubeOne.
+
+## Preparing the VM
+
+We'll configure the VM to be used as a template VM by KubeOne and
+machine-controller. Before proceeding, power on the VM via vCenter and open
+the Web Console or connect to the VM via SSH.
+
+Once the VM is booted, you'll see a prompt to enter credentials in the Web
+Console. Login with username `ubuntu` and use the password that you've chosen
+earlier when preparing the `config.json` file.
+
+For the sake of simplicity, switch to the `root` user:
+
+```shell
+sudo -i
+```
+
+As a first step, make sure that the VM is up-to-date:
+
+```shell
+apt-get update
+apt-get dist-upgrade -y
+```
+
+Next, ensure that you have cloud-init and VMware Tools installed:
+
+```shell
+apt-get install cloud-init open-vm-tools
+```
+
+Ensure that a service for VMware Tools is enabled and started:
+
+```shell
+systemctl enable --now vmtoolsd
+```
+
+For Ubuntu VMs, you need to take additional steps to ensure that each VM
+cloned from this template VM has unique IP and MAC addresses. More information
+about this can be found in [VMware KB82229].
+
+[VMware KB82229]: https://kb.vmware.com/s/article/82229
+
+Run the following command to reset the `machine-id` property of the VM:
+
+```shell
+echo -n > /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+```
+
+With that done, we need to configure networking for the VM. The following
+step assumes that you want to use DHCP for your VM. This might be different
+depending on your vSphere setup.
+
+List all files in the `/etc/netplan` directory. There should be a file named
+as `50-*.yaml`. Open that file with a text editor of your choice. Remove
+everything from that file and paste the following contents:
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    default:
+      match:
+        name: e*
+      dhcp4: yes
+      dhcp-identifier: mac
+```
+
+Save the file and exit the text editor. Finally, apply the network configuration
+and ensure that you still have network connectivity afterwards.
+
+```shell
+netplan apply
+```
+
+If there are any additional adjustments that you want to make to the VM, you
+should do those adjustments now before proceeding.
+
+To make sure the VM is fresh and can be used as a template, and that vApp
+works as expected, it's recommended to clean the cloud-init data:
+
+```shell
+cloud-init clean
+cloud-init clean -l
+```
+
+Finally, power off the VM:
+
+```shell
+poweroff
+```
+
+{{% notice note %}}
+If you ever boot the template VM again, you will need to repeat steps from
+deleting the machine-id to cleaning the cloud-init data again.
+{{% /notice %}}
+
+## Configuring the VM Properties and Enabling vApp
+
+There are few steps that you should take to ensure the VM will work correctly
+as a template for Terraform and machine-controller.
+
+First, right click on the VM in the right pane and select **Edit Settings...**.
+Ensure that **CD/DVD drive 1** is set to **Client Device**, then click on that
+drive and ensure that **Device Mode** is set to **Passthrough CD-ROM**. Click on
+**OK** button to confirm the changes.
+
+Finally, go to the **Configure** tab and then choose vApp Options. Click on 
+the **Edit** button and ensure that:
+- **Enable vApp options** is checked
+- **IP protocol** is set to the appropriate protocol
+- In the **OVF Details** tab, both **ISO image** and **VMware Tools** must be checked
+
+Confirm the changes by clicking on the **OK** button.
+
+## Conclusion
+
+The VM configuration is now completely done and the VM can be used as a 
+template VM for both Terraform and machine-controller.
+
+[cloud images]: https://cloud-images.ubuntu.com/
+[cloud-images-jammy]: https://cloud-images.ubuntu.com/jammy/current/

--- a/content/kubeone/v1.5/guides/vsphere-template-vm/_index.en.md
+++ b/content/kubeone/v1.5/guides/vsphere-template-vm/_index.en.md
@@ -1,0 +1,20 @@
++++
+title = "Creating vSphere Template VMs"
+date = 2022-10-31T12:00:00+02:00
+enableToc = false
++++
+
+This guide describes how to create templates VMs for vSphere to be used with
+Terraform, Kubermatic KubeOne, and Kubermatic machine-controller. This is an
+umbrella document — we have a dedicated guide for each operating system:
+
+- [Ubuntu]({{< ref "./ubuntu/" >}})
+- [CentOS 7]({{< ref "./centos/" >}})
+
+Guides for other operating systems will be added in the future.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}

--- a/content/kubeone/v1.5/guides/vsphere-template-vm/centos/_index.en.md
+++ b/content/kubeone/v1.5/guides/vsphere-template-vm/centos/_index.en.md
@@ -1,0 +1,251 @@
++++
+title = "CentOS 7 Template VM"
+date = 2022-10-31T12:00:00+02:00
+enableToc = true
++++
+
+This guide describes how to create a template VM for vSphere running CentOS 7.
+The template VM is supposed to be compatible with Terraform, Kubermatic KubeOne,
+and Kubermatic machine-controller.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}
+
+## Requirements
+
+You need to satisfy the following requirements before proceeding:
+
+* Have access to the vSphere API via `govc` and vCenter
+* Have the following tools installed on your local machine: `govc`, `qemu-img`,
+  and `virt-customize` (comes with the `libguestfs-tools` package)
+
+## Preparing Local Environment
+
+Before getting started, you should prepare your local environment by exporting
+`GOVC_` environment variables with the information about your vSphere setup:
+
+```shell
+export GOVC_URL="https://<url>"
+export GOVC_USERNAME="<username>"
+export GOVC_PASSWORD="<password>"
+export GOVC_INSECURE=false # set to true if you don't have a valid/trusted certificate
+export GOVC_DATASTORE="<datastore-name>"
+```
+
+## Downloading CentOS 7 VM
+
+We'll download CentOS 7 `qcow2` image. `qcow2` is a hard drive with preinstalled
+CentOS 7 that can be used for creating (vSphere) VMs. That being said, you don't
+need to install CentOS manually, that's already done for you.
+
+The `qcow2` image can be downloaded from the [official CentOS website][centos].
+Download the latest available `qcow2` file. At the time of writing this document,
+the latest available file is called `CentOS-7-x86_64-GenericCloud-2111.qcow2`.
+It's recommended to verify checksums, but we'll omit that because of brevity.
+
+[centos]: https://cloud.centos.org/centos/7/images/?C=M;O=D
+
+## Preparing and Uploading the CentOS qcow2 File
+
+The downloaded CentOS installation comes in `qcow2` format, however, we need
+VMDK format so that it can be used with vSphere. Additionally, we need to login
+to the VM to configure it. The installation comes with `root` and `centos` users,
+but neither has a password set, so it's not possible to login to the VM using
+those users.
+
+First, we'll set the password for the `root` user using the `virt-customize`
+tool:
+
+```shell
+sudo virt-customize -a CentOS-7-x86_64-GenericCloud-2111.qcow2 --root-password 'password:<insert-your-password-here>'
+```
+
+Customizing the VM might take a minute or two. Once that's done, we can convert
+the `qcow2` file to `vmdk` using `qemu-img`:
+
+```shell
+qemu-img convert -O vmdk -o subformat=streamOptimized "./CentOS-7-x86_64-GenericCloud-2111.qcow2" "CentOS-7-x86_64-GenericCloud-2111.vmdk"
+```
+
+Converting the image to vmdk might take several minutes. Finally, once that is
+done, we can upload the `vmdk` file to vSphere using `govc` or using vCenter.
+We'll use `govc` for purposes of this guide:
+
+```shell
+govc import.vmdk -dc=<datacenter-name> -pool=/<datacenter-name>/host/<cluster-name>/Resources -ds=<datastore-name> "./CentOS-7-x86_64-GenericCloud-2111.vmdk"
+```
+
+That might take a few minutes depending on your internet connection speed.
+In the next step, we'll create a new vSphere VM using the uploaded `vmdk` file
+as the hard drive.
+
+## Creating a Template VM
+
+Go to vCenter and create a new Virtual Machine. You can name and place the
+VM however you prefer. When asked about compatibility, choose the latest
+available compatibility level. For Guest OS, choose Linux and CentOS 7 (64bit).
+
+When asked to customize the hardware, you should take the following steps:
+
+- remove the existing hard drive
+- click on **Add New Device** and choose **Existing Hard Disk**
+  - Find the uploaded `vmdk` file and then click on the **OK** button
+- choose **Client Device** for **New CD/DVD Drive** and ensure that 
+  **Device Mode** is set to **Passthrough Mode** for that CD/DVD drive
+
+Proceed with creating the VM. Once the VM is created, power it on and proceed
+to the next step.
+
+## Preparing the VM
+
+We'll configure the VM to be used as a template VM by KubeOne and
+machine-controller. Before proceeding, power on the VM via vCenter and open
+the Web Console or connect to the VM via SSH.
+
+Once the VM is booted, you'll see a prompt to enter credentials in the Web
+Console. Login with username `root` and use the password that you've chosen
+earlier.
+
+As a first step, make sure that the VM is up-to-date:
+
+```shell
+yum update
+```
+
+Next, ensure that you have the following packages installed:
+
+```shell
+yum install \
+  cloud-init \
+  open-vm-tools \
+  curl \
+  wget \
+  sudo \
+  vim \
+  epel-release
+```
+
+Once the `epel-release` package is installed, you can install `pip` which
+will be used later:
+
+```shell
+yum install python2-pip
+```
+
+Ensure that a service for VMware Tools is enabled and started:
+
+```shell
+systemctl enable --now vmtoolsd
+```
+
+CentOS 7 comes with an old version of cloud-init which does **not** support
+VMware Tools as a datasource for cloud-config. We'll download a vSphere
+datastore plugin from VMware that extends cloud-init in a way that it can be
+used with VMware Tools. The project is called [cloud-init-guestinfo] and it's
+available on GitHub. The project is archived because it has been integrated
+into cloud-init, but as mentioned, CentOS 7 is using an older cloud-init version
+without this datasource plugin.
+
+[cloud-init-guestinfo]: https://github.com/vmware-archive/cloud-init-vmware-guestinfo
+
+The easiest way to install the latest version of this datasource plugin is by
+using the install script:
+
+```shell
+curl -sSL https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo/master/install.sh | sh -
+```
+
+The script will use `pip` (which we installed earlier) to download needed
+dependencies and install the cloud-init datasource plugin.
+
+Once the datasource plugin is installed, we need to adjust the plugin's
+configuration to allow using it alongside with the integrated NoCloud datasource
+plugin. The NoCloud datasource plugin is required by Kubermatic
+machine-controller. Open the following configuration file in a text editor of
+your choice:
+
+```shell
+vi /etc/cloud/cloud.cfg.d/99-DataSourceVMwareGuestInfo.cfg
+```
+
+Replace `datasource_list: [ "VMwareGuestInfo" ]` with the following line:
+
+```yaml
+datasource_list: [ "VMwareGuestInfo", "NoCloud" ]
+```
+
+If there are any additional adjustments that you want to make to the VM, you
+should do those adjustments now before proceeding.
+
+As a final step, we'll cleanup the VM so that it can be used as a template.
+
+First, we'll ensure that there's no hardcoded MAC address in the network
+configuration. Run `ip addr` and note the name of your network interface,
+for example `eth0`. Locate and open a network configuration file for your
+network interface. Network configuration files are located in
+`/etc/sysconfig/network-scripts` and are named as `ifcfg-<interface-name>`.
+For example:
+
+```shell
+vi /etc/sysconfig/network-scripts/ifcfg-eth0
+```
+
+Locate the line starting with `HWADDR=...`. If there's such line, remove it
+completely, then save the file and close the text editor. If there's no such
+line, you don't need to take any action and can just close the text editor.
+
+Then, remove generated SSH host keys. They'll be regenerated upon the next
+boot:
+
+```shell
+rm -f /etc/ssh/ssh_host_*
+```
+
+Proceed to remove logs from `/var/log` and installation logs from the `/root`
+directory:
+
+```shell
+find /var/log -type f -exec truncate --size=0 {} \;
+rm -f /root/anaconda-ks.cfg /root/original-ks.cfg
+```
+
+We can also cleanup temporary directories:
+
+```shell
+rm -rf /tmp/* /var/tmp/*
+```
+
+To make sure VMs are provisioned from the template correctly, we also have to
+reset the seed and machine-id:
+
+```shell
+rm -f /var/lib/systemd/random-seed
+echo -n > /etc/machine-id
+```
+
+Finally, to make sure that cloud-init works as expected, it's recommended to
+clean the cloud-init data:
+
+```shell
+cloud-init clean
+cloud-init clean -l
+```
+
+Finally, power off the VM:
+
+```shell
+poweroff
+```
+
+{{% notice note %}}
+If you ever boot the template VM again, you will need to repeat the cleanup
+steps again.
+{{% /notice %}}
+
+## Conclusion
+
+The VM configuration is now completely done and the VM can be used as a 
+template VM for both Terraform and machine-controller.

--- a/content/kubeone/v1.5/guides/vsphere-template-vm/ubuntu/_index.en.md
+++ b/content/kubeone/v1.5/guides/vsphere-template-vm/ubuntu/_index.en.md
@@ -1,0 +1,267 @@
++++
+title = "Ubuntu Template VM"
+date = 2022-10-31T12:00:00+02:00
+enableToc = true
++++
+
+This guide describes how to create a template VM for vSphere running Ubuntu.
+The template VM is supposed to be compatible with Terraform, Kubermatic KubeOne,
+and Kubermatic machine-controller.
+
+This guide has been tested with Ubuntu 22.04 and vSphere 7.0. Using other
+versions of Ubuntu and/or vSphere might require some adjustments to the guide.
+Concretely speaking, older Ubuntu versions might come with cloud-init not
+compatible with vSphere and vApp. This might require taking addition steps to
+get it working.
+
+{{% notice warning %}}
+The **template VM** in this guide refers to a regular vSphere VM and not VM
+Templates according to the vSphere terminology. The difference is quite subtle,
+but VM Templates are not supported yet by machine-controller.
+{{% /notice %}}
+
+## Requirements
+
+You need to satisfy the following requirements before proceeding:
+
+* Have access to the vSphere API via `govc` and vCenter
+* Have the `govc` tool installed on your local machine
+
+## Preparing Local Environment
+
+Before getting started, you should prepare your local environment by exporting
+`GOVC_` environment variables with the information about your vSphere setup:
+
+```shell
+export GOVC_URL="https://<url>"
+export GOVC_USERNAME="<username>"
+export GOVC_PASSWORD="<password>"
+export GOVC_INSECURE=false # set to true if you don't have a valid/trusted certificate
+export GOVC_DATASTORE="<datastore-name>"
+```
+
+## Downloading an Ubuntu 22.04 VM
+
+Ubuntu has dedicated [cloud images] built to be used on cloud platforms and
+hypervisors such as vSphere. We'll use an OVA cloud image because it provides
+the best compatibility with vSphere. OVA provides preinstalled Ubuntu VM that
+can be uploaded to vSphere and used as such. That being said, you don't need
+to install Ubuntu manually, that's already done for you.
+
+The [following directory on the cloud images website][cloud-images-jammy]
+contains the latest images for Ubuntu 22.04 (Jammy Jellyfish). Find and download
+an OVA image from that directory or use the `curl` command below. The image
+should be named something like `jammy-server-cloudimg-amd64.ova`. It's
+recommended to verify checksums, but we'll omit that because of brevity.
+
+You can download the image using curl:
+
+```shell
+curl -LO https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.ova
+```
+
+## Preparing Configuration for the VM
+
+The next step is to extract the config from the downloaded OVA file and change
+it as described in this step. We want to ensure that we can login to the VM
+once we upload it to vSphere.
+
+The easiest way to extract the config is using `govc`. The following command
+will save the VM config to a file called `config.json`:
+
+```shell
+govc import.spec jammy-server-cloudimg-amd64.ova > config.json
+```
+
+Edit the `config.json` file in a text editor of your choice:
+- Set `DiskProvisioning` to `thin`
+  ```json
+  ...
+  "DiskProvisioning": "thin",
+  ...
+  ```
+- Set `password` in `PropertyMapping` to a password that you want to use to
+  login to the VM:
+  ```json
+  ...
+    "PropertyMapping": [
+      ...
+      {
+        "Key": "password",
+        "Value": "<your-password>"
+      }
+    ],
+    ...
+  ```
+- Set `Network` in `NetworkMapping` to the name of the network that you want
+  to use:
+  ```json
+  ...
+  "NetworkMapping": [
+    {
+      "Name": "VM Network",
+      "Network": "<network-name>"
+    }
+  ],
+  ...
+  ```
+- Ensure that following properties are configured as below:
+  ```json
+  ...
+  "MarkAsTemplate": false,
+  "PowerOn": false,
+  "InjectOvfEnv": false,
+  "WaitForIP": false,
+  "Name": null
+  ```
+
+With that done, save the file, close the text editor and proceed to the next
+step where we'll upload the VM to vSphere.
+
+## Uploading the VM to vSphere
+
+Now that the VM configuration is ready, we can upload the OVA file to vSphere.
+That can be done using `govc` or via vCenter. We'll use `govc` for purposes
+of this guide:
+
+```bash
+govc import.ova --options config.json jammy-server-cloudimg-amd64.ova
+```
+
+That might take a few minutes depending on your internet connection speed.
+After upload is done, you should be able to see a newly-created VM in the
+vCenter. Note the VM name as we will use it later — it should be something
+along `jammy-server-cloudimg-amd64`.
+
+Once the VM is uploaded, you'll need to upgrade the VM compatibility to version
+15 or newer (it's recommended to use the latest version). Go to vCenter, find
+the VM, right click on it in the right pane, go to the **Compatibility** menu
+and then click on **Upgrade VM Compatibility...**. This should open a pop-up
+window with a dropdown menu where you can choose the VM compatibility level.
+Choose the latest available level and then proceed to upgrade the VM.
+Once the VM is upgraded, go to the next step of this guide to prepare the VM
+to be used as a template VM by KubeOne.
+
+## Preparing the VM
+
+We'll configure the VM to be used as a template VM by KubeOne and
+machine-controller. Before proceeding, power on the VM via vCenter and open
+the Web Console or connect to the VM via SSH.
+
+Once the VM is booted, you'll see a prompt to enter credentials in the Web
+Console. Login with username `ubuntu` and use the password that you've chosen
+earlier when preparing the `config.json` file.
+
+For the sake of simplicity, switch to the `root` user:
+
+```shell
+sudo -i
+```
+
+As a first step, make sure that the VM is up-to-date:
+
+```shell
+apt-get update
+apt-get dist-upgrade -y
+```
+
+Next, ensure that you have cloud-init and VMware Tools installed:
+
+```shell
+apt-get install cloud-init open-vm-tools
+```
+
+Ensure that a service for VMware Tools is enabled and started:
+
+```shell
+systemctl enable --now vmtoolsd
+```
+
+For Ubuntu VMs, you need to take additional steps to ensure that each VM
+cloned from this template VM has unique IP and MAC addresses. More information
+about this can be found in [VMware KB82229].
+
+[VMware KB82229]: https://kb.vmware.com/s/article/82229
+
+Run the following command to reset the `machine-id` property of the VM:
+
+```shell
+echo -n > /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+```
+
+With that done, we need to configure networking for the VM. The following
+step assumes that you want to use DHCP for your VM. This might be different
+depending on your vSphere setup.
+
+List all files in the `/etc/netplan` directory. There should be a file named
+as `50-*.yaml`. Open that file with a text editor of your choice. Remove
+everything from that file and paste the following contents:
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    default:
+      match:
+        name: e*
+      dhcp4: yes
+      dhcp-identifier: mac
+```
+
+Save the file and exit the text editor. Finally, apply the network configuration
+and ensure that you still have network connectivity afterwards.
+
+```shell
+netplan apply
+```
+
+If there are any additional adjustments that you want to make to the VM, you
+should do those adjustments now before proceeding.
+
+To make sure the VM is fresh and can be used as a template, and that vApp
+works as expected, it's recommended to clean the cloud-init data:
+
+```shell
+cloud-init clean
+cloud-init clean -l
+```
+
+Finally, power off the VM:
+
+```shell
+poweroff
+```
+
+{{% notice note %}}
+If you ever boot the template VM again, you will need to repeat steps from
+deleting the machine-id to cleaning the cloud-init data again.
+{{% /notice %}}
+
+## Configuring the VM Properties and Enabling vApp
+
+There are few steps that you should take to ensure the VM will work correctly
+as a template for Terraform and machine-controller.
+
+First, right click on the VM in the right pane and select **Edit Settings...**.
+Ensure that **CD/DVD drive 1** is set to **Client Device**, then click on that
+drive and ensure that **Device Mode** is set to **Passthrough CD-ROM**. Click on
+**OK** button to confirm the changes.
+
+Finally, go to the **Configure** tab and then choose vApp Options. Click on 
+the **Edit** button and ensure that:
+- **Enable vApp options** is checked
+- **IP protocol** is set to the appropriate protocol
+- In the **OVF Details** tab, both **ISO image** and **VMware Tools** must be checked
+
+Confirm the changes by clicking on the **OK** button.
+
+## Conclusion
+
+The VM configuration is now completely done and the VM can be used as a 
+template VM for both Terraform and machine-controller.
+
+[cloud images]: https://cloud-images.ubuntu.com/
+[cloud-images-jammy]: https://cloud-images.ubuntu.com/jammy/current/


### PR DESCRIPTION
This PR adds guides for creating vSphere template VMs running Ubuntu 22.04 and CentOS 7. Those guides have been written in a way that resulting template VMs are compatible with Terraform, vApp, KubeOne, and machine-controller. The guides are written based on experience with creating template VMs for KubeOne on our new vSphere infrastructure.

We should also create guides for Rocky Linux, RHEL, and Flatcar Linux. This will be done at some point in the future. I'll create follow-up issues once this PR is merged.

/assign @kron4eg @ahmedwaleedmalik @moadqassem @WeirdMachine 
/hold
for review by @moadqassem and/or @WeirdMachine 