### PR TITLE
Update swagger specs from patch releases 2.21.3, 2.20.10 and 2.19.12

### DIFF
--- a/content/kubermatic/v2.19/data/swagger.json
+++ b/content/kubermatic/v2.19/data/swagger.json
@@ -17500,7 +17500,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Preset"
+              "$ref": "#/definitions/PresetBody"
             }
           }
         ],
@@ -17550,7 +17550,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Preset"
+              "$ref": "#/definitions/PresetBody"
             }
           }
         ],
@@ -18048,6 +18048,36 @@
     }
   },
   "definitions": {
+    "AKS": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "x-go-name": "ClientID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "x-go-name": "ClientSecret"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "subscriptionId": {
+          "type": "string",
+          "x-go-name": "SubscriptionID"
+        },
+        "tenantId": {
+          "type": "string",
+          "x-go-name": "TenantID"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "AKSCloudSpec": {
       "type": "object",
       "properties": {
@@ -18124,6 +18154,56 @@
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
+    },
+    "AWS": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string",
+          "x-go-name": "AccessKeyID"
+        },
+        "assumeRoleARN": {
+          "type": "string",
+          "x-go-name": "AssumeRoleARN"
+        },
+        "assumeRoleExternalID": {
+          "type": "string",
+          "x-go-name": "AssumeRoleExternalID"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "instanceProfileName": {
+          "type": "string",
+          "x-go-name": "InstanceProfileName"
+        },
+        "roleARN": {
+          "type": "string",
+          "x-go-name": "ControlPlaneRoleARN"
+        },
+        "routeTableId": {
+          "type": "string",
+          "x-go-name": "RouteTableID"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "x-go-name": "SecretAccessKey"
+        },
+        "securityGroupID": {
+          "type": "string",
+          "x-go-name": "SecurityGroupID"
+        },
+        "vpcId": {
+          "type": "string",
+          "x-go-name": "VPCID"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "AWSCloudSpec": {
       "type": "object",
@@ -18896,6 +18976,28 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
     },
+    "Alibaba": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string",
+          "x-go-name": "AccessKeyID"
+        },
+        "accessKeySecret": {
+          "type": "string",
+          "x-go-name": "AccessKeySecret"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "AlibabaCloudSpec": {
       "type": "object",
       "title": "AlibabaCloudSpec specifies the access data to Alibaba.",
@@ -19050,6 +19152,25 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
+    "Anexia": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "token": {
+          "description": "Token is used to authenticate with the Anexia API.",
+          "type": "string",
+          "x-go-name": "Token"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "AnexiaCloudSpec": {
       "type": "object",
       "title": "AnexiaCloudSpec specifies the access data to Anexia.",
@@ -19159,6 +19280,63 @@
     },
     "AuditPolicyPreset": {
       "type": "string",
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
+    "Azure": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "x-go-name": "ClientID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "x-go-name": "ClientSecret"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "loadBalancerSKU": {
+          "$ref": "#/definitions/LBSKU"
+        },
+        "resourceGroup": {
+          "type": "string",
+          "x-go-name": "ResourceGroup"
+        },
+        "routeTable": {
+          "type": "string",
+          "x-go-name": "RouteTableName"
+        },
+        "securityGroup": {
+          "type": "string",
+          "x-go-name": "SecurityGroup"
+        },
+        "subnet": {
+          "type": "string",
+          "x-go-name": "SubnetName"
+        },
+        "subscriptionId": {
+          "type": "string",
+          "x-go-name": "SubscriptionID"
+        },
+        "tenantId": {
+          "type": "string",
+          "x-go-name": "TenantID"
+        },
+        "vnet": {
+          "type": "string",
+          "x-go-name": "VNetName"
+        },
+        "vnetResourceGroup": {
+          "type": "string",
+          "x-go-name": "VNetResourceGroup"
+        }
+      },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "AzureAvailabilityZonesList": {
@@ -21240,6 +21418,25 @@
       },
       "x-go-package": "kubevirt.io/api/core/v1"
     },
+    "Digitalocean": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "token": {
+          "description": "Token is used to authenticate with the DigitalOcean API.",
+          "type": "string",
+          "x-go-name": "Token"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "DigitaloceanCloudSpec": {
       "type": "object",
       "title": "DigitaloceanCloudSpec specifies access data to DigitalOcean.",
@@ -21515,6 +21712,32 @@
         }
       },
       "x-go-package": "kubevirt.io/api/core/v1"
+    },
+    "EKS": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string",
+          "x-go-name": "AccessKeyID"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "region": {
+          "type": "string",
+          "x-go-name": "Region"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "x-go-name": "SecretAccessKey"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "EKSCloudSpec": {
       "type": "object",
@@ -22131,6 +22354,24 @@
       },
       "x-go-package": "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
     },
+    "Fake": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "token": {
+          "type": "string",
+          "x-go-name": "Token"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "FakeCloudSpec": {
       "type": "object",
       "title": "FakeCloudSpec specifies access data for a fake cloud.",
@@ -22361,6 +22602,32 @@
         }
       },
       "x-go-package": "kubevirt.io/api/core/v1"
+    },
+    "GCP": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "network": {
+          "type": "string",
+          "x-go-name": "Network"
+        },
+        "serviceAccount": {
+          "type": "string",
+          "x-go-name": "ServiceAccount"
+        },
+        "subnetwork": {
+          "type": "string",
+          "x-go-name": "Subnetwork"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "GCPCloudSpec": {
       "type": "object",
@@ -22608,6 +22875,24 @@
         "$ref": "#/definitions/GCPZone"
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "GKE": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "serviceAccount": {
+          "type": "string",
+          "x-go-name": "ServiceAccount"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "GKEAutoprovisioningNodePoolDefaults": {
       "description": "GKEAutoprovisioningNodePoolDefaults\ncontains defaults for a node pool created by NAP.",
@@ -23190,6 +23475,30 @@
     "HealthStatus": {
       "type": "integer",
       "format": "int64",
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
+    "Hetzner": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "network": {
+          "description": "Network is the pre-existing Hetzner network in which the machines are running.\nWhile machines can be in multiple networks, a single one must be chosen for the\nHCloud CCM to work.\nIf this is empty, the network configured on the datacenter will be used.",
+          "type": "string",
+          "x-go-name": "Network"
+        },
+        "token": {
+          "description": "Token is used to authenticate with the Hetzner API.",
+          "type": "string",
+          "x-go-name": "Token"
+        }
+      },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "HetznerCloudSpec": {
@@ -23872,6 +24181,24 @@
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "Kubevirt": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "kubeconfig": {
+          "type": "string",
+          "x-go-name": "Kubeconfig"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "KubevirtCloudSpec": {
       "type": "object",
@@ -24918,6 +25245,40 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
     },
+    "Nutanix": {
+      "type": "object",
+      "properties": {
+        "clusterName": {
+          "type": "string",
+          "x-go-name": "ClusterName"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "projectName": {
+          "type": "string",
+          "x-go-name": "ProjectName"
+        },
+        "proxyURL": {
+          "type": "string",
+          "x-go-name": "ProxyURL"
+        },
+        "username": {
+          "type": "string",
+          "x-go-name": "Username"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "NutanixCloudSpec": {
       "description": "NUTANIX IMPLEMENTATION IS EXPERIMENTAL AND UNSUPPORTED.",
       "type": "object",
@@ -25258,6 +25619,80 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
+    "Openstack": {
+      "type": "object",
+      "properties": {
+        "applicationCredentialID": {
+          "type": "string",
+          "x-go-name": "ApplicationCredentialID"
+        },
+        "applicationCredentialSecret": {
+          "type": "string",
+          "x-go-name": "ApplicationCredentialSecret"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "domain": {
+          "type": "string",
+          "x-go-name": "Domain"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "floatingIpPool": {
+          "type": "string",
+          "x-go-name": "FloatingIPPool"
+        },
+        "network": {
+          "type": "string",
+          "x-go-name": "Network"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "project": {
+          "type": "string",
+          "x-go-name": "Project"
+        },
+        "projectID": {
+          "type": "string",
+          "x-go-name": "ProjectID"
+        },
+        "routerID": {
+          "type": "string",
+          "x-go-name": "RouterID"
+        },
+        "securityGroups": {
+          "type": "string",
+          "x-go-name": "SecurityGroups"
+        },
+        "subnetID": {
+          "type": "string",
+          "x-go-name": "SubnetID"
+        },
+        "tenant": {
+          "type": "string",
+          "x-go-name": "Tenant"
+        },
+        "tenantID": {
+          "type": "string",
+          "x-go-name": "TenantID"
+        },
+        "useToken": {
+          "type": "boolean",
+          "x-go-name": "UseToken"
+        },
+        "username": {
+          "type": "string",
+          "x-go-name": "Username"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "OpenstackAvailabilityZone": {
       "type": "object",
       "title": "OpenstackAvailabilityZone is the object representing a openstack availability zone.",
@@ -25590,6 +26025,32 @@
       },
       "x-go-package": "kubevirt.io/api/core/v1"
     },
+    "Packet": {
+      "type": "object",
+      "properties": {
+        "apiKey": {
+          "type": "string",
+          "x-go-name": "APIKey"
+        },
+        "billingCycle": {
+          "type": "string",
+          "x-go-name": "BillingCycle"
+        },
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "projectId": {
+          "type": "string",
+          "x-go-name": "ProjectID"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+    },
     "PacketCPU": {
       "type": "object",
       "title": "PacketCPU represents an array of Packet CPUs. It is a part of PacketSize.",
@@ -25862,6 +26323,31 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
     },
+    "PresetBody": {
+      "description": "PresetBody represents the body of a created preset",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "spec": {
+          "$ref": "#/definitions/PresetSpec"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
+    },
+    "PresetBodyMetadata": {
+      "description": "PresetBodyMetadata represents metadata within the body of a created preset",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
+    },
     "PresetList": {
       "description": "PresetList represents a list of presets",
       "type": "object",
@@ -25889,6 +26375,78 @@
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
+    },
+    "PresetSpec": {
+      "description": "Presets specifies default presets for supported providers",
+      "type": "object",
+      "properties": {
+        "aks": {
+          "$ref": "#/definitions/AKS"
+        },
+        "alibaba": {
+          "$ref": "#/definitions/Alibaba"
+        },
+        "anexia": {
+          "$ref": "#/definitions/Anexia"
+        },
+        "aws": {
+          "$ref": "#/definitions/AWS"
+        },
+        "azure": {
+          "$ref": "#/definitions/Azure"
+        },
+        "digitalocean": {
+          "$ref": "#/definitions/Digitalocean"
+        },
+        "eks": {
+          "$ref": "#/definitions/EKS"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "fake": {
+          "$ref": "#/definitions/Fake"
+        },
+        "gcp": {
+          "$ref": "#/definitions/GCP"
+        },
+        "gke": {
+          "$ref": "#/definitions/GKE"
+        },
+        "hetzner": {
+          "$ref": "#/definitions/Hetzner"
+        },
+        "kubevirt": {
+          "$ref": "#/definitions/Kubevirt"
+        },
+        "nutanix": {
+          "$ref": "#/definitions/Nutanix"
+        },
+        "openstack": {
+          "$ref": "#/definitions/Openstack"
+        },
+        "packet": {
+          "$ref": "#/definitions/Packet"
+        },
+        "requiredEmailDomain": {
+          "description": "see RequiredEmails",
+          "type": "string",
+          "x-go-name": "RequiredEmailDomain"
+        },
+        "requiredEmails": {
+          "description": "RequiredEmails: specify emails and domains\nRequiredEmailDomain is appended to RequiredEmails for backward compatibility.\ne.g.:\nRequiredEmailDomain: \"example.com\"\nRequiredEmails: [\"foo.com\", \"foo.bar@test.com\"]\nResult:\n@example.com, *@foo.com and foo.bar@test.com can use the Preset",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "RequiredEmails"
+        },
+        "vsphere": {
+          "$ref": "#/definitions/VSphere"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "Project": {
       "description": "Project is a top-level container for a set of resources",
@@ -25965,6 +26523,20 @@
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
+    "ProviderPreset": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "ProviderType": {
       "type": "string",
@@ -27350,6 +27922,44 @@
         }
       },
       "x-go-package": "kubevirt.io/api/core/v1"
+    },
+    "VSphere": {
+      "type": "object",
+      "properties": {
+        "datacenter": {
+          "type": "string",
+          "x-go-name": "Datacenter"
+        },
+        "datastore": {
+          "type": "string",
+          "x-go-name": "Datastore"
+        },
+        "datastoreCluster": {
+          "type": "string",
+          "x-go-name": "DatastoreCluster"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-go-name": "Enabled"
+        },
+        "password": {
+          "type": "string",
+          "x-go-name": "Password"
+        },
+        "resourcePool": {
+          "type": "string",
+          "x-go-name": "ResourcePool"
+        },
+        "username": {
+          "type": "string",
+          "x-go-name": "Username"
+        },
+        "vmNetName": {
+          "type": "string",
+          "x-go-name": "VMNetName"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
     },
     "VSphereCloudSpec": {
       "type": "object",

--- a/content/kubermatic/v2.20/data/swagger.json
+++ b/content/kubermatic/v2.20/data/swagger.json
@@ -19179,6 +19179,27 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
     },
+    "AnexiaDiskConfig": {
+      "description": "AnexiaDiskConfig defines a single disk for a node at anexia",
+      "type": "object",
+      "required": [
+        "size"
+      ],
+      "properties": {
+        "performanceType": {
+          "description": "PerformanceType configures the performance type this disks of each node will have.\nKnown values are something like \"ENT3\" or \"HPC2\".",
+          "type": "string",
+          "x-go-name": "PerformanceType"
+        },
+        "size": {
+          "description": "Disks configures this disk of each node will have.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Size"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
     "AnexiaNodeSpec": {
       "description": "AnexiaNodeSpec anexia specific node settings",
       "type": "object",
@@ -19186,8 +19207,7 @@
         "vlanID",
         "templateID",
         "cpus",
-        "memory",
-        "diskSize"
+        "memory"
       ],
       "properties": {
         "cpus": {
@@ -19197,10 +19217,18 @@
           "x-go-name": "CPUs"
         },
         "diskSize": {
-          "description": "DiskSize states the disk size that node will have.",
+          "description": "DiskSize states the disk size that node will have.\nDeprecated: please use the new Disks attribute instead.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "DiskSize"
+        },
+        "disks": {
+          "description": "Disks configures the disks each node will have.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnexiaDiskConfig"
+          },
+          "x-go-name": "Disks"
         },
         "memory": {
           "description": "Memory states the memory that node will have.",
@@ -20716,6 +20744,36 @@
         }
       },
       "x-go-package": "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+    },
+    "ContainerRuntimeContainerd": {
+      "type": "object",
+      "title": "ContainerRuntimeContainerd defines containerd container runtime registries configs.",
+      "properties": {
+        "registries": {
+          "description": "A map of registries to use to render configs and mirrors for containerd registries",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ContainerdRegistry"
+          },
+          "x-go-name": "Registries"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+    },
+    "ContainerdRegistry": {
+      "type": "object",
+      "title": "ContainerdRegistry defines endpoints and security for given container registry.",
+      "properties": {
+        "mirrors": {
+          "description": "List of registry mirrors to use",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Mirrors"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
     },
     "ControlPlaneMetrics": {
       "description": "ControlPlaneMetrics defines a metric for the user cluster control plane resources",
@@ -22629,6 +22687,7 @@
           "x-go-name": "NodePortsAllowedIPRange"
         },
         "serviceAccount": {
+          "description": "The Google Service Account (JSON format), encoded with base64.",
           "type": "string",
           "x-go-name": "ServiceAccount"
         },
@@ -24189,7 +24248,12 @@
         "credentialsReference": {
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },
+        "csiKubeconfig": {
+          "type": "string",
+          "x-go-name": "CSIKubeconfig"
+        },
         "kubeconfig": {
+          "description": "The cluster's kubeconfig file, encoded with base64.",
           "type": "string",
           "x-go-name": "Kubeconfig"
         }
@@ -25029,6 +25093,9 @@
       "type": "object",
       "title": "NodeSettings are node specific flags which can be configured on datacenter level.",
       "properties": {
+        "containerdRegistryMirrors": {
+          "$ref": "#/definitions/ContainerRuntimeContainerd"
+        },
         "httpProxy": {
           "$ref": "#/definitions/ProxyValue"
         },

--- a/content/kubermatic/v2.21/data/swagger.json
+++ b/content/kubermatic/v2.21/data/swagger.json
@@ -22023,6 +22023,11 @@
         "credentialsReference": {
           "$ref": "#/definitions/GlobalSecretKeySelector"
         },
+        "disableIAMReconciling": {
+          "description": "DisableIAMReconciling is used to disable reconciliation for IAM related configuration. This is useful in air-gapped\nsetups where access to IAM service is not possible.",
+          "type": "boolean",
+          "x-go-name": "DisableIAMReconciling"
+        },
         "instanceProfileName": {
           "type": "string",
           "x-go-name": "InstanceProfileName"
@@ -23009,6 +23014,27 @@
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
     },
+    "AnexiaDiskConfig": {
+      "description": "AnexiaDiskConfig defines a single disk for a node at anexia",
+      "type": "object",
+      "required": [
+        "size"
+      ],
+      "properties": {
+        "performanceType": {
+          "description": "PerformanceType configures the performance type this disks of each node will have.\nKnown values are something like \"ENT3\" or \"HPC2\".",
+          "type": "string",
+          "x-go-name": "PerformanceType"
+        },
+        "size": {
+          "description": "Disks configures this disk of each node will have.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Size"
+        }
+      },
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v1"
+    },
     "AnexiaNodeSpec": {
       "description": "AnexiaNodeSpec anexia specific node settings",
       "type": "object",
@@ -23016,8 +23042,7 @@
         "vlanID",
         "templateID",
         "cpus",
-        "memory",
-        "diskSize"
+        "memory"
       ],
       "properties": {
         "cpus": {
@@ -23027,10 +23052,18 @@
           "x-go-name": "CPUs"
         },
         "diskSize": {
-          "description": "DiskSize states the disk size that node will have.",
+          "description": "DiskSize states the disk size that node will have.\nDeprecated: please use the new Disks attribute instead.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "DiskSize"
+        },
+        "disks": {
+          "description": "Disks configures the disks each node will have.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnexiaDiskConfig"
+          },
+          "x-go-name": "Disks"
         },
         "memory": {
           "description": "Memory states the memory that node will have.",
@@ -23334,7 +23367,7 @@
           "$ref": "#/definitions/RawExtension"
         }
       },
-      "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
     },
     "ApplicationInstallationStatus": {
       "type": "object",
@@ -24447,6 +24480,9 @@
         },
         "eventRateLimitConfig": {
           "$ref": "#/definitions/EventRateLimitConfig"
+        },
+        "exposeStrategy": {
+          "$ref": "#/definitions/ExposeStrategy"
         },
         "kubernetesDashboard": {
           "$ref": "#/definitions/KubernetesDashboard"
@@ -29287,7 +29323,7 @@
           "x-go-name": "Name"
         }
       },
-      "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+      "x-go-package": "k8c.io/kubermatic/v2/pkg/api/v2"
     },
     "NetworkDefaults": {
       "type": "object",


### PR DESCRIPTION
Swagger specs are outdated in our docs because they're only synced automatically up to the initial minor release. This bumps the files to what is on `cmd/kubermatic-api/swagger.json` for the respective release tags.