### PR TITLE
Copy over vSphere needed permissions for KKP

### DIFF
--- a/content/kubermatic/main/architecture/supported-providers/vSphere/vSphere.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/vSphere/vSphere.en.md
@@ -62,11 +62,12 @@ As this Config must also be deployed onto each worker node of a user cluster, it
 
 The vsphere user has to have to following permissions on the correct resources:
 
-#### Seed Cluster
+#### User Cluster Could Controller Manager / CSI
+**Note:** Below roles were updated based on [vsphere-storage-plugin-roles] for external CCM which is available from kkp v2.18+ and vsphere v7.0.2+
 
-For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-seed-cluster`) is needed:
+For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-ccm-cluster`) is needed:
 
-* Role `k8c-storage-vmfolder-propagate`
+* Role `k8c-ccm-storage-vmfolder-propagate`
   * Granted at **VM Folder** and **Template Folder**, propagated
   * Permissions
     * Virtual machine
@@ -79,17 +80,39 @@ For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-s
       * Create folder
       * Delete dolder
 
-* Role `k8c-storage-datastore-propagate`
+```
+$ govc role.ls k8c-ccm-storage-vmfolder-propagate
+Folder.Create
+Folder.Delete
+VirtualMachine.Config.AddExistingDisk
+VirtualMachine.Config.AddNewDisk
+VirtualMachine.Config.AddRemoveDevice
+VirtualMachine.Config.RemoveDisk
+```
+
+* Role `k8c-ccm-storage-datastore-propagate`
   * Granted at **Datastore**, propagated
   * Permissions
     * Datastore
       * Allocate space
       * Low level file operations
 
+```
+$ govc role.ls k8c-ccm-storage-datastore-propagate
+Datastore.AllocateSpace
+Datastore.FileManagement
+```
+
 * Role `Read-only` (predefined)
   * Granted at ..., **not** propagated
     * Datacenter
 
+```
+$ govc role.ls ReadOnly
+System.Anonymous
+System.Read
+System.View
+```
 #### User Cluster
 
 For provisioning actions of the KKP in scope of an user cluster, a technical user (e.g. `cust-user-cluster`) is needed:
@@ -98,12 +121,26 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
   * Granted at **vcenter** level, **not** propagated
   * Needed to customize VM during provisioning
   * Permissions
+    * CNS
+      * Searchable
     * Profile-driven storage
       * Profile-driven storage view
     * VirtualMachine
       * Provisioning
         * Modify customization specification
         * Read customization specifications
+
+```
+$ govc role.ls k8c-user-vcenter
+Cns.Searchable
+InventoryService.Tagging.ObjectAttachable
+StorageProfile.View
+System.Anonymous
+System.Read
+System.View
+VirtualMachine.Provisioning.ModifyCustSpecs
+VirtualMachine.Provisioning.ReadCustSpecs
+```
 
 * Role `k8c-user-datacenter`
   * Granted at **datacenter** level, **not** propagated
@@ -124,12 +161,31 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
     * Inventory
       * Create from existing
 
+```
+$ govc role.ls k8c-user-datacenter
+Datastore.AllocateSpace
+Datastore.Browse
+Datastore.DeleteFile
+Datastore.FileManagement
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
+VApp.ApplicationConfig
+VApp.InstanceConfig
+VirtualMachine.Config.CPUCount
+VirtualMachine.Config.Memory
+VirtualMachine.Config.Settings
+VirtualMachine.Inventory.CreateFromExisting
+```
+
 * Role `k8c-user-cluster-propagate`
   * Granted at **cluster** level, propagated
   * Needed for upload of `cloud-init.iso` (Ubuntu and CentOS) or defining the Ignition config into Guestinfo (CoreOS)
   * Permissions
     * Host
       * Configuration
+        * Storage partition configuration
         * System Management
       * Local operations
         * Reconfigure virtual machine
@@ -141,11 +197,29 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
       * vApp application configuration
       * vApp instance configuration
 
-* Role k8s-network-attach
+```
+$ govc role.ls k8c-user-cluster-propagate
+Folder.Create
+Host.Config.Storage
+Host.Config.SystemManagement
+Host.Local.ReconfigVM
+Resource.AssignVMToPool
+Resource.ColdMigrate
+Resource.HotMigrate
+VApp.ApplicationConfig
+VApp.InstanceConfig
+```
+
+* Role k8c-network-attach
   * Granted for each network that should be used (distributed switch + network)
   * Permissions
     * Network
       * Assign network
+
+```
+$ govc role.ls k8c-network-attach
+Network.Assign
+```
 
 * Role `k8c-user-datastore-propagate`
   * Granted at **datastore / datastore cluster** level, propagated
@@ -154,6 +228,13 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
       * Allocate space
       * Browse datastore
       * Low level file operations
+
+```
+$ govc role.ls k8c-user-datastore-propagate
+Datastore.AllocateSpace
+Datastore.Browse
+Datastore.FileManagement
+```
 
 * Role `k8c-user-folder-propagate`
   * Granted at **VM Folder** and **Template Folder** level, propagated
@@ -172,7 +253,104 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
       * Provisioning
       * Snapshot management
 
-The described permissions have been tested with vSphere 6.7 and might be different for other vSphere versions.
+```
+$ govc role.ls k8c-user-folder-propagate
+Folder.Create
+Folder.Delete
+Global.SetCustomField
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
+VirtualMachine.Config.AddExistingDisk
+VirtualMachine.Config.AddNewDisk
+VirtualMachine.Config.AddRemoveDevice
+VirtualMachine.Config.AdvancedConfig
+VirtualMachine.Config.Annotation
+VirtualMachine.Config.CPUCount
+VirtualMachine.Config.ChangeTracking
+VirtualMachine.Config.DiskExtend
+VirtualMachine.Config.DiskLease
+VirtualMachine.Config.EditDevice
+VirtualMachine.Config.HostUSBDevice
+VirtualMachine.Config.ManagedBy
+VirtualMachine.Config.Memory
+VirtualMachine.Config.MksControl
+VirtualMachine.Config.QueryFTCompatibility
+VirtualMachine.Config.QueryUnownedFiles
+VirtualMachine.Config.RawDevice
+VirtualMachine.Config.ReloadFromPath
+VirtualMachine.Config.RemoveDisk
+VirtualMachine.Config.Rename
+VirtualMachine.Config.ResetGuestInfo
+VirtualMachine.Config.Resource
+VirtualMachine.Config.Settings
+VirtualMachine.Config.SwapPlacement
+VirtualMachine.Config.ToggleForkParent
+VirtualMachine.Config.Unlock
+VirtualMachine.Config.UpgradeVirtualHardware
+VirtualMachine.GuestOperations.Execute
+VirtualMachine.GuestOperations.Modify
+VirtualMachine.GuestOperations.ModifyAliases
+VirtualMachine.GuestOperations.Query
+VirtualMachine.GuestOperations.QueryAliases
+VirtualMachine.Interact.AnswerQuestion
+VirtualMachine.Interact.Backup
+VirtualMachine.Interact.ConsoleInteract
+VirtualMachine.Interact.CreateScreenshot
+VirtualMachine.Interact.CreateSecondary
+VirtualMachine.Interact.DefragmentAllDisks
+VirtualMachine.Interact.DeviceConnection
+VirtualMachine.Interact.DisableSecondary
+VirtualMachine.Interact.DnD
+VirtualMachine.Interact.EnableSecondary
+VirtualMachine.Interact.GuestControl
+VirtualMachine.Interact.MakePrimary
+VirtualMachine.Interact.Pause
+VirtualMachine.Interact.PowerOff
+VirtualMachine.Interact.PowerOn
+VirtualMachine.Interact.PutUsbScanCodes
+VirtualMachine.Interact.Record
+VirtualMachine.Interact.Replay
+VirtualMachine.Interact.Reset
+VirtualMachine.Interact.SESparseMaintenance
+VirtualMachine.Interact.SetCDMedia
+VirtualMachine.Interact.SetFloppyMedia
+VirtualMachine.Interact.Suspend
+VirtualMachine.Interact.TerminateFaultTolerantVM
+VirtualMachine.Interact.ToolsInstall
+VirtualMachine.Interact.TurnOffFaultTolerance
+VirtualMachine.Inventory.Create
+VirtualMachine.Inventory.CreateFromExisting
+VirtualMachine.Inventory.Delete
+VirtualMachine.Inventory.Move
+VirtualMachine.Inventory.Register
+VirtualMachine.Inventory.Unregister
+VirtualMachine.Provisioning.Clone
+VirtualMachine.Provisioning.CloneTemplate
+VirtualMachine.Provisioning.CreateTemplateFromVM
+VirtualMachine.Provisioning.Customize
+VirtualMachine.Provisioning.DeployTemplate
+VirtualMachine.Provisioning.DiskRandomAccess
+VirtualMachine.Provisioning.DiskRandomRead
+VirtualMachine.Provisioning.FileRandomAccess
+VirtualMachine.Provisioning.GetVmFiles
+VirtualMachine.Provisioning.MarkAsTemplate
+VirtualMachine.Provisioning.MarkAsVM
+VirtualMachine.Provisioning.ModifyCustSpecs
+VirtualMachine.Provisioning.PromoteDisks
+VirtualMachine.Provisioning.PutVmFiles
+VirtualMachine.Provisioning.ReadCustSpecs
+VirtualMachine.State.CreateSnapshot
+VirtualMachine.State.RemoveSnapshot
+VirtualMachine.State.RenameSnapshot
+VirtualMachine.State.RevertToSnapshot
+
+```
+
+
+
+The described permissions have been tested with vSphere 7.0.U2 and might be different for other vSphere versions.
 
 #### Terraform Setup
 
@@ -200,8 +378,8 @@ shared management interface.
 In KKP *Datastores* are used for two purposes:
 - Storing the VMs files for the worker nodes of vSphere user clusters.
 - Generating the vSphere cloud provider storage configuration for user clusters.
-    In particular to provide the `dafault-datastore` value, that is the default
-    datastore for dynamic volume provisioning.
+  In particular to provide the `dafault-datastore` value, that is the default
+  datastore for dynamic volume provisioning.
 
 *Datastore Clusters* can only be used for the first purpose as it cannot be
 specified directly in [vSphere cloud configuration][vsphere-cloud-config].
@@ -210,13 +388,13 @@ There are two places where Datastores and Datastore Clusters can be configured
 in KKP
 
 - At datacenter level (either with [Seed CRD]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})
-    or [datacenters.yaml]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})) is possible to
-    specify the default *Datastore* that will be used for user clusters dynamic
-    volume provisioning and workers VMs placement in case no *Datastore* or
-    *Datastore Cluster* is specified at cluster level.
+  or [datacenters.yaml]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})) is possible to
+  specify the default *Datastore* that will be used for user clusters dynamic
+  volume provisioning and workers VMs placement in case no *Datastore* or
+  *Datastore Cluster* is specified at cluster level.
 - At *Cluster* level it is possible to provide either a *Datastore* or a
-    *Datastore Cluster* respectively with `spec.cloud.vsphere.datastore` and
-    `spec.cloud.vsphere.datastoreCluster` fields.
+  *Datastore Cluster* respectively with `spec.cloud.vsphere.datastore` and
+  `spec.cloud.vsphere.datastoreCluster` fields.
 
 {{% notice warning %}}
 At the moment of writing this document *Datastore and *Datastore Cluster*
@@ -225,4 +403,5 @@ are not supported yet at `Cluster` level by Kubermatic UI.
 
 It is possible to specify *Datastore* or *Datastore Clusters* in preset.
 
-[vsphere-cloud-config]: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html#template-config-file
+[vsphere-cloud-config]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html?hWord=N4IghgNiBcIMYQK4GcAuBTATgWgJYBMACAYQGUBJEAXyA
+[vsphere-storage-plugin-roles]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-0AB6E692-AA47-4B6A-8CEA-38B754E16567.html#GUID-043ACF65-9E0B-475C-A507-BBBE2579AA58__GUID-E51466CB-F1EA-4AD7-A541-F22CDC6DE881

--- a/content/kubermatic/v2.21/architecture/supported-providers/vSphere/vSphere.en.md
+++ b/content/kubermatic/v2.21/architecture/supported-providers/vSphere/vSphere.en.md
@@ -62,11 +62,12 @@ As this Config must also be deployed onto each worker node of a user cluster, it
 
 The vsphere user has to have to following permissions on the correct resources:
 
-#### Seed Cluster
+#### User Cluster Could Controller Manager / CSI
+**Note:** Below roles were updated based on [vsphere-storage-plugin-roles] for external CCM which is available from kkp v2.18+ and vsphere v7.0.2+
 
-For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-seed-cluster`) is needed:
+For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-ccm-cluster`) is needed:
 
-* Role `k8c-storage-vmfolder-propagate`
+* Role `k8c-ccm-storage-vmfolder-propagate`
   * Granted at **VM Folder** and **Template Folder**, propagated
   * Permissions
     * Virtual machine
@@ -79,17 +80,39 @@ For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-s
       * Create folder
       * Delete dolder
 
-* Role `k8c-storage-datastore-propagate`
+```
+$ govc role.ls k8c-ccm-storage-vmfolder-propagate
+Folder.Create
+Folder.Delete
+VirtualMachine.Config.AddExistingDisk
+VirtualMachine.Config.AddNewDisk
+VirtualMachine.Config.AddRemoveDevice
+VirtualMachine.Config.RemoveDisk
+```
+
+* Role `k8c-ccm-storage-datastore-propagate`
   * Granted at **Datastore**, propagated
   * Permissions
     * Datastore
       * Allocate space
       * Low level file operations
 
+```
+$ govc role.ls k8c-ccm-storage-datastore-propagate
+Datastore.AllocateSpace
+Datastore.FileManagement
+```
+
 * Role `Read-only` (predefined)
   * Granted at ..., **not** propagated
     * Datacenter
 
+```
+$ govc role.ls ReadOnly
+System.Anonymous
+System.Read
+System.View
+```
 #### User Cluster
 
 For provisioning actions of the KKP in scope of an user cluster, a technical user (e.g. `cust-user-cluster`) is needed:
@@ -98,12 +121,26 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
   * Granted at **vcenter** level, **not** propagated
   * Needed to customize VM during provisioning
   * Permissions
+    * CNS
+      * Searchable
     * Profile-driven storage
       * Profile-driven storage view
     * VirtualMachine
       * Provisioning
         * Modify customization specification
         * Read customization specifications
+
+```
+$ govc role.ls k8c-user-vcenter
+Cns.Searchable
+InventoryService.Tagging.ObjectAttachable
+StorageProfile.View
+System.Anonymous
+System.Read
+System.View
+VirtualMachine.Provisioning.ModifyCustSpecs
+VirtualMachine.Provisioning.ReadCustSpecs
+```
 
 * Role `k8c-user-datacenter`
   * Granted at **datacenter** level, **not** propagated
@@ -124,12 +161,31 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
     * Inventory
       * Create from existing
 
+```
+$ govc role.ls k8c-user-datacenter
+Datastore.AllocateSpace
+Datastore.Browse
+Datastore.DeleteFile
+Datastore.FileManagement
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
+VApp.ApplicationConfig
+VApp.InstanceConfig
+VirtualMachine.Config.CPUCount
+VirtualMachine.Config.Memory
+VirtualMachine.Config.Settings
+VirtualMachine.Inventory.CreateFromExisting
+```
+
 * Role `k8c-user-cluster-propagate`
   * Granted at **cluster** level, propagated
   * Needed for upload of `cloud-init.iso` (Ubuntu and CentOS) or defining the Ignition config into Guestinfo (CoreOS)
   * Permissions
     * Host
       * Configuration
+        * Storage partition configuration
         * System Management
       * Local operations
         * Reconfigure virtual machine
@@ -141,11 +197,29 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
       * vApp application configuration
       * vApp instance configuration
 
-* Role k8s-network-attach
+```
+$ govc role.ls k8c-user-cluster-propagate
+Folder.Create
+Host.Config.Storage
+Host.Config.SystemManagement
+Host.Local.ReconfigVM
+Resource.AssignVMToPool
+Resource.ColdMigrate
+Resource.HotMigrate
+VApp.ApplicationConfig
+VApp.InstanceConfig
+```
+
+* Role k8c-network-attach
   * Granted for each network that should be used (distributed switch + network)
   * Permissions
     * Network
       * Assign network
+
+```
+$ govc role.ls k8c-network-attach
+Network.Assign
+```
 
 * Role `k8c-user-datastore-propagate`
   * Granted at **datastore / datastore cluster** level, propagated
@@ -154,6 +228,13 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
       * Allocate space
       * Browse datastore
       * Low level file operations
+
+```
+$ govc role.ls k8c-user-datastore-propagate
+Datastore.AllocateSpace
+Datastore.Browse
+Datastore.FileManagement
+```
 
 * Role `k8c-user-folder-propagate`
   * Granted at **VM Folder** and **Template Folder** level, propagated
@@ -172,7 +253,104 @@ For provisioning actions of the KKP in scope of an user cluster, a technical use
       * Provisioning
       * Snapshot management
 
-The described permissions have been tested with vSphere 6.7 and might be different for other vSphere versions.
+```
+$ govc role.ls k8c-user-folder-propagate
+Folder.Create
+Folder.Delete
+Global.SetCustomField
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
+VirtualMachine.Config.AddExistingDisk
+VirtualMachine.Config.AddNewDisk
+VirtualMachine.Config.AddRemoveDevice
+VirtualMachine.Config.AdvancedConfig
+VirtualMachine.Config.Annotation
+VirtualMachine.Config.CPUCount
+VirtualMachine.Config.ChangeTracking
+VirtualMachine.Config.DiskExtend
+VirtualMachine.Config.DiskLease
+VirtualMachine.Config.EditDevice
+VirtualMachine.Config.HostUSBDevice
+VirtualMachine.Config.ManagedBy
+VirtualMachine.Config.Memory
+VirtualMachine.Config.MksControl
+VirtualMachine.Config.QueryFTCompatibility
+VirtualMachine.Config.QueryUnownedFiles
+VirtualMachine.Config.RawDevice
+VirtualMachine.Config.ReloadFromPath
+VirtualMachine.Config.RemoveDisk
+VirtualMachine.Config.Rename
+VirtualMachine.Config.ResetGuestInfo
+VirtualMachine.Config.Resource
+VirtualMachine.Config.Settings
+VirtualMachine.Config.SwapPlacement
+VirtualMachine.Config.ToggleForkParent
+VirtualMachine.Config.Unlock
+VirtualMachine.Config.UpgradeVirtualHardware
+VirtualMachine.GuestOperations.Execute
+VirtualMachine.GuestOperations.Modify
+VirtualMachine.GuestOperations.ModifyAliases
+VirtualMachine.GuestOperations.Query
+VirtualMachine.GuestOperations.QueryAliases
+VirtualMachine.Interact.AnswerQuestion
+VirtualMachine.Interact.Backup
+VirtualMachine.Interact.ConsoleInteract
+VirtualMachine.Interact.CreateScreenshot
+VirtualMachine.Interact.CreateSecondary
+VirtualMachine.Interact.DefragmentAllDisks
+VirtualMachine.Interact.DeviceConnection
+VirtualMachine.Interact.DisableSecondary
+VirtualMachine.Interact.DnD
+VirtualMachine.Interact.EnableSecondary
+VirtualMachine.Interact.GuestControl
+VirtualMachine.Interact.MakePrimary
+VirtualMachine.Interact.Pause
+VirtualMachine.Interact.PowerOff
+VirtualMachine.Interact.PowerOn
+VirtualMachine.Interact.PutUsbScanCodes
+VirtualMachine.Interact.Record
+VirtualMachine.Interact.Replay
+VirtualMachine.Interact.Reset
+VirtualMachine.Interact.SESparseMaintenance
+VirtualMachine.Interact.SetCDMedia
+VirtualMachine.Interact.SetFloppyMedia
+VirtualMachine.Interact.Suspend
+VirtualMachine.Interact.TerminateFaultTolerantVM
+VirtualMachine.Interact.ToolsInstall
+VirtualMachine.Interact.TurnOffFaultTolerance
+VirtualMachine.Inventory.Create
+VirtualMachine.Inventory.CreateFromExisting
+VirtualMachine.Inventory.Delete
+VirtualMachine.Inventory.Move
+VirtualMachine.Inventory.Register
+VirtualMachine.Inventory.Unregister
+VirtualMachine.Provisioning.Clone
+VirtualMachine.Provisioning.CloneTemplate
+VirtualMachine.Provisioning.CreateTemplateFromVM
+VirtualMachine.Provisioning.Customize
+VirtualMachine.Provisioning.DeployTemplate
+VirtualMachine.Provisioning.DiskRandomAccess
+VirtualMachine.Provisioning.DiskRandomRead
+VirtualMachine.Provisioning.FileRandomAccess
+VirtualMachine.Provisioning.GetVmFiles
+VirtualMachine.Provisioning.MarkAsTemplate
+VirtualMachine.Provisioning.MarkAsVM
+VirtualMachine.Provisioning.ModifyCustSpecs
+VirtualMachine.Provisioning.PromoteDisks
+VirtualMachine.Provisioning.PutVmFiles
+VirtualMachine.Provisioning.ReadCustSpecs
+VirtualMachine.State.CreateSnapshot
+VirtualMachine.State.RemoveSnapshot
+VirtualMachine.State.RenameSnapshot
+VirtualMachine.State.RevertToSnapshot
+
+```
+
+
+
+The described permissions have been tested with vSphere 7.0.U2 and might be different for other vSphere versions.
 
 #### Terraform Setup
 
@@ -200,8 +378,8 @@ shared management interface.
 In KKP *Datastores* are used for two purposes:
 - Storing the VMs files for the worker nodes of vSphere user clusters.
 - Generating the vSphere cloud provider storage configuration for user clusters.
-    In particular to provide the `dafault-datastore` value, that is the default
-    datastore for dynamic volume provisioning.
+  In particular to provide the `dafault-datastore` value, that is the default
+  datastore for dynamic volume provisioning.
 
 *Datastore Clusters* can only be used for the first purpose as it cannot be
 specified directly in [vSphere cloud configuration][vsphere-cloud-config].
@@ -210,13 +388,13 @@ There are two places where Datastores and Datastore Clusters can be configured
 in KKP
 
 - At datacenter level (either with [Seed CRD]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})
-    or [datacenters.yaml]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})) is possible to
-    specify the default *Datastore* that will be used for user clusters dynamic
-    volume provisioning and workers VMs placement in case no *Datastore* or
-    *Datastore Cluster* is specified at cluster level.
+  or [datacenters.yaml]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})) is possible to
+  specify the default *Datastore* that will be used for user clusters dynamic
+  volume provisioning and workers VMs placement in case no *Datastore* or
+  *Datastore Cluster* is specified at cluster level.
 - At *Cluster* level it is possible to provide either a *Datastore* or a
-    *Datastore Cluster* respectively with `spec.cloud.vsphere.datastore` and
-    `spec.cloud.vsphere.datastoreCluster` fields.
+  *Datastore Cluster* respectively with `spec.cloud.vsphere.datastore` and
+  `spec.cloud.vsphere.datastoreCluster` fields.
 
 {{% notice warning %}}
 At the moment of writing this document *Datastore and *Datastore Cluster*
@@ -225,4 +403,5 @@ are not supported yet at `Cluster` level by Kubermatic UI.
 
 It is possible to specify *Datastore* or *Datastore Clusters* in preset.
 
-[vsphere-cloud-config]: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html#template-config-file
+[vsphere-cloud-config]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-BFF39F1D-F70A-4360-ABC9-85BDAFBE8864.html?hWord=N4IghgNiBcIMYQK4GcAuBTATgWgJYBMACAYQGUBJEAXyA
+[vsphere-storage-plugin-roles]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-0AB6E692-AA47-4B6A-8CEA-38B754E16567.html#GUID-043ACF65-9E0B-475C-A507-BBBE2579AA58__GUID-E51466CB-F1EA-4AD7-A541-F22CDC6DE881


### PR DESCRIPTION
It seems that, we kinda forget to copy over the correct and full required permissions for vSphere cloud provider for KKP 2.21.0 and main branch. This PR copies those over. 