### PR TITLE
Add migration guide for kubevirt VMs regarding cluster labels

### DIFF
--- a/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
@@ -85,6 +85,7 @@ spec:
             - "<< YOUR_PUBLIC_KEY >>"
           cloudProvider: "kubevirt"
           cloudProviderSpec:
+            clusterName: "cluster-name"
             auth:
               kubeconfig:
                 value: '<< KUBECONFIG >>'

--- a/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
@@ -566,7 +566,7 @@ Newly created VMs will have these labels automatically but for existing VMs and 
 
 Add following labels
 ```yaml
-cluster.x-k8s.io/cluster-name: cluster-<cluster-id>
+cluster.x-k8s.io/cluster-name: <cluster-id>
 cluster.x-k8s.io/role: worker
 ```
 to:
@@ -586,27 +586,27 @@ $ export CLUSTERID=<your kkp user cluster id>
 $ cat << EOF > patch-vm.yaml
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: cluster-$CLUSTERID
+    cluster.x-k8s.io/cluster-name: $CLUSTERID
     cluster.x-k8s.io/role: worker
 spec:
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: cluster-$CLUSTERID
+        cluster.x-k8s.io/cluster-name: $CLUSTERID
         cluster.x-k8s.io/role: worker
 EOF
 $ kubectl patch -n cluster-$CLUSTERID vm <vm> --patch-file patch-vm.yaml --type=merge
 $ cat << EOF > patch-vmi.yaml
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: cluster-$CLUSTERID
+    cluster.x-k8s.io/cluster-name: $CLUSTERID
     cluster.x-k8s.io/role: worker
 EOF
 $ kubectl patch -n cluster-$CLUSTERID vmi <vmi> --patch-file patch-vmi.yaml --type=merge
 $ cat << EOF > patch-lb-svc.yaml
 spec:
   selector:
-    cluster.x-k8s.io/cluster-name: cluster-$CLUSTERID
+    cluster.x-k8s.io/cluster-name: $CLUSTERID
     cluster.x-k8s.io/role: worker
 EOF
 $ kubectl patch -n cluster-$CLUSTERID svc <lb-svc> --patch-file patch-lb-svc.yaml --type=merge

--- a/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
@@ -615,3 +615,13 @@ spec:
 EOF
 $ kubectl patch -n cluster-$CLUSTERID svc <lb-svc> --patch-file patch-lb-svc.yaml --type=merge
 ```
+
+### MachineDeployments
+
+MachineDeployments created with KKP 2.22 will have the field `clusterName` set with the cluster ID in the KubeVirt `cloudProviderSpec`,
+which is used by the machine-controller to set the cluster labels on VMs and VMIs. Any pre-existing MachineDeployments will not have this
+field set automatically to avoid rolling over all Machines. So in the scenario of scaling up pre-existing MachineDeployments for
+LoadBalancers to properly function, there are 2 possibilities:
+
+1. If it's no problem that all VMs get re-created, just set `MachineDeployment.spec.template.spec.providerSpec.value.cloudProviderSpec.clusterName` to your cluster ID.
+2. Otherwise you need to manually set the cluster labels described above on all VMs and VMIs that are being created while scaling the MachineDeployment up.

--- a/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt.en.md
@@ -557,6 +557,10 @@ Follow the below steps to import the dashboard in Grafana:
 
 ## Migration to KKP 2.22
 
+### KubeVirt upgrade
+
+tbd.
+
 ### Cluster labels
 
 With KKP 2.22 KubeVirt CCM is upgraded from `v0.2.0` to `v0.4.0`.


### PR DESCRIPTION
This contains the migration steps for already existing KubeVirt VMs after upgrading to KKP 2.22.

Reference: https://github.com/kubermatic/kubermatic/issues/10923