### PR TITLE
Drop support for Kubernetes 1.22 in KubeOne 1.6

### DIFF
--- a/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
@@ -20,26 +20,18 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.25  | 1.24  | 1.23  | 1.22\*  | 1.21\*\*  | 1.20\*\*  |
+| KubeOne version | 1.25  | 1.24  | 1.23  | 1.22\*  | 1.21\*    | 1.20\*    |
 | --------------- | ----- | ----- | ----- | ------- | --------- | --------- |
-| v1.6            | ✓     | ✓     | ✓     | ✓\*\*\* | -         | -         |
+| v1.6            | ✓     | ✓     | ✓     | -       | -         | -         |
 | v1.5            | -     | ✓     | ✓     | ✓       | -         | -         |
 | v1.4            | -     | -     | ✓     | ✓       | ✓         | ✓         |
 
-\* Kubernetes 1.22 is in the [maintenance mode] which means that only critical
-and security issues are fixed. It's strongly recommended to upgrade to a newer
-Kubernetes version as soon as possible.
-
-\*\* Kubernetes 1.21 and 1.20 have reached End-of-Life (EOL). We strongly
+\* Kubernetes 1.22, 1.21 and 1.20 have reached End-of-Life (EOL). We strongly
 recommend upgrading to a supported Kubernetes release as soon as possible.
-
-\*\*\* Support for Kubernetes 1.22 might be removed from KubeOne 1.6 because
-1.22 will reach End-of-Life (EOL) before KubeOne 1.6 planned release date.
 
 We recommend using a Kubernetes release that's not older than one minor release
 than the latest Kubernetes release. For example, with 1.24 being the latest
 release, we recommend running at least Kubernetes 1.23.
 
 [upstream-supported-versions]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
-[maintenance mode]: https://kubernetes.io/releases/patch-releases/#support-period
 [kubernetes-issue-93194]: https://github.com/kubernetes/kubernetes/issues/93194

--- a/content/kubeone/v1.4/architecture/compatibility/_index.en.md
+++ b/content/kubeone/v1.4/architecture/compatibility/_index.en.md
@@ -35,18 +35,15 @@ Kubernetes 1.19 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.23  | 1.22\*  | 1.21\*\*  | 1.20\*\*  | 1.19\*\* |
+| KubeOne version | 1.23  | 1.22\*  | 1.21\*    | 1.20\*    | 1.19\*   |
 | --------------- | ----- | ------- | --------- | --------- | -------- |
 | v1.4+           | ✓     | ✓       | ✓         | ✓         | -        |
 | v1.3            | -     | ✓       | ✓         | ✓         | ✓        |
 | v1.2            | -     | -       | ✓         | ✓         | ✓        |
 
-\* Kubernetes 1.22 is in the [maintenance mode] which means that only critical
-and security issues are fixed. It's strongly recommended to upgrade to a newer
-Kubernetes version as soon as possible.
-
-\*\* Kubernetes 1.21, 1.20, and 1.19 have reached End-of-Life (EOL). We strongly
-recommend upgrading to a supported Kubernetes release as soon as possible.
+\* Kubernetes 1.22, 1.21, 1.20, and 1.19 have reached End-of-Life (EOL).
+We strongly recommend upgrading to a supported Kubernetes release as soon as
+possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
 than the latest Kubernetes release. For example, with 1.23 being the latest
@@ -77,4 +74,3 @@ The following operating systems are supported:
 [kubernetes-issue-93194]: https://github.com/kubernetes/kubernetes/issues/93194
 [terraform-configs]: https://github.com/kubermatic/kubeone/tree/master/examples/terraform
 [aws-versions-tf]: https://github.com/kubermatic/kubeone/blob/master/examples/terraform/aws/versions.tf
-[maintenance mode]: https://kubernetes.io/releases/patch-releases/#support-period

--- a/content/kubeone/v1.5/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/v1.5/architecture/compatibility/supported-versions/_index.en.md
@@ -20,23 +20,19 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.24  | 1.23  | 1.22\*  | 1.21\*\*  | 1.20\*\*  | 1.19\*\*   |
+| KubeOne version | 1.24  | 1.23  | 1.22\*  | 1.21\*    | 1.20\*    | 1.19\*     |
 | --------------- | ----- | ----- | ------- | --------- | --------- | ---------- |
 | v1.5            | ✓     | ✓     | ✓       | -         | -         | -          |
 | v1.4            | -     | ✓     | ✓       | ✓         | ✓         | -          |
 | v1.3            | -     | -     | ✓       | ✓         | ✓         | ✓          |
 
-\* Kubernetes 1.22 is in the [maintenance mode] which means that only critical
-and security issues are fixed. It's strongly recommended to upgrade to a newer
-Kubernetes version as soon as possible.
-
-\*\* Kubernetes 1.21, 1.20, and 1.19 have reached End-of-Life (EOL). We strongly
-recommend upgrading to a supported Kubernetes release as soon as possible.
+\* Kubernetes 1.22, 1.21, 1.20, and 1.19 have reached End-of-Life (EOL).
+We strongly recommend upgrading to a supported Kubernetes release as soon as
+possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
 than the latest Kubernetes release. For example, with 1.24 being the latest
 release, we recommend running at least Kubernetes 1.23.
 
 [upstream-supported-versions]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
-[maintenance mode]: https://kubernetes.io/releases/patch-releases/#support-period
 [kubernetes-issue-93194]: https://github.com/kubernetes/kubernetes/issues/93194


### PR DESCRIPTION
Follow up on https://github.com/kubermatic/kubeone/pull/2481