### PR TITLE
Update k8s support matrix with footnotes and updated k8s EOL status

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -31,22 +31,20 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version | 1.24\* | 1.23\* | 1.22 | 1.21 | 1.20\*\* | 1.19\*\*   | 1.18\*\*   |
-| ----------- | ------ |------- | ---- | ---- | -------- | ---------- | ---------- |
-| 2.21.x      | ✓      | ✓      | ✓    | ✓    | -        | -          | -          |
-| 2.20.x      | -      | -      | ✓    | ✓    | ✓        | -          | -          |
-| 2.19.x      | -      | -      | ✓    | ✓    | ✓        | -          | -          |
-| 2.18.x      | -      | -      | ✓    | ✓    | ✓        | ✓          | -          |
-| 2.17.x      | -      | -      | -    | ✓    | ✓        | ✓          | ✓          |
-| 2.16.x      | -      | -      | -    | -    | ✓        | ✓          | ✓          |
+| KKP version  | 1.25     | 1.24[^1] | 1.23[^1] | 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2]   |
+| ------------ | -------- | -------- | -------- | -------- | -------- | -------- | ---------- |
+| 2.22.x[^not-out-yet] | ✓        | ✓        | ✓        | -        | -        | -        | -          |
+| 2.21.x       | -        | ✓        | ✓        | ✓        | ✓        | -        | -          |
+| 2.20.x       | -        | -        | -        | ✓        | ✓        | ✓        | -          |
+| 2.19.x       | -        | -        | -        | ✓        | ✓        | ✓        | -          |
+| 2.18.x[^3]   | -        | -        | -        | ✓        | ✓        | ✓        | ✓          |
 
-\* Kubernetes 1.24 and 1.23 are currently not supported on ARM64 clusters with Canal CNI
-and kube-proxy running in the IPVS mode.
+[^1]: Kubernetes 1.24 and 1.23 are currently not supported on ARM64 clusters with Canal CNI and kube-proxy running in the IPVS mode.
 
-\*\* Kubernetes 1.18, 1.19 and 1.20 releases have reached End-of-Life (EOL). We
-strongly recommend upgrading to a supported Kubernetes release as soon as
-possible.
+[^2]: Kubernetes 1.18, 1.19, 1.20, 1.21 and 1.22 releases have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
-Upgrades from a previous Kubernetes version are generally supported whenever a
-version is marked as supported, for example KKP 2.17 supports updating clusters
-from Kubernetes 1.18 to 1.21.
+[^3]: KKP 2.18 has reached End-of-Life (EOL). We strongly recommend upgrading to a supported KKP version as soon as possible.
+
+[^not-out-yet]: KKP 2.22 has not been released yet.
+
+Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.

--- a/content/kubermatic/v2.21/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/supported-versions/_index.en.md
@@ -31,22 +31,17 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version | 1.24\* | 1.23\* | 1.22 | 1.21 | 1.20\*\* | 1.19\*\*   | 1.18\*\*   |
-| ----------- | ------ |------- | ---- | ---- | -------- | ---------- | ---------- |
-| 2.21.x      | ✓      | ✓      | ✓    | ✓    | -        | -          | -          |
-| 2.20.x      | -      | -      | ✓    | ✓    | ✓        | -          | -          |
-| 2.19.x      | -      | -      | ✓    | ✓    | ✓        | -          | -          |
-| 2.18.x      | -      | -      | ✓    | ✓    | ✓        | ✓          | -          |
-| 2.17.x      | -      | -      | -    | ✓    | ✓        | ✓          | ✓          |
-| 2.16.x      | -      | -      | -    | -    | ✓        | ✓          | ✓          |
+| KKP version  | 1.24[^1] | 1.23[^1] | 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2]   |
+| ------------ | -------- | -------- | -------- | -------- | -------- | ---------- |
+| 2.21.x       | ✓        | ✓        | ✓        | ✓        | -        | -          |
+| 2.20.x       | -        | -        | ✓        | ✓        | ✓        | -          |
+| 2.19.x       | -        | -        | ✓        | ✓        | ✓        | -          |
+| 2.18.x[^3]   | -        | -        | ✓        | ✓        | ✓        | ✓          |
 
-\* Kubernetes 1.24 and 1.23 are currently not supported on ARM64 clusters with Canal CNI
-and kube-proxy running in the IPVS mode.
+[^1]: Kubernetes 1.24 and 1.23 are currently not supported on ARM64 clusters with Canal CNI and kube-proxy running in the IPVS mode.
 
-\*\* Kubernetes 1.18, 1.19 and 1.20 releases have reached End-of-Life (EOL). We
-strongly recommend upgrading to a supported Kubernetes release as soon as
-possible.
+[^2]: Kubernetes 1.18, 1.19, 1.20, 1.21 and 1.22 releases have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
-Upgrades from a previous Kubernetes version are generally supported whenever a
-version is marked as supported, for example KKP 2.17 supports updating clusters
-from Kubernetes 1.18 to 1.21.
+[^3]: KKP 2.18 has reached End-of-Life (EOL). We strongly recommend upgrading to a supported KKP version as soon as possible.
+
+Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.


### PR DESCRIPTION
Upstream support for k8s has EOL'd for both 1.22 and 1.21, so this updates the docs for `main` and `2.21`. In addition, I've:

- converted footnotes to real footnotes
- add prospective supported versions for 2.22 in `main` content
- remove older KKP versions from the matrix so we can also remove some ancient Kubernetes versions
- add a note saying that KKP 2.18 has reached end of life

I'd like to get both reviews from @xmudrii and @csengerszabo from a technical/sig-release and a product management perspective please.