### PR TITLE
Cilium docs fixes

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/networking/cni-cluster-network/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/cni-cluster-network/_index.en.md
@@ -51,48 +51,12 @@ In KKP versions below v2.19, this was the only supported CNI.
 ### Cilium CNI
 
 [Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).
-The following table lists the supported operating systems and cloud providers for cilium CNI in KKP:
 
-{{%expand "With ebpf proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | Amazon Linux 2 | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | -------------- | ---- |
-| AWS                   | ✓      | -      | ✓       | ✓    | ✓              | x    |
-| Azure                 | ✓      | -      | ✓       | ✓    | -              | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -              | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -              | -    |
-| Hetzner               | ✓      | x      | -       | -    | -              | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -              | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -              | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -              | -    |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-
-{{% /expand%}}
-
-{{%expand "With iptables proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | ---- |
-| AWS                   | ✓      | x      | ✓       | ✓    | x    |
-| Azure                 | ✓      | -      | ✓       | x    | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -    |
-| Hetzner               | ✓      | x      | -       | -    | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -    |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-- A tilde(~) denotes a partial support
-
-{{% /expand%}}
-
-**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
+Before opting for Cilium CNI, please verify that your worker nodes' Linux distributions is known to work well with Cilium based on the [Linux Distribution Compatibility List](https://docs.cilium.io/en/stable/operations/system_requirements/#linux-distribution-compatibility-considerations).
 
 The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only if [Konnectivity](#konnectivity) is enabled.
+
+**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
 
 To provide better observability on cluster networking with Cilium CNI via a web user interface, KKP provides a Hubble Addon that can be easily installed into user clusters with Cilium CNI via the KKP UI on the cluster page, as shown below:
 

--- a/content/kubermatic/v2.19/architecture/concept/kkp-concepts/addons/_index.en.md
+++ b/content/kubermatic/v2.19/architecture/concept/kkp-concepts/addons/_index.en.md
@@ -371,6 +371,12 @@ spec:
               name: canal
               labels:
                 addons.kubermatic.io/ensure: true
+          - apiVersion: kubermatic.k8c.io/v1
+            kind: Addon
+            metadata:
+              name: cilium
+              labels:
+                addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8s.io/v1
             kind: Addon
             metadata:

--- a/content/kubermatic/v2.19/tutorials_howtos/networking/cni_cluster_network/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/networking/cni_cluster_network/_index.en.md
@@ -42,65 +42,13 @@ In KKP versions below v2.19, this was the only supported CNI.
 
 ### Cilium CNI
 
-[Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).  
-The following table lists the supported operating systems and cloud providers for cilium CNI in KKP:
+Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).
 
-{{%expand "With ebpf proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | Amazon Linux 2 | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | -------------- | ---- |
-| AWS                   | ✓      | -      | ✓       | ✓    | ✓              | x    |
-| Azure                 | ✓      | -      | ✓       | ✓    | -              | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -              | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -              | -    |
-| Hetzner               | ✓      | x      | -       | -    | -              | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -              | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -              | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -              | -    |
+Before opting for Cilium CNI, please verify that your worker nodes' Linux distributions is known to work well with Cilium based on the [Linux Distribution Compatibility List](https://docs.cilium.io/en/stable/operations/system_requirements/#linux-distribution-compatibility-considerations).
 
-**NOTE:**
+The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only if [Konnectivity](#konnectivity) is enabled.
 
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-
-{{% /expand%}}
-
-{{%expand "With ipvs proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL  |
-| --------------------- | ------ | ------ | ------- | ----- |
-| AWS                   | ~[^1]  | x      | ~[^1]   | ~[^1] |
-| Azure                 | ~[^1]  | x      | ~[^1]   | ~[^1] |
-| Google Cloud Platform | ~[^1]  | -      | -       | -     |
-| Openstack             | ~[^1]  | x      | ~[^1]   | ~[^1] |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-- A tilde(~) denotes a partial support
-
-[^1]: Pod can not access `<internal_node_ip>:<node_port>`. issue [8767](https://github.com/kubermatic/kubermatic/issues/8767)
-
-{{% /expand%}}
-
-{{%expand "With iptables proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | ---- |
-| AWS                   | ✓      | x      | ✓       | ✓    | x    |
-| Azure                 | ✓      | -      | ✓       | x    | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -    |
-| Hetzner               | ✓      | x      | -       | -    | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -    |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-- A tilde(~) denotes a partial support
-
-{{% /expand%}}
-
-
-The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only of [Konnectivity](#konnectivity) is enabled.
+**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
 
 To provide better observability on cluster networking with Cilium CNI via a web user interface, KKP provides a Hubble Addon that can be easily installed into user clusters with Cilium CNI via the KKP UI on the cluster page, as shown below:
 

--- a/content/kubermatic/v2.19/tutorials_howtos/networking/cni_cluster_network/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/networking/cni_cluster_network/_index.en.md
@@ -48,7 +48,7 @@ Before opting for Cilium CNI, please verify that your worker nodes' Linux distri
 
 The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only if [Konnectivity](#konnectivity) is enabled.
 
-**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
+**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to a [known issue](https://github.com/cilium/cilium/issues/18610).
 
 To provide better observability on cluster networking with Cilium CNI via a web user interface, KKP provides a Hubble Addon that can be easily installed into user clusters with Cilium CNI via the KKP UI on the cluster page, as shown below:
 

--- a/content/kubermatic/v2.20/architecture/concept/kkp-concepts/addons/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/concept/kkp-concepts/addons/_index.en.md
@@ -374,6 +374,12 @@ spec:
           - apiVersion: kubermatic.k8c.io/v1
             kind: Addon
             metadata:
+              name: cilium
+              labels:
+                addons.kubermatic.io/ensure: true
+          - apiVersion: kubermatic.k8c.io/v1
+            kind: Addon
+            metadata:
               name: csi
               labels:
                 addons.kubermatic.io/ensure: true

--- a/content/kubermatic/v2.20/tutorials_howtos/networking/cni_cluster_network/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/networking/cni_cluster_network/_index.en.md
@@ -43,65 +43,13 @@ In KKP versions below v2.19, this was the only supported CNI.
 
 ### Cilium CNI
 
-[Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).  
-The following table lists the supported operating systems and cloud providers for cilium CNI in KKP:
+[Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).
 
-{{%expand "With ebpf proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | Amazon Linux 2 | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | -------------- | ---- |
-| AWS                   | ✓      | -      | ✓       | ✓    | ✓              | x    |
-| Azure                 | ✓      | -      | ✓       | ✓    | -              | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -              | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -              | -    |
-| Hetzner               | ✓      | x      | -       | -    | -              | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -              | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -              | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -              | -    |
+Before opting for Cilium CNI, please verify that your worker nodes' Linux distributions is known to work well with Cilium based on the [Linux Distribution Compatibility List](https://docs.cilium.io/en/stable/operations/system_requirements/#linux-distribution-compatibility-considerations).
 
-**NOTE:**
+The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only if [Konnectivity](#konnectivity) is enabled.
 
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-
-{{% /expand%}}
-
-{{%expand "With ipvs proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL  |
-| --------------------- | ------ | ------ | ------- | ----- |
-| AWS                   | ~[^1]  | x      | ~[^1]   | ~[^1] |
-| Azure                 | ~[^1]  | x      | ~[^1]   | ~[^1] |
-| Google Cloud Platform | ~[^1]  | -      | -       | -     |
-| Openstack             | ~[^1]  | x      | ~[^1]   | ~[^1] |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-- A tilde(~) denotes a partial support
-
-[^1]: Pod can not access `<internal_node_ip>:<node_port>`. issue [8767](https://github.com/kubermatic/kubermatic/issues/8767)
-
-{{% /expand%}}
-
-{{%expand "With iptables proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | ---- |
-| AWS                   | ✓      | x      | ✓       | ✓    | x    |
-| Azure                 | ✓      | -      | ✓       | x    | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -    |
-| Hetzner               | ✓      | x      | -       | -    | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -    |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-- A tilde(~) denotes a partial support
-
-{{% /expand%}}
-
-
-The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only of [Konnectivity](#konnectivity) is enabled.
+**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
 
 To provide better observability on cluster networking with Cilium CNI via a web user interface, KKP provides a Hubble Addon that can be easily installed into user clusters with Cilium CNI via the KKP UI on the cluster page, as shown below:
 

--- a/content/kubermatic/v2.20/tutorials_howtos/networking/cni_cluster_network/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/networking/cni_cluster_network/_index.en.md
@@ -49,7 +49,7 @@ Before opting for Cilium CNI, please verify that your worker nodes' Linux distri
 
 The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only if [Konnectivity](#konnectivity) is enabled.
 
-**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
+**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to a [known issue](https://github.com/cilium/cilium/issues/18610).
 
 To provide better observability on cluster networking with Cilium CNI via a web user interface, KKP provides a Hubble Addon that can be easily installed into user clusters with Cilium CNI via the KKP UI on the cluster page, as shown below:
 

--- a/content/kubermatic/v2.21/architecture/concept/kkp-concepts/addons/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/concept/kkp-concepts/addons/_index.en.md
@@ -387,6 +387,12 @@ spec:
           - apiVersion: kubermatic.k8c.io/v1
             kind: Addon
             metadata:
+              name: cilium
+              labels:
+                addons.kubermatic.io/ensure: true
+          - apiVersion: kubermatic.k8c.io/v1
+            kind: Addon
+            metadata:
               name: csi
               labels:
                 addons.kubermatic.io/ensure: true

--- a/content/kubermatic/v2.21/tutorials-howtos/networking/cni-cluster-network/_index.en.md
+++ b/content/kubermatic/v2.21/tutorials-howtos/networking/cni-cluster-network/_index.en.md
@@ -50,49 +50,13 @@ In KKP versions below v2.19, this was the only supported CNI.
 
 ### Cilium CNI
 
-[Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).  
-The following table lists the supported operating systems and cloud providers for cilium CNI in KKP:
+[Cilium](https://cilium.io/) is a feature-rich CNI plugin, which leverages the revolutionary eBPF Kernel technology. It provides enhanced security and observability features, but requires more recent kernel versions on the worker nodes (see [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/)).
 
-{{%expand "With ebpf proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | Amazon Linux 2 | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | -------------- | ---- |
-| AWS                   | ✓      | -      | ✓       | ✓    | ✓              | x    |
-| Azure                 | ✓      | -      | ✓       | ✓    | -              | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -              | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -              | -    |
-| Hetzner               | ✓      | x      | -       | -    | -              | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -              | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -              | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -              | -    |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-
-{{% /expand%}}
-
-{{%expand "With iptables proxy mode" %}}
-|                       | Ubuntu | CentOS | Flatcar | RHEL | SLES |
-| --------------------- | ------ | ------ | ------- | ---- | ---- |
-| AWS                   | ✓      | x      | ✓       | ✓    | x    |
-| Azure                 | ✓      | -      | ✓       | x    | -    |
-| Digitalocean          | ✓      | x      | -       | -    | -    |
-| Google Cloud Platform | ✓      | -      | -       | -    | -    |
-| Hetzner               | ✓      | x      | -       | -    | -    |
-| KubeVirt              | ✓      | x      | ✓       | ✓    | -    |
-| Equinix Metal         | ✓      | x      | -       | -    | -    |
-| Openstack             | ✓      | x      | ✓       | ✓    | -    |
-
-**NOTE:**
-
-- A hyphen(-) denotes that the operating system is not supported for the given cloud provider.
-- A tilde(~) denotes a partial support
-
-{{% /expand%}}
-
-**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
+Before opting for Cilium CNI, please verify that your worker nodes' Linux distributions is known to work well with Cilium based on the [Linux Distribution Compatibility List](https://docs.cilium.io/en/stable/operations/system_requirements/#linux-distribution-compatibility-considerations).
 
 The most of the Cilium CNI features can be utilized when the `ebpf` Proxy Mode is used (Cilium `kube-proxy-replacement` is enabled). This can be done by selecting `ebpf` for `Proxy Mode` in the [Cluster Network Configuration](#other-cluster-network-configuration). Please note that this option is available only if [Konnectivity](#konnectivity) is enabled.
+
+**NOTE:** IPVS kube-proxy mode is not recommended with Cilium CNI due to [a known issue]({{< relref "../../../architecture/known-issues/" >}}#2-connectivity-issue-in-pod-to-nodeport-service-in-cilium--ipvs-proxy-mode).
 
 To provide better observability on cluster networking with Cilium CNI via a web user interface, KKP provides a Hubble Addon that can be easily installed into user clusters with Cilium CNI via the KKP UI on the cluster page, as shown below:
 


### PR DESCRIPTION
- Instead of maintaining Cilium-OS compatibility matrix, link to the upstream docs
- Add cilium Addon into the defaultManifests list docs - however, intentionally NOT for the main version, as Cilium will be managed by Apps infra as of the next KKP release.