### PR TITLE
Update support matrix for Kubernetes 1.23 support in KKP 2.20

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -35,7 +35,7 @@ current KKP version.
 | ------------ | -------- | -------- | -------- | -------- | -------- | -------- | ---------- |
 | 2.22.x[^not-out-yet] | ✓        | ✓        | ✓        | -        | -        | -        | -          |
 | 2.21.x       | -        | ✓        | ✓        | ✓        | ✓        | -        | -          |
-| 2.20.x       | -        | -        | -        | ✓        | ✓        | ✓        | -          |
+| 2.20.x       | -        | -        | ✓[^4]    | ✓        | ✓        | ✓        | -          |
 | 2.19.x       | -        | -        | -        | ✓        | ✓        | ✓        | -          |
 | 2.18.x[^3]   | -        | -        | -        | ✓        | ✓        | ✓        | ✓          |
 
@@ -44,6 +44,8 @@ current KKP version.
 [^2]: Kubernetes 1.19, 1.20, 1.21 and 1.22 releases have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
 [^3]: KKP 2.18 has reached End-of-Life (EOL). We strongly recommend upgrading to a supported KKP version as soon as possible.
+
+[^4]: Kubernetes 1.23 support has been added in KKP 2.20.3.
 
 [^not-out-yet]: KKP 2.22 has not been released yet.
 

--- a/content/kubermatic/v2.20/architecture/support_policy/supported_versions/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/support_policy/supported_versions/_index.en.md
@@ -58,6 +58,4 @@ current KKP version.
 
 [^3]: Kubernetes 1.23 support has been added in KKP 2.20.3.
 
-Upgrades from a previous Kubernetes version are generally supported whenever a
-version is marked as supported, for example KKP 2.17 supports updating clusters
-from Kubernetes 1.18 to 1.21.
+Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.17 supports updating clusters from Kubernetes 1.18 to 1.21.

--- a/content/kubermatic/v2.20/architecture/support_policy/supported_versions/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/support_policy/supported_versions/_index.en.md
@@ -48,9 +48,9 @@ current KKP version.
 | ----------- | ----- |-------- | -------- | -------- | -------- | -------- |
 | 2.20.x      | ✓[^3] | ✓       | ✓        | ✓        | -        | -        |
 | 2.19.x      | -     | ✓       | ✓        | ✓        | -        | -        |
-| 2.18.x      | -     | ✓       | ✓        | ✓        | ✓        | -        |
-| 2.17.x      | -     | -       | ✓        | ✓        | ✓        | ✓        |
-| 2.16.x      | -     | -       | -        | ✓        | ✓        | ✓        |
+| 2.18.x[^2]  | -     | ✓       | ✓        | ✓        | ✓        | -        |
+| 2.17.x[^2]  | -     | -       | ✓        | ✓        | ✓        | ✓        |
+| 2.16.x[^2]  | -     | -       | -        | ✓        | ✓        | ✓        |
 
 [^1]: Kubernetes 1.22 and lower have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 

--- a/content/kubermatic/v2.20/architecture/support_policy/supported_versions/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/support_policy/supported_versions/_index.en.md
@@ -44,17 +44,19 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version | 1.22 | 1.21 | 1.20\* | 1.19\*   | 1.18\*   |
-| ----------- | ---- | ---- | ------ | -------- | -------- |
-| 2.20.x      | ✓    | ✓    | ✓      | -        | -        |
-| 2.19.x      | ✓    | ✓    | ✓      | -        | -        |
-| 2.18.x      | ✓    | ✓    | ✓      | ✓        | -        |
-| 2.17.x      | -    | ✓    | ✓      | ✓        | ✓        |
-| 2.16.x      | -    | -    | ✓      | ✓        | ✓        |
+| KKP version | 1.23  |1.22[^1] | 1.21[^1] | 1.20[^1] | 1.19[^1] | 1.18[^1] |
+| ----------- | ----- |-------- | -------- | -------- | -------- | -------- |
+| 2.20.x      | ✓[^3] | ✓       | ✓        | ✓        | -        | -        |
+| 2.19.x      | -     | ✓       | ✓        | ✓        | -        | -        |
+| 2.18.x      | -     | ✓       | ✓        | ✓        | ✓        | -        |
+| 2.17.x      | -     | -       | ✓        | ✓        | ✓        | ✓        |
+| 2.16.x      | -     | -       | -        | ✓        | ✓        | ✓        |
 
-\* Kubernetes 1.18, 1.19 and 1.20 releases have reached End-of-Life (EOL). We
-strongly recommend upgrading to a supported Kubernetes release as soon as
-possible.
+[^1]: Kubernetes 1.22 and lower have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
+
+[^2]: KKP 2.18 and lower have reached End-of-Life (EOL). We strongly recommend upgrading to a supported KKP release as soon as possible.
+
+[^3]: Kubernetes 1.23 support has been added in KKP 2.20.3.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a
 version is marked as supported, for example KKP 2.17 supports updating clusters

--- a/content/kubermatic/v2.21/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/supported-versions/_index.en.md
@@ -34,7 +34,7 @@ current KKP version.
 | KKP version  | 1.24[^1] | 1.23[^1] | 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2]   |
 | ------------ | -------- | -------- | -------- | -------- | -------- | ---------- |
 | 2.21.x       | ✓        | ✓        | ✓        | ✓        | -        | -          |
-| 2.20.x       | -        | -        | ✓        | ✓        | ✓        | -          |
+| 2.20.x       | -        | ✓[^4]    | ✓        | ✓        | ✓        | -          |
 | 2.19.x       | -        | -        | ✓        | ✓        | ✓        | -          |
 | 2.18.x[^3]   | -        | -        | ✓        | ✓        | ✓        | ✓          |
 
@@ -43,5 +43,7 @@ current KKP version.
 [^2]: Kubernetes 1.19, 1.20, 1.21 and 1.22 releases have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
 [^3]: KKP 2.18 has reached End-of-Life (EOL). We strongly recommend upgrading to a supported KKP version as soon as possible.
+
+[^4]: Kubernetes 1.23 support has been added in KKP 2.20.3.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.


### PR DESCRIPTION
We forgot to update this ("we" as in "I"). This PR updates the docs to include Kubernetes 1.23 support in KKP 2.20, which we added in kKP 2.20.3.