### PR TITLE
Drop docker related configurations from sample OSP

### DIFF
--- a/content/operatingsystemmanager/compatibility/_index.en.md
+++ b/content/operatingsystemmanager/compatibility/_index.en.md
@@ -26,6 +26,6 @@ The page provides an overview for the supported operating systems on various clo
 
 Currently supported K8S versions are:
 
+- 1.26
 - 1.25
 - 1.24
-- 1.23

--- a/content/operatingsystemmanager/data/osp-ubuntu-swap-enabled.yaml
+++ b/content/operatingsystemmanager/data/osp-ubuntu-swap-enabled.yaml
@@ -103,56 +103,6 @@ spec:
             systemctl daemon-reload
             systemctl enable --now containerd
 
-      - name: docker
-        files:
-          - path: /etc/systemd/system/containerd.service.d/environment.conf
-            content:
-              inline:
-                data: |
-                  [Service]
-                  Restart=always
-                  EnvironmentFile=-/etc/environment
-
-          - path: /etc/systemd/system/docker.service.d/environment.conf
-            content:
-              inline:
-                data: |
-                  [Service]
-                  Restart=always
-                  EnvironmentFile=-/etc/environment
-
-          - path: /etc/docker/daemon.json
-            permissions: 644
-            content:
-              inline:
-                encoding: b64
-                data: |-
-                  {{ .ContainerRuntimeConfig }}
-
-          - path: /root/.docker/config.json
-            permissions: 600
-            content:
-              inline:
-                encoding: b64
-                data: |-
-                  {{ .ContainerRuntimeAuthConfig }}
-
-        templates:
-          containerRuntimeInstallation: |-
-            apt-get update
-            apt-get install -y apt-transport-https ca-certificates curl software-properties-common lsb-release
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-            add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-
-            apt-get install --allow-downgrades -y \
-                containerd.io=1.5* \
-                docker-ce-cli=5:20.10* \
-                docker-ce=5:20.10*
-            apt-mark hold docker-ce* containerd.io
-
-            systemctl daemon-reload
-            systemctl enable --now docker
-
     templates:
       safeDownloadBinariesScript: |-
         {{- /* setup some common directories */}}
@@ -162,9 +112,6 @@ spec:
 
         {{- /* create all the necessary dirs */}}
         mkdir -p /etc/cni/net.d /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
-        {{- if semverCompare "<1.23" .KubeVersion }}
-        mkdir -p /etc/kubernetes/dynamic-config-dir
-        {{- end }}
         {{- /* HOST_ARCH can be defined outside of machine-controller (in kubeone for example) */}}
         arch=${HOST_ARCH-}
         if [ -z "$arch" ]
@@ -553,9 +500,6 @@ spec:
                 --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
                 --kubeconfig=/var/lib/kubelet/kubeconfig \
                 --config=/etc/kubernetes/kubelet.conf \
-                {{- if semverCompare "<1.24" .KubeVersion }}
-                --network-plugin=cni \
-                {{- end }}
                 --cert-dir=/etc/kubernetes/pki \
                 {{- if .ExternalCloudProvider }}
                 --cloud-provider=external \
@@ -568,10 +512,6 @@ spec:
                 {{- else if and (eq .CloudProviderName "aws") (.ExternalCloudProvider) }}
                 --hostname-override=${KUBELET_HOSTNAME} \
                 {{- end }}
-                {{- if semverCompare "<1.23" .KubeVersion }}
-                --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
-                --feature-gates=DynamicKubeletConfig=true,NodeSwap=true \
-                {{- end }}
                 --exit-on-lock-contention \
                 --lock-file=/tmp/kubelet.lock \
                 {{- if .PauseImage }}
@@ -583,10 +523,6 @@ spec:
                 {{- if eq .ContainerRuntime "containerd" }}
                 --container-runtime=remote \
                 --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
-                {{- end }}
-                {{- if eq .ContainerRuntime "docker" }}
-                --container-runtime=docker \
-                --container-runtime-endpoint=unix:///var/run/dockershim.sock \
                 {{- end }}
                 {{- /* If external or in-tree CCM is in use we don't need to set --node-ip as the cloud provider will know what IPs to return.  */}}
                 {{- if not (and (eq .NetworkIPFamily "IPv4+IPv6") (or (.InTreeCCMAvailable) (.ExternalCloudProvider))) }}
@@ -720,8 +656,6 @@ spec:
               - "{{ . }}"
               {{- end }}
               clusterDomain: cluster.local
-              {{- /* containerLogMaxSize and containerLogMaxFiles have no effect for docker  */}}
-              {{- if ne .ContainerRuntime "docker" }}
               {{- if .ContainerLogMaxSize }}
               containerLogMaxSize: {{ .ContainerLogMaxSize }}
               {{- else }}
@@ -731,7 +665,6 @@ spec:
               containerLogMaxFiles: {{ .ContainerLogMaxFiles }}
               {{- else }}
               containerLogMaxFiles: 5
-              {{- end }}
               {{- end }}
               cpuManagerReconcilePeriod: 0s
               evictionPressureTransitionPeriod: 0s

--- a/content/operatingsystemmanager/guides/osm-configuration/_index.en.md
+++ b/content/operatingsystemmanager/guides/osm-configuration/_index.en.md
@@ -34,6 +34,7 @@ OSM can be configured using the following command line flags:
 | `override-bootstrap-kubelet-apiserver` | string | false | `""` | Override for the API server address used in worker nodes bootstrap-kubelet.conf. |
 | `bootstrap-token-service-account-name` | string | false | `""` | When set use the service account token from this SA as bootstrap token instead of creating a temporary one. Passed in `namespace/name` format. |
 | `worker-count` | int | false | `10` | Number of workers which process reconciliation in parallel. |
+| `ca-bundle` | string | false | `""` | Path to a file containing all PEM-encoded CA certificates. Will be used for Kubernetes CA certificates. |
 
 ## Configuring Operating System Profile
 


### PR DESCRIPTION
This PR updates the documentation of OSM against the following changes:
1. Update supported k8s versions and cleanup checks for older versions
2. Drop docker related configurations from sample OSP
3. Sync flags with OSM

Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>