### PR TITLE
Minor documentation improvements for wording and capitalisation

### DIFF
--- a/content/kubermatic/main/_index.en.md
+++ b/content/kubermatic/main/_index.en.md
@@ -19,35 +19,37 @@ KKP is the easiest and most effective software for managing cloud native IT infr
 
 ## Features
 
-#### Powerful & intuitive dashboard to visualize your Kubernetes deployment
-Manage your projects and clusters with the KKP dashboard. Scale your cluster by adding and removing nodes in just a few clicks. As an Admin, the dashboard also allows you to customize the theme and disable theming options for other users.
+#### Powerful & Intuitive Dashboard to Visualize your Kubernetes Deployment
+Manage your [projects and clusters with the KKP dashboard]({{< ref "./tutorials-howtos/project-and-cluster-management/" >}}). Scale your cluster by adding and removing nodes in just a few clicks. As an admin, the dashboard also allows you to [customize the theme]({{< ref "./tutorials-howtos/dashboard-customization/" >}}) and disable theming options for other users.
 
-#### Deploy, scale & update multiple Kubernetes clusters
+#### Deploy, Scale & Update Multiple Kubernetes Clusters
 Kubernetes environments must be highly distributed to meet the performance demands of modern cloud native applications. Organizations can ensure consistent operations across all environments with effective cluster management. KKP empowers you to take advantage of all the advanced features that Kubernetes has to offer and increases the speed, flexibility and scalability of your cloud deployment workflow.
 
 At Kubermatic, we have chosen to do multi-cluster management with Kubernetes Operators. Operators (a method of packaging, deploying and managing a Kubernetes application) allow KKP to automate creation as well as the full lifecycle management of clusters. With KKP you can create a cluster for each need, fine-tune it, reuse it and continue this process hassle-free. This results in:
-- Better failure resilience
-- Smaller individual clusters being more adaptable than one big cluster
-- Faster development thanks to less complex environments
+
+- Better failure resilience.
+- Smaller individual clusters being more adaptable than one big cluster.
+- Faster development thanks to less complex environments.
 
 #### Kubernetes Autoscaler Integration
 Autoscaling in Kubernetes refers to the ability to increase or decrease the number of nodes as the demand for service response changes. Without autoscaling, teams would manually first provision and then scale up or down resources every time conditions change. This means, either services fail at peak demand due to the unavailability of enough resources or you pay at peak capacity to ensure availability.
 
-The Kubernetes Autoscaler in the KKP Cluster automatically scales up/down when one of the following conditions is satisfied:
+[The Kubernetes Autoscaler in a cluster created by KKP]({{< ref "./tutorials-howtos/KKP-autoscaler/" >}}) can automatically scale up/down when one of the following conditions is satisfied:
+
 1. Some pods fail to run in the cluster due to insufficient resources.
 2. There are nodes in the cluster that have been underutilized for an extended period (10 minutes by default) and pods running on those nodes can be rescheduled to other existing nodes.
 
-#### Manage all KKP users directly from a single panel
-The Admin panel allows KKP administrators to manage the global settings that impact all KKP users directly. Here as an administrator, you can do the following:
+#### Manage all KKP Users Directly from a Single Panel
+The admin panel allows KKP administrators to manage the global settings that impact all KKP users directly. As an administrator, you can do the following:
 
-- Customize the way custom links (example: Twitter, Github, Slack) are displayed in the Kubermatic dashboard
-- Control various cluster related settings that influence cluster creation, management and clean up after deletion
-- Select from a range of filters to find and control existing dynamic data centres or add new ones
-- Define Preset types in a Kubernetes Custom Resource Definition (CRD) allowing the assignment of new credential types to supported providers
-- Enable and configure etcd backups for your clusters through Backup Buckets
+- Customize the way custom links (example: Twitter, Github, Slack) are displayed in the Kubermatic dashboard.
+- Control various cluster related settings that influence cluster creation, management and clean up after deletion.
+- Select from a range of filters to find and control existing dynamic data centres or add new ones.
+- Define Preset types in a Kubernetes Custom Resource Definition (CRD) allowing the assignment of new credential types to supported providers.
+- Enable and configure etcd backups for your clusters through Backup Buckets.
 
-#### Manage worker nodes via the UI or the CLI
-Worker nodes can be managed via the KKP web dashboard. Once you have installed kubectl, you can also manage them via CLI to automate the creation, deletion, and upgrade of nodes.
+#### Manage Worker Nodes via the UI or the CLI
+Worker nodes can be managed [via the KKP web dashboard]({{< ref "./tutorials-howtos/manage-worker's-node/via-ui/" >}}). Once you have installed kubectl, you can also manage them [via CLI]({{< ref "./tutorials-howtos/manage-worker's-node/via-command-line" >}}) to automate the creation, deletion, and upgrade of nodes.
 
 #### Monitoring, Logging & Alerting
 When it comes to monitoring, no approach fits all use cases. KKP allows you to adjust things to your needs by enabling certain customizations to enable easy and tactical monitoring.
@@ -60,19 +62,19 @@ KKP provides two different levels of Monitoring, Logging, and Alerting.
 Integrated Monitoring, Logging and Alerting functionality for applications and services in KKP user clusters are built using Prometheus, Loki, Cortex and Grafana. Furthermore, this can be enabled with a single click on the KKP UI.
 
 #### OIDC Provider Configuration
-Since Kubernetes does not provide an OpenID Connect (OIDC) Identity Provider, KKP allows the user to configure a custom OIDC. This way you can grant access and information to the right stakeholders.
+Since Kubernetes does not provide an OpenID Connect (OIDC) Identity Provider, KKP allows the user to configure a custom OIDC. This way you can grant access and information to the right stakeholders and fulfill security requirements by managing user access in a central identity provider across your whole infrastructure.
 
-#### Upgrading Control Plane and the kubelets
+#### Easily Upgrading Control Plane and Nodes
 A specific version of Kubernetes’ control plane typically supports a specific range of kubelet versions connected to it. KKP enforces the rule “kubelet must not be newer than kube-apiserver, and maybe up to two minor versions older” on its own. KKP ensures this rule is followed by checking during each upgrade of the clusters’ control plane or node’s kubelet. Additionally, only compatible versions are listed in the UI as available for upgrades.
 
-#### OPA
-To enforce policies and improve governance in Kubernetes, the Open Policy Agent (OPA) can be used. KKP integrates it using Gatekeeper which is an OPA’s Kubernetes native policy engine. As an Admin you can enable and enforce OPA integration during cluster creation by default via the UI.
+#### Open Policy Agent (OPA)
+To enforce policies and improve governance in Kubernetes, Open Policy Agent (OPA) can be used. KKP integrates it using OPA Gatekeeper as a kubernetes-native policy engine supporting OPA policies. As an admin you can enable and enforce OPA integration during cluster creation by default via the UI.
 
 #### Cluster Templates
-Clusters can be created in a few clicks with the UI. To take the user experience one step further and make repetitive tasks redundant, cluster templates allow you to save data entered into a wizard to create multiple clusters from a single template at once. The templates can be saved to be used subsequently for new cluster creation.
+Clusters can be created in a few clicks with the UI. To take the user experience one step further and make repetitive tasks redundant, cluster templates allow you to save data entered into a wizard to create multiple clusters from a single template at once. Templates can be saved to be used subsequently for new cluster creation.
 
-#### Use default Addons to extend the functionality of Kubernetes
-Addons are specific services and tools extending the functionality of Kubernetes. Default addons are installed in each user cluster in KKP. The KKP Operator comes with a tool to output full default KKP configuration, serving as a starting point for adjustments. Accessible addons can be installed in each user cluster in KKP on user demand.
+#### Use Default Addons to Extend the Functionality of Kubernetes
+[Addons]({{< ref "./architecture/concept/kkp-concepts/addons/" >}}) are specific services and tools extending the functionality of Kubernetes. Default addons are installed in each user cluster in KKP. The KKP Operator comes with a tool to output full default KKP configuration, serving as a starting point for adjustments. Accessible addons can be installed in each user cluster in KKP on user demand.
 
 {{% notice tip %}}
 For latest updates follow us on Twitter [@Kubermatic](https://twitter.com/Kubermatic)
@@ -81,4 +83,4 @@ For latest updates follow us on Twitter [@Kubermatic](https://twitter.com/Kuberm
 
 ## Further Information
 
-See [Kubermatic.com](https://www.kubermatic.com/).
+See [kubermatic.com](https://www.kubermatic.com/).

--- a/content/kubermatic/main/architecture/_index.en.md
+++ b/content/kubermatic/main/architecture/_index.en.md
@@ -7,7 +7,7 @@ weight = 5
 
 Kubermatic Kubernetes Platform (KKP) makes full use of Kubernetes cluster to organize and scale workloads, depending on your and your customer's needs. In a typical small-scale setup, pictured below, a single cluster contains KKP and the master components for every user cluster.
 
-![KKP Architecture Diagram](/img/kubermatic/main/architecture/combined-main-seed.png)
+![KKP Architecture Diagram](/img/kubermatic/main/architecture/combined-master-seed.png)
 
 ### Master Cluster
 

--- a/content/kubermatic/main/installation/_index.en.md
+++ b/content/kubermatic/main/installation/_index.en.md
@@ -2,9 +2,20 @@
 title = "Installation"
 date = 2018-04-28T12:07:15+02:00
 weight = 15
-chapter = true
 +++
 
-# Installation
+This chapter offers guidance on how to install Kubermatic Kubernetes Platform (KKP).
 
-Get information on how to install and manage Kubermatic Kubernetes Platform (KKP).
+## Terminology
+
+In this chapter, you will find the following KKP-specific terms:
+
+* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
+* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
+* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
+
+It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../architecture/" >}}).
+
+## Installation Methods
+
+At the moment, the only supported installation method for KKP is using the Kubermatic Installer. We provide an [installation guide for the Community Edition (CE)]({{< ref "./install-kkp-CE/" >}}) that uses this method. Installation for the Enterprise Edition (EE) is fundamentally the same and only requires a adjustments to the CE installation that you can find [here]({{< ref "./install-kkp-EE/" >}}).

--- a/content/kubermatic/main/tutorials-howtos/KKP-autoscaler/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/KKP-autoscaler/_index.en.md
@@ -1,15 +1,15 @@
 
 +++
-title = "Kubermatic Kubernetes Platform (KKP) Cluster Autoscaler"
+title = "Cluster Autoscaler"
 date = 2021-08-05T14:07:10+02:00
 weight = 8
 +++
 
-This section deals with the usage of Kubernetes Cluster Autoscaler in the KKP Cluster.
+This section deals with the usage of Kubernetes Cluster Autoscaler in a KKP User Cluster.
 
 ## What is a Cluster Autoscaler in Kubernetes?
 
-Kubernetes Cluster Autoscaler is a tool that automatically adjusts the size of the worker’s node up or down depending on the consumption. This means that the Autoscaler, for example, automatically scale up a Cluster by increasing the node size when there are not enough node resources for Cluster workload scheduling and scale down when the node resources have continuously staying idle, or there are more than enough node resources available for Cluster workload scheduling. In a nutshell, it is a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes.
+Kubernetes Cluster Autoscaler is a tool that automatically adjusts the size of the worker’s node up or down depending on the consumption. This means that the autoscaler, for example, automatically scale up a Cluster by increasing the node count when there are not enough node resources for Cluster workload scheduling and scale down when the node resources have continuously staying idle, or there are more than enough node resources available for Cluster workload scheduling. In a nutshell, it is a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes.
 
 ## KKP Cluster Autoscaler Usage
 


### PR DESCRIPTION
This PR improves our docs landing page and the installation section in some ways:

- Enforce title case capitalisation on feature headlines on the docs landing page
- Add links to some of the docs landing page features
- Fix image reference on architecture page
- Improve the "Installation" chapter page with some basic content and references to the subpages
- Some light improvements to the installation guide, including mention of key cloud providers we support
- Change the title of the autoscaler doc because it wasn't matching other tutorial pages visually