### PR TITLE
Brighten up inline code highlighting

### DIFF
--- a/content/kubermatic/main/_index.en.md
+++ b/content/kubermatic/main/_index.en.md
@@ -3,9 +3,7 @@ title = ""
 date = 2019-04-27T16:06:34+02:00
 +++
 
-
 ![Kubermatic Kubernetes Platform logo](/img/KubermaticKubernetesPlatform-logo.jpg)
-
 
 ## What is Kubermatic Kubernetes Platform (KKP)?
 

--- a/themes/kubermatic-docs/assets/scss/_theme-kubermatic.scss
+++ b/themes/kubermatic-docs/assets/scss/_theme-kubermatic.scss
@@ -328,10 +328,10 @@ body {
 
 code {
     padding: 1px 5px;
-    background-color: var(--GRAY-color);
+    background-color: #F3F3F3;
     color: var(--MAIN-TEXT-color);
-    border: none;
-    border-radius: 0;
+    border: 1px solid var(--GRAY-color);
+    border-radius: 4px;
     font-size: 1rem;
     white-space: pre-wrap;
 }


### PR DESCRIPTION
As per discussions with @cschieder, this PR updates the inline code highlight blocks (this is how they look like in GitHub markdown: `inline code highlight`). IMHO it improves readability (since the background is brightened up) while still highlighting code blocks.

This is how it looks like:

![Screenshot 2023-01-12 at 11 05 35](https://user-images.githubusercontent.com/10295525/212037904-34f27b3d-aded-4fcd-9275-859af809e20a.png)
