### PR TITLE
Add `oidc_logout_url` in OIDC provider configuration docs

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
@@ -87,6 +87,7 @@ various UI-related options can be set, among them:
 
 - `oidc_provider_url` to change the base URL of the OIDC provider
 - `oidc_provider_scope` to change the scope of the OIDC provider (the `scope` URL parameter)
+- `oidc_logout_url` to redirect to logout URL of the OIDC provider
 
 A configuration of a custom OIDC provider may look like this:
 
@@ -96,7 +97,8 @@ spec:
     config: |
       {
         "oidc_provider_url": "https://keycloak.kubermatic.test/auth/realms/test/protocol/openid-connect/auth",
-        "oidc_provider_scope": "openid email profile roles"
+        "oidc_provider_scope": "openid email profile roles",
+        "oidc_logout_url": "https://keycloak.kubermatic.test/auth/realms/test/protocol/openid-connect/logout"
       }
 ```
 

--- a/content/kubermatic/v2.21/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
+++ b/content/kubermatic/v2.21/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
@@ -87,6 +87,7 @@ various UI-related options can be set, among them:
 
 - `oidc_provider_url` to change the base URL of the OIDC provider
 - `oidc_provider_scope` to change the scope of the OIDC provider (the `scope` URL parameter)
+- `oidc_logout_url` to redirect to logout URL of the OIDC provider (available in `2.21.5`)
 
 A configuration of a custom OIDC provider may look like this:
 
@@ -96,7 +97,8 @@ spec:
     config: |
       {
         "oidc_provider_url": "https://keycloak.kubermatic.test/auth/realms/test/protocol/openid-connect/auth",
-        "oidc_provider_scope": "openid email profile roles"
+        "oidc_provider_scope": "openid email profile roles",
+        "oidc_logout_url": "https://keycloak.kubermatic.test/auth/realms/test/protocol/openid-connect/logout"
       }
 ```
 


### PR DESCRIPTION
A new `oidc_logout_url` endpoint was added in https://github.com/kubermatic/dashboard/pull/5521. If this endpoint is provided then UI will redirect to it after logging out.