### PR TITLE
Add release cycles to support policy document

### DIFF
--- a/content/kubermatic/main/architecture/support-policy/_index.en.md
+++ b/content/kubermatic/main/architecture/support-policy/_index.en.md
@@ -8,11 +8,22 @@ weight = 4
 
 ## Supported KKP Versions
 
-KKP versions are expressed as x.y.z, where x is the major version, y is the
-minor version, and z is the patch version.
+KKP versions are expressed as x.y.z, where x is the **major** version, y is the
+**minor** version, and z is the **patch** version.
 
 KKP follows the Kubernetes release model and cycle, though for practical reasons
 releases are a bit delayed to ensure compatibility with Kubernetes. In general,
-the latest three minor versions of KKP are supported, i.e. 2.21, 2.20 and 2.19.
+the latest three minor versions of KKP are supported, i.e. 2.22, 2.21 and 2.20.
 With the release of a new minor KKP version, support for the oldest supported
 KKP version is dropped.
+
+## Release Cycle
+
+New KKP [versions](https://github.com/kubermatic/kubermatic/releases) are released in
+a semi-fixed cadence. Actual release dates might vary due to a lack of changes to warrant a release
+or due to urgent fixes that cannot wait for the next release window. As such,
+the following release rhythms are given as orientation only and do not constitute guaranteed release dates.
+
+* Patch releases are scheduled **monthly**.
+* Minor releases are scheduled **triannual**.
+* Major releases have no fixed schedule and will only happen when KKP changes in a substantial way.

--- a/content/kubermatic/main/architecture/support-policy/_index.en.md
+++ b/content/kubermatic/main/architecture/support-policy/_index.en.md
@@ -13,9 +13,8 @@ KKP versions are expressed as x.y.z, where x is the **major** version, y is the
 
 KKP follows the Kubernetes release model and cycle, though for practical reasons
 releases are a bit delayed to ensure compatibility with Kubernetes. In general,
-the latest three minor versions of KKP are supported, i.e. 2.22, 2.21 and 2.20.
-With the release of a new minor KKP version, support for the oldest supported
-KKP version is dropped.
+the latest three minor versions of KKP are supported. With the release of a
+new minor KKP version, support for the oldest supported KKP version is dropped.
 
 ## Release Cycle
 


### PR DESCRIPTION
We want to publish some general information on how often we cut patch and minor releases. This adds information to our "Support Policy" document, which already described what KKP versions are supported and how long. Combining both information will help end users estimate the lifecycle of a KKP release much better.