### PR TITLE
Update headers to be more consistent in language

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/pod-security-policy/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/pod-security-policy/_index.en.md
@@ -11,9 +11,9 @@ This is also true for existing clusters. Without an authorizing policy, the cont
 
 PSP objects are cluster-level objects. They define a set of conditions that a pod must pass to be accepted by the PSP admission controller. The most common way to apply this is using RBAC. For a pod to use a specific Pod Security Policy, the pod should run using a Service Account or a User that has `use` permission to that particular Pod Security policy.
 
-## Note on PodSecurityPolicy deprecation
+## Note on PodSecurityPolicy Deprecation
 
-Please note that PodSecurityPolicy [Pod Security Policy deprecation](https://kubernetes.io/docs/concepts/security/pod-security-policy/) was deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. As such, future KKP releases will not support the PodSecurityPolicy feature on Kubernetes 1.25 or higher.
+Please note that PodSecurityPolicy [Pod Security Policy deprecation](https://kubernetes.io/docs/concepts/security/pod-security-policy/) was deprecated in Kubernetes v1.21, and removed from Kubernetes in v1.25. As such, KKP does not support the PodSecurityPolicy feature on Kubernetes 1.25 or higher.
 
 We suggest to move to [Open Policy Agent (OPA)]({{< relref "../../../../../tutorials-howtos/opa-integration/">}}) as a replacement.
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
@@ -14,6 +14,8 @@ It is still possible to access the system services by using `kubectl port-forwar
 proxy's authentication entirely.
 {{% /notice %}}
 
+## Configuration
+
 Dex can then be configured to use external authentication sources like GitHub's or Google's OAuth endpoint, LDAP or
 OpenID Connect. For this to work you have to configure both Dex (the `oauth` Helm chart) and OAuth2-Proxy
 (called "IAP", Identity-Aware Proxy) in your Helm `values.yaml`.
@@ -148,13 +150,13 @@ a single wildcard entry for all IAP deployments or individual records. Refer to 
 [installation instructions]({{< ref "../../../../../installation/install-kkp-CE" >}}) for more information on
 what records to create.
 
-### Alternative Authentication Provider
+## Alternative Authentication Provider
 
 It's possible to use a different authentication provider than Dex. Please refer to the
 [OIDC provider]({{< ref "../../../../../tutorials-howtos/OIDC-Provider-Configuration" >}}) chapter for more information on how to configure
 KKP and OAuth2-Proxy accordingly.
 
-### Security Considerations
+## Security Considerations
 
 The IAP does not protect services against access from within the cluster. Sensitive services should therefore
 be configured to require further authentication. Grafana, the [Master / Seed Monitoring, Logging & Alerting Stack]({{< ref "../../../../monitoring-logging-alerting/master-seed/" >}})'s

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
@@ -6,9 +6,7 @@ enterprise = true
 
 +++
 
-## Resource Quotas in KKP
-
-Resource Quotas allow administrators to set quotas on the amount of resources a subject can use. For now the only
+Resource Quotas in KKP allow administrators to set quotas on the amount of resources a subject can use. For now the only
 subject which is supported is Project, so the resource quotas currently limit the amount of resources that can be used project-wide.
 
 The resources in question are the resources of the user cluster:
@@ -24,7 +22,7 @@ That one just controls the size of the machines suggested to users in the KKP Da
 {{% /notice %}}
 
 
-### Setting up the resource quotas
+## Setting up Resource Quotas
 
 The resource quotas are managed by administrators either through the KKP UI/API or through the Resource Quota CRDs.
 
@@ -52,7 +50,7 @@ represent the values. One note is that CPU is denoted in single integer numbers.
 To simplify matters the UI uses GB as representation for Memory and Storage. The conversion from any value
 set in the ResourceQuota is done automatically by the API.
 
-### Calculating the quota usage
+## Calculating Quota Usage
 
 The ResourceQuota has 2 status fields:
 - `globalUsage` which shows the resource usage across all seeds
@@ -101,7 +99,7 @@ resulting K8s Node `.status.capacity`.
 | VMWare Cloud Director | CPU * CPUCores (Machine spec)                                                          | MemoryMB (from Machine spec)                                                            | DiskSizeGB (from Machine spec)                         |
 
 
-### Enforcing the quotas
+## Enforcing Quotas
 
 The quotas are enforced through a validating webhook on Machine resources in the user clusters. This means that the quota validation
 takes place after the MachineDeployment is created, and if quota is exceeded, the creation of the Machines(Nodes) will be blocked.
@@ -115,7 +113,7 @@ Furthermore, a project quota widget of the active project is visible in the dash
 
 ![Quota Widget](/img/kubermatic/main/architecture/concepts/resource-quotas/widget.png?classes=shadow,border "Quota Widget")
 
-### Some additional information
+## Some Additional Information
 
 {{% notice note %}}
 **Note:** If multiple nodes are created in the same time there is a possibility of a race happening and the quota being exceeded.
@@ -137,7 +135,7 @@ The quotas won't restrict the usage of resources for the control plane on the se
 
 Nodes which join the cluster using other means than through KKP are not supported in the quotas.
 
-### Default Project Resource Quotas
+## Default Project Resource Quotas
 
 It is possible to set the a default resource quota for all projects which do not have a quota already set.
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/service-account/service-account-token-projection/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/service-account/service-account-token-projection/_index.en.md
@@ -58,7 +58,7 @@ The following table summarizes the supported properties of the `ServiceAccountSe
 | `apiAudiences`                 | Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences. Multiple audiences can be separated by comma (`,`). | Equal to `issuer`. |
 
 
-### Example: Configuration using a request to KKP API
+### Example: Configuration using a Request to KKP API
 To configure the feature in an existing cluster, execute a `PATCH` request to URL:
 
 `https://<your-kubermatic-domain>/api/v1/projects/<project-id>/dc/<datacenter-name>/clusters/<cluster-id>` 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/service-account/using-service-account/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/service-account/using-service-account/_index.en.md
@@ -36,7 +36,7 @@ You can also change a token name. It is possible to delete a service account tok
 
 You can see when a token was created and when will expire.
 
-## Using service accounts with KKP
+## Using Service Accounts with KKP
 You can control service account access in your project by provided groups.
 There are three basic access level groups:
  - viewers
@@ -65,7 +65,7 @@ Permissions for read-only actions that do not affect state, such as viewing.
  - editors are not allowed to interact with members of a project (UserProjectBinding)
  - editors are not allowed to interact with service accounts (User)
 
-#### Project managers
+#### Project Managers
 
 **The `project managers` is service account specific group. Which allows**
 
@@ -75,7 +75,7 @@ Permissions for read-only actions that do not affect state, such as viewing.
 
 Project managers are not allowed to interact with clusters.
 
-## Accessing API via Service Account Token
+## Accessing the API via Service Account Tokens
 
 A client that wants to authenticate itself with a server can then do so by including an `Authorization` request header
 field with the service account token:

--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -9,7 +9,7 @@ weight = 25
 
 This page documents the list of known issues and possible work arounds/solutions.
 
-### 1. OIDC user authentication issue
+### 1. OIDC User Authentication Issue
 
 **Problem** 
 
@@ -45,7 +45,7 @@ In the case where upgrade is not desirable then a work around can be applied by 
 
 `kubectl label ns nginx-ingress-controller "kubernetes.io/metadata.name=nginx-ingress-controller"`
 
-### 2. Connectivity issue in pod-to-NodePort service in Cilium + IPVS proxy mode
+### 2. Connectivity Issue in Pod-to-NodePort Service in Cilium + IPVS Proxy Mode
 
 **Problem**
 

--- a/content/kubermatic/main/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/main/architecture/requirements/cluster-requirements/_index.en.md
@@ -5,9 +5,7 @@ weight = 15
 
 +++
 
-## Requirements
-
-### Master Cluster
+## Master Cluster
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in a highly-available setup with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
@@ -20,7 +18,7 @@ The Master Cluster hosts the KKP components and might also act as a seed cluster
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
-### User Cluster
+## User Cluster
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
@@ -37,20 +35,24 @@ The User Cluster is a Kubernetes cluster created and managed by KKP. The exact r
 * Certain ports are open on your machines. See below for more details.
 * Swap disabled. You **MUST** disable swap in order for the kubelet to work properly.
 
-### Verify the MAC Address and `product_uuid` Are Unique for Every Node
+## Verify Node Uniqueness
+
+You will need to verify that MAC address and `product_uuid` are unique on every node. This should usually be the case but might not be, especially for on-premise providers.
 
 * You can get the MAC address of the network interfaces using the command `ip link` or `ifconfig -a`
 * The product\_uuid can be checked by using the command `sudo cat /sys/class/dmi/id/product_uuid`
 
 It is very likely that hardware devices will have unique addresses, although some virtual machines may have identical values. Kubernetes uses these values to uniquely identify the nodes in the cluster. If these values are not unique to each node, the installation process may [fail](https://github.com/kubernetes/kubeadm/issues/31).
 
-### Check Network Adapters
+## Check Network Adapters
 
 If you have more than one network adapter, and your Kubernetes components are not reachable on the default route, we recommend you add IP route(s) so Kubernetes cluster addresses go via the appropriate adapter.
 
-### Check Required Ports
+## Check Required Ports
 
-#### Master Cluster Master Node(s)
+The tables below list the ports that need to be open for communication, e.g. by allowing them via a firewall.
+
+### Master Cluster Master Node(s)
 
 | Protocol | Direction | Port Range | Purpose                 |
 |----------|-----------|------------|-------------------------|
@@ -61,7 +63,7 @@ If you have more than one network adapter, and your Kubernetes components are no
 | TCP      | Inbound   | 10252      | kube-controller-manager |
 | TCP      | Inbound   | 10255      | Read-only kubelet API   |
 
-#### Worker Node(s) & User Cluster Worker Nodes
+### Worker Node(s) & User Cluster Worker Nodes
 
 | Protocol | Direction | Port Range  | Purpose               |
 |----------|-----------|-------------|-----------------------|

--- a/content/kubermatic/main/architecture/role-based-access-control/_index.en.md
+++ b/content/kubermatic/main/architecture/role-based-access-control/_index.en.md
@@ -10,7 +10,7 @@ weight = 5
 A project is an entity that logically groups various resources.  All resources in a project can be accessed by users that have the correct role associated with them.
 Affiliation of a user to one of the roles gives them certain powers they are allowed to use within a project.
 
-### Kubermatic Kubernetes Platform (KKP) roles
+## Kubermatic Kubernetes Platform (KKP) Roles
 
 There are three roles: owner, editor, and viewer. These roles are concentric; that is, the owner role includes the permissions
 of the editor role, and the editor role includes the permissions of the viewer role.
@@ -29,7 +29,7 @@ The following table summarizes the permissions:
 | editor                                            | All viewer permissions, plus permissions to create, edit & delete the cluster.<br>Editors are not allowed to delete a project. Editors are not allowed to interact with members of a project (UserProjectBinding).<br>Editors are not allowed to interact with service accounts (user) |
 | owner (role can not be held by a service account) | All editor permissions and permissions for managing permissions for a project.<br>Only the owners of a project can create a service account (aka. users) <br>Only the owners of a project can manipulate members                                                                        |
 
-### KKP Service Accounts
+## KKP Service Accounts
 
 A service account is a special type of user account that belongs to the KKP project, instead of to an individual
 end-user. A service account is considered as project's resource. Only the owner of a project can create and update a

--- a/content/kubermatic/main/architecture/supported-providers/AWS/aws.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/AWS/aws.en.md
@@ -5,8 +5,6 @@ weight = 7
 
 +++
 
-## AWS
-
 When using KKP to provision user clusters on Amazon Web Services (AWS), the cluster credentials provided must have a policy assigned that allows managing the instance profiles and roles. This means that only a single policy for KKP must be created while all others are automatically created and removed when no longer required.
 
 Ensure that the assigned policy contains at least the following permissions. Policies and users can be managed on the [AWS Management Console](https://eu-central-1.console.aws.amazon.com/iamv2/home?region=eu-central-1#/policies).

--- a/content/kubermatic/main/architecture/supported-providers/google-cloud/gcp.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/google-cloud/gcp.en.md
@@ -5,14 +5,12 @@ weight = 7
 
 +++
 
-## Google Cloud Platform
+## Compute Engine API
 
-### Compute Engine API
-
-For the access to the Compute Engine API it has to be enabled at the
+For the access to the Compute Engine API it has to be enabled in the
 [Google APIs console](https://console.developers.google.com/apis/dashboard).
 
-### User Roles
+## User Roles
 
 The user for the *Google Service Account* that has to be created has to
 have three roles:
@@ -37,7 +35,7 @@ gcloud projects add-iam-policy-binding YOUR_PROJECT_ID --member 'serviceAccount:
 gcloud projects add-iam-policy-binding YOUR_PROJECT_ID --member 'serviceAccount:YOUR_SERVICE_ACCOUNT_ID' --role='roles/viewer'
 ```
 
-### Google Service Account
+## Google Service Account
 
 A *Google Service Account* for the platform has to be created, see
 [Creating and managing service accounts](https://cloud.google.com/iam/docs/creating-managing-service-accounts).

--- a/content/kubermatic/main/architecture/supported-providers/vSphere/vSphere.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/vSphere/vSphere.en.md
@@ -5,13 +5,11 @@ weight = 7
 
 +++
 
-## VSphere
-
 {{% notice warning %}}
 The Kubernetes vSphere driver contains bugs related to detaching volumes from offline nodes. See the [**Volume detach bug**](#volume-detach-bug) section for more details.
 {{% /notice %}}
 
-### VM Images
+## VM Images
 
 When creating worker nodes for a user cluster, the user can specify an existing image. Defaults may be set in the [seed cluster `spec.datacenters.EXAMPLEDC.vsphere.endpoint`]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}}).
 
@@ -24,7 +22,7 @@ Supported operating systems
 * Flatcar (Stable channel) [ova](https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova)
 
 
-#### Importing the OVA
+### Importing the OVA
 
 1. Go into the VSphere WebUI, select your datacenter, right click onto it and choose "Deploy OVF Template"
 1. Fill in the "URL" field with the appropriate url
@@ -34,23 +32,23 @@ Supported operating systems
 1. Leave everyhting in the "Customize Template" and "Ready to complete" dialog as it is
 1. Wait until the VM got fully imported and the "Snapshots" => "Create Snapshot" button is not grayed out anymore
 
-#### Importing the QCOW2
+### Importing the QCOW2
 
 1. Convert it to vmdk: `qemu-img convert -f qcow2 -O vmdk CentOS-7-x86_64-GenericCloud.qcow2 CentOS-7-x86_64-GenericCloud.vmdk`
 1. Upload it to a Datastore of your vSphere installation
 1. Create a new virtual machine that uses the uploaded vmdk as rootdisk
 
-#### Modifications
+### Modifications
 
 Modifications like Network, disk size, etc. must be done in the ova template before creating a worker node from it.
 If user clusters have dedicated networks, all user clusters therefore need a custom template.
 
-### VM Folder
+## VM Folder
 
 During creation of a user cluster Kubermatic Kubernetes Platform (KKP) creates a dedicated VM folder in the root path on the Datastore (Defined in the [seed cluster `spec.datacenters.EXAMPLEDC.vsphere.datastore`]({{< ref "../../../tutorials-howtos/project-and-cluster-management/seed-cluster" >}})).
 That folder will contain all worker nodes of a user cluster.
 
-### Credentials / Cloud-Config
+## Credentials / Cloud-Config
 
 Kubernetes needs to talk to the vSphere to enable Storage inside the cluster.
 For this, kubernetes needs a config called `cloud-config`.
@@ -58,11 +56,11 @@ This config contains all details to connect to a vCenter installation, including
 
 As this Config must also be deployed onto each worker node of a user cluster, its recommended to have individual credentials for each user cluster.
 
-### Permissions
+## Permissions
 
 The vsphere user has to have to following permissions on the correct resources:
 
-#### User Cluster Could Controller Manager / CSI
+### User Cluster Could Controller Manager / CSI
 **Note:** Below roles were updated based on [vsphere-storage-plugin-roles] for external CCM which is available from kkp v2.18+ and vsphere v7.0.2+
 
 For provisioning actions of the KKP seed cluster, a technical user (e.g. `cust-ccm-cluster`) is needed:
@@ -113,7 +111,7 @@ System.Anonymous
 System.Read
 System.View
 ```
-#### User Cluster
+### User Cluster
 
 For provisioning actions of the KKP in scope of an user cluster, a technical user (e.g. `cust-user-cluster`) is needed:
 
@@ -352,12 +350,12 @@ VirtualMachine.State.RevertToSnapshot
 
 The described permissions have been tested with vSphere 7.0.U2 and might be different for other vSphere versions.
 
-#### Terraform Setup
+### Terraform Setup
 
 It's also possible to create the roles by a terraform script. The following repo can be used as reference:
 * https://github.com/kubermatic-labs/kubermatic-vsphere-permissions-terraform
 
-#### Volume Detach Bug
+### Volume Detach Bug
 
 After a node is powered-off, the Kubernetes vSphere driver doesn't detach disks associated with PVCs mounted on that node. This makes it impossible to reschedule pods using these PVCs until the disks are manually detached in vCenter.
 
@@ -369,7 +367,7 @@ Upstream Kubernetes has been working on the issue for a long time now and tracki
 * <https://github.com/kubernetes/kubernetes/issues/71829>
 * <https://github.com/kubernetes/kubernetes/issues/75342>
 
-### Datastores and Datastore Clusters
+## Datastores and Datastore Clusters
 
 *Datastore* in VMWare vSphere is an abstraction for storage.
 *Datastore Cluster* is a collection of datastores with shared resources and a

--- a/content/kubermatic/main/cheat-sheets/changelog/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/changelog/_index.en.md
@@ -125,7 +125,7 @@ after the release.
 }
 ```
 
-### Overriding embedded changelog
+### Overriding Embedded Changelog
 
 Assuming that you know how to exec into the container and copy resources from/to it, `changelog.json` can be simply
 copied over to running KKP Dashboard container. It is stored inside the container in `dist/assets/config` directory.

--- a/content/kubermatic/main/cheat-sheets/debugging/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/debugging/_index.en.md
@@ -7,7 +7,7 @@ chapter = false
 
 ## Debugging
 
-### Check if the Kubermatic Kubernetes Platform (KKP) Components Are Running
+### Check if the Kubermatic Kubernetes Platform (KKP) Components are Running
 
 1. Check on the kubermatic-pods by issuing a `kubectl get pod -n kubermatic`
 1. If any of them is not running, execute `kubectl logs -n kubermatic $PODNAME` to find out the issue

--- a/content/kubermatic/main/cheat-sheets/etcd/backup-and-restore/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/etcd/backup-and-restore/_index.en.md
@@ -18,7 +18,7 @@ The new controllers manage backup, restore and cleanup operations using [Kuberne
 
 Currently, only S3 compatible backup backends are supported.
 
-## Enabling The New controllers
+## Enabling the new Controllers
 
 To use the new backup/restore controller, the [etcd-launcher]({{< ref "../etcd-launcher" >}}) feature must be enabled along with specifically enabling the controllers by passing the flag `--enable-etcd-backups-restores` to the seed controller manager.
 This can be achieved for a Seed by KPP admins through configuring backup destinations for a Seed. As soon as there is at least one backup destination set, the feature is enabled.
@@ -32,7 +32,7 @@ The legacy way of enabling the automatic etcd backups through the KubermaticConf
 
 The new backup controller uses 2 default jobs to for storing backups and deleting them. If needed, it is possible to configure custom jobs in the [KubermaticConfiguration](https://docs.kubermatic.com/kubermatic/main/references/crds/#kubermaticseedcontrollerconfiguration).
 
-#### Store job container(backupStoreContainer)
+#### Store Job Container (backupStoreContainer)
 
 ```yaml
 name: store-container
@@ -54,7 +54,7 @@ volumeMounts:
   mountPath: /backup
 ```
 
-#### Delete job container(backupDeleteContainer)
+#### Delete Job Container (backupDeleteContainer)
 
 ```yaml
 name: delete-container

--- a/content/kubermatic/main/cheat-sheets/etcd/etcd-launcher/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/etcd/etcd-launcher/_index.en.md
@@ -3,7 +3,7 @@ title = "Etcd Launcher"
 weight = 30
 +++
 
-Starting with version v2.15.0, KKP introduced etcd-launcher as an experimental feature. Etcd-launcher is a lightweight wrapper around the etcd binary. It's responsible for reading information from KKP API and flexibly control how the user cluster etcd ring is started.
+Starting with version v2.15.0, KKP introduced etcd-launcher as an experimental feature. etcd-launcher is a lightweight wrapper around the etcd binary. It's responsible for reading information from KKP API and flexibly control how the user cluster etcd ring is started.
 
 In v2.19.0, peer TLS connections have been added to etcd-launcher. Existing etcd clusters (with or without etcd-launcher) will be upgraded to peer TLS connections if the etcd-launcher feature gate is enabled on a cluster.
 
@@ -23,7 +23,7 @@ etcd-launcher is an optional feature. It should not be enabled unless all users 
 
 Since this is an optional feature, it's disabled by default. There are two modes to enable etcd-launcher support:
 
-## Etcd-launcher for all user clusters (global setting)
+## etcd-launcher for all User Clusters (global setting)
 
 {{% notice warning %}}
 It is not recommended to enable the `EtcdLauncher` feature gate globally at the same as applying a KKP upgrade, due to the potential for several changes to etcd happening in short sequence.
@@ -64,7 +64,7 @@ Once the seed controller manager is reloaded, all users clusters will get upgrad
 
 When etcd-launcher is enabled for all user clusters, the setting is "inherited" into all user clusters. It is not possible to revert the settings for existing user clusters, but you can revert the changes in your `KubermaticConfiguration` so that new clusters are not created with etcd-launcher. Just undo the changes shown above and apply again.
 
-## Etcd-launcher for a specific user cluster
+## etcd-launcher for a Specific User Cluster
 
 ### Enabling etcd-launcher
 In this mode, the feature is only enabled for a specific user cluster. This can be done by editing the object cluster and enabling the feature flag for etcd-launcher:
@@ -90,7 +90,7 @@ It is not possible to disable etcd-launcher since v2.19.0, as the upgrade of pee
 ## Etcd Launcher Features
 Enabling etcd-launcher enables cluster operators to perform several operational tasks that were not possible before. With the the v2.15.0 releases, etcd-launcher provides the following capabilities:
 
-### Scaling user cluster etcd ring
+### Scaling User Cluster etcd Ring
 Prior to version v2.15.0, the user cluster etcd ring ran as a simple and static 3-node ring. With etcd-launcher enabled, it's now possible to resize the etcd ring to increase capacity and/or availability for user clusters.
 
 Currently, the supported minimum etcd ring size is 3 nodes. This is required to maintain etcd quorum during operations. The maximum supported size is 9 nodes, as recommended by etcd upstream.

--- a/content/kubermatic/main/cheat-sheets/etcd/legacy-restore/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/etcd/legacy-restore/_index.en.md
@@ -30,7 +30,7 @@ Therefore the etcd statefulset must be configured to just execute a `exec /bin/s
 kubectl -n cluster-xxxxxxxxxx edit statefulset etcd
 ```
 
-### Deleting All PVC's
+### Deleting All PVCs
 
 To ensure that we start on each pod with a empty disk, we delete all PVC's.
 The StatefulSet will create new ones with empty PV's automatically.
@@ -47,7 +47,7 @@ To ensure all Pods start with the sleep command and with new PV's, all etcd pods
 kubectl -n cluster-xxxxxxxxxx delete pod -l app=etcd
 ```
 
-### Restoring the etcd (Must Be Executed on All etcd Pods)
+### Restoring etcd (Must Be Executed on All etcd Pods)
 
 The restore command is different for each member. Make sure to update it gets executed.
 

--- a/content/kubermatic/main/cheat-sheets/rollout-machinedeployment/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/rollout-machinedeployment/_index.en.md
@@ -5,14 +5,14 @@ description = "Rolling restart machine deployments: Learn about the concept and 
 weight = 25
 +++
 
-## To rolling restart a single machineDeployment
+## To Rolling Restart a Single MachineDeployment
 
 ```shell
 forceRestartAnnotations="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"forceRestart\":\"$(date +%s)\"}}}}}"
 kubectl patch machinedeployment -n kube-system <NAME> --type=merge -p $forceRestartAnnotations 
 ```
 
-## To rolling restart all machineDeployments
+## To Rolling Restart all MachineDeployments
 
 ```shell
 forceRestartAnnotations="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"forceRestart\":\"$(date +%s)\"}}}}}"

--- a/content/kubermatic/main/cheat-sheets/vsphere-cluster-id/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/vsphere-cluster-id/_index.en.md
@@ -26,7 +26,7 @@ user clusters.
   namespace in the seed cluster named `cluster-<name>`, where `<name>` is the
   user cluster name as defined above (e.g. `cluster-s8kkpcccfq`)
 
-## Affected KKP versions and vSphere User Clusters
+## Affected KKP Versions and vSphere User Clusters
 
 The following vSphere user clusters are affected by this issue:
 
@@ -88,7 +88,7 @@ Finally, verify value of the `cluster-id` field:
       don't use an affected KKP version when migrating the cluster to the
       external CCM/CSI**
 
-## Changing the `cluster-id` value
+## Changing the `cluster-id` Value
 
 This guide documents two different approaches to change the `cluster-id` value.
 
@@ -166,7 +166,7 @@ to do in two places:
 1. The `cloud-config-csi` ConfigMap in the user cluster namespace in the
    seed cluster
 
-#### Changing the `cloud-config-csi` Secret in the user cluster
+#### Changing the `cloud-config-csi` Secret in the User Cluster
 
 {{% notice warning %}}
 You should run steps in this section on one cluster at a time. In other words,
@@ -251,7 +251,7 @@ Secret in other affected user clusters**. Once that's done, proceed to the next
 section where you'll update the `cloud-config-csi` Secret in the user cluster
 namespaces in the seed cluster.
 
-#### Changing the `cloud-config-csi` ConfigMap in the user cluster namespaces
+#### Changing the `cloud-config-csi` ConfigMap in the User Cluster Namespaces
 
 {{% notice warning %}}
 You should run steps in this section on one cluster at a time. In other words,
@@ -294,7 +294,7 @@ Before proceeding to the next step, **you need to update the `cloud-config-csi`
 ConfigMap for other affected user clusters**. Once that's done, proceed to the
 next section where you'll finalize the procedure.
 
-#### Finaling the procedure
+#### Finalizing the Procedure
 
 Before proceeding with this section, you **MUST WAIT FOR AN HOUR** to give time
 to vSphere to de-register all volumes.
@@ -361,7 +361,7 @@ kubectl patch cluster <cluster-name-n> --type=merge -p $clusterPatch
 Wait for a minute or two to give time to KKP to reconcile and apply changes on
 all user clusters.
 
-#### Verifying that ConfigMaps and Secrets are updated
+#### Verifying that ConfigMaps and Secrets are Updated
 
 {{% notice warning %}}
 You should run steps in this section on one cluster at a time. In other words,
@@ -397,7 +397,7 @@ cluster-id        = "<vsphere-compute-cluster>"
 **Repeat steps in this section for each affected user cluster** and then proceed
 to the next section.
 
-#### Restarting the CSI controller pods
+#### Restarting the CSI Controller Pods
 
 Finally, restart the vSphere CSI controller pods in the **each affected user
 cluster** to put those changes in the effect:

--- a/content/kubermatic/main/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-CE/_index.en.md
@@ -21,7 +21,7 @@ migrating existing installations.
 For this guide you need to have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [Helm](https://www.helm.sh/) (version 3) installed locally.
 You should be familiar with core Kubernetes concepts and the YAML file format before proceeding.
 
-### Plan your Architecture
+### Plan Your Architecture
 
 Before getting started we strongly recommend you to think ahead and model your KKP setup. In particular you should decide if you want Master and Seed components
 to share the same cluster (a shared Master/Seed setup) or run Master and Seed on two separate clusters. See [our architecture overview]({{< ref "../../architecture/" >}}) for
@@ -33,7 +33,7 @@ Depending on which choice you make, you will need to have either one or two Kube
 If you would like to run multiple Seeds to scale your setup beyond a single Seed, please check out the [Enterprise Edition]({{< ref "../install-kkp-EE/" >}})
 as that feature is only available there.
 
-### Set up Kubernetes
+### Set Up Kubernetes
 
 To aid in setting up the Seed and Master Clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/), which can be used to set up a highly-available Kubernetes cluster.
 Refer to the [KubeOne documentation](https://docs.kubermatic.com/kubeone) for details on how to use it.

--- a/content/kubermatic/main/installation/install-kkp-on-node/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-on-node/_index.en.md
@@ -20,7 +20,7 @@ In this **Get Started with KKP** guide, we will be using AWS Cloud as our underl
 1. [Terraform >v1.0.0](https://www.terraform.io/downloads)
 2. [KubeOne](https://github.com/kubermatic/kubeone/releases)
 
-## Download the repository
+## Download the Repository
 
 The [kubermatic/kkp-single-node](https://github.com/kubermatic/kkp-single-node) contains the required configuration to install KKP on single node k8s with kubeone. Clone or download it, so that you deploy KKP quickly as per the following instructions and get started with it!
 
@@ -59,7 +59,7 @@ output "kubeone_hosts" {
       untaint              = true
 ```
 
-## Prepare the KKP addon configuration
+## Prepare the KKP Addon Configuration
 
 > Replace the TODO place holder in addons/kkp yaml definitions.
 
@@ -81,7 +81,7 @@ sed -i 's/TODO-A-RANDOM-SERVICEACCOUNTKEY/'"$SERVICEACCOUNTKEY"'/g' ./aws/addons
 
 **KKP_DNS** specifies the domain where the kubermatic dashboard would be hosted.
 
-## Create k8s cluster using kubeone along with KKP master as an addon
+## Create k8s Cluster using KubeOne along with KKP Master as an Addon
 
 ```bash
 make k1-apply PROVIDER=aws
@@ -93,7 +93,7 @@ make k1-apply PROVIDER=aws
 export KUBECONFIG=$PWD/aws/<cluster_name>-kubeconfig
 ```
 
-## Validate the KKP Master setup
+## Validate the KKP Master Setup
 
 * Get the LoadBalancer External IP by following command.
 

--- a/content/kubermatic/main/tutorials-howtos/CCM-migration/CCM-migration-via-UI/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/CCM-migration/CCM-migration-via-UI/_index.en.md
@@ -7,8 +7,6 @@ weight = 10
 
 This manual explains how to migrate to using external Cloud Controller Managers for supported providers via UI.
 
-## Cloud Controller Manager (CCM)
-
 The [CCM](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) (Cloud Controller Manager) is a Kubernetes
 control plane component that embeds cloud-specific control logic. There are two different kinds of Cloud controller managers:
 in-tree and out-of-tree. According to the Kubernetes [design proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers),
@@ -20,7 +18,7 @@ among which the dependency of the CCM release cycle from the Kubernetes core rel
 to the Kubernetes core code. Then, the Kubernetes community moved toward the out-of-tree implementation by introducing
 a plugin mechanism that allows different cloud providers to integrate their platforms with Kubernetes.
 
-### CCM migration status
+## CCM Migration Status
 To allow migration from in-tree to out-of-tree CCM for existing cluster, the cluster details view has been extended by a
 section in the top area, the "External CCM Migration Status", that indicates the status of the CCM migration.
 
@@ -28,26 +26,26 @@ section in the top area, the "External CCM Migration Status", that indicates the
 
 The "External CCM Migration Status" can have four different possible values:
 
-#### Not needed
+### Not Needed
 The cluster already uses the external CCM.
 ![ccm_migration_not_needed](ccm_migration_not_needed.png?height=60px&classes=shadow,border)
 
-#### Supported
+### Supported
 KKP supports the external CCM for the given cloud provider, therefore the cluster can be migrated.
 ![ccm_migration_supported](ccm_migration_supported.png?height=130px&classes=shadow,border)
 
 When clicking on this button, a windows pops up to confirm the migration.
 ![ccm_migration_supported](ccm_migration_confirm.png?height=200px&classes=shadow,border)
 
-#### In progress
+### In Progress
 External CCM migration has already been enabled for the given cluster, and the migration is in progress.
 ![ccm_migration_in_progress](ccm_migration_in_progress.png?height=60px&classes=shadow,border)
 
-#### Unsupported
+### Unsupported
 KKP does not support yet the external CCM for the given cloud provider.
 ![ccm_migration_unsupported](ccm_migration_unsupported.png?height=60px&classes=shadow,border)
 
-### Roll out the machineDeployments
+## Roll out MachineDeployments
 Once the CCM migration has been enabled by clicking on the "Supported" button, the migration procedure will hang in 
 "In progress" status until all the `machineDeployments` will be rolled out. To roll out a `machineDeployment` get into 
 the `machineDeployment` view and click on the circular arrow in the top right.

--- a/content/kubermatic/main/tutorials-howtos/KKP-autoscaler/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/KKP-autoscaler/_index.en.md
@@ -18,10 +18,9 @@ The Kubernetes Autoscaler in the KKP Cluster automatically scaled up/down when o
 * Some pods failed to run in the cluster due to insufficient resources.
 * There are nodes in the cluster that have been underutilised for an extended period (10 minutes by default) and can place their Pods on other existing nodes.
 
-## Installing Kubernetes Auto-scaler on KKP Cluster
+## Installing Kubernetes Autoscaler on User Cluster
 
-You can install Kubernetes autoscaler on a running KKP Cluster using the KKP addon mechanism, which is already built into the KKP Cluster dashboard.
-
+You can install Kubernetes autoscaler on a running User Cluster using the KKP addon mechanism, which is already built into the KKP Cluster dashboard.
 
 **Step 1**
 
@@ -129,7 +128,7 @@ test-cluster-worker-pndqd  3h59m            1             1           aws    ubu
 
 The annotation command will be used with one of the MachineDeployments above to annotate the desired MachineDeployments.  In this case, the  `test-cluster-worker-v5drmq` will be annotated, and the minimum and maximum will be set.
 
-### Minimum annotation:
+### Minimum Annotation
 
 ```bash
 $ kubectl annotate machinedeployment -n kube-system test-cluster-worker-v5drmq cluster.k8s.io/cluster-api-autoscaler-node-group-min-size="1"
@@ -137,7 +136,7 @@ $ kubectl annotate machinedeployment -n kube-system test-cluster-worker-v5drmq c
 machinedeployment.cluster.k8s.io/test-cluster-worker-v5drmq annotated
 ```
 
-### Maximum annotation:
+### Maximum Annotation
 
 ```bash
 $ kubectl annotate machinedeployment -n kube-system test-cluster-worker-v5drmq cluster.k8s.io/cluster-api-autoscaler-node-group-max-size="5"
@@ -214,7 +213,7 @@ You can delete Autoscaler from where you edit it above and select delete.
  Once it has been deleted, you can check the Cluster to ensure that the Autoscaler has been deleted using `kubectl get pods -n kube-system` command.
 
 
-## Summary:
+## Summary
 
 That is it! You have successfully deployed a Kubernetes Autoscaler on a KKP Cluster and annotated the desired MachineDeployment, which Autoscaler should consider. Please check the learn more below for more resources on Kubernetes Autoscaler and how to provision a KKP Cluster.
 

--- a/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
@@ -7,7 +7,7 @@ weight = 14
 
 This manual explains how to configure a custom OIDC provider to use with Kubermatic Kubernetes Platform (KKP).
 
-### Default Configuration
+## Default Configuration
 
 When nothing is configured, KKP uses `https://<domain>/dex` as the OIDC provider
 URL, which by default points to Dex. The domain is taken from the
@@ -22,7 +22,7 @@ adds the following parameters to the base URL:
 - `&scope` is set to `openid email profile groups`
 - `&nonce` is randomly generated, 32 character string to prevent replay attacks
 
-### Custom Configuration
+## Custom Configuration
 
 The default configuration can be changed as KKP supports other OIDC providers as well. This
 involves updating the KKP dashboard and API using the `KubermaticConfiguration` CRD on the
@@ -51,7 +51,7 @@ kubectl -n kubermatic get kubermaticconfiguration kubermatic -o yaml
 
 There are two sections to update.
 
-#### API Configuration
+### API Configuration
 
 The KKP API validates the given token for authentication and therefore needs to be able to
 find the new token issuer. The relevant fields are under `spec.auth` and the following snippet
@@ -79,7 +79,7 @@ spec:
     tokenIssuer: 'https://keycloak.kubermatic.test/auth/realms/test'
 ```
 
-#### UI Configuration
+### UI Configuration
 
 The KKP dashboard needs to know where to redirect the user to in order to perform a
 login. This can be set by setting a `spec.ui.config` field, containing JSON. This is where
@@ -102,7 +102,7 @@ spec:
       }
 ```
 
-### Applying the Changes
+## Applying Changes
 
 Edit the KubermaticConfiguration either directly via `kubectl edit` or apply it from a YAML
 file by using `kubectl apply`. The KKP Operator will pick up on the changes and

--- a/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/share-clusters-via-delegated-OIDC-authentication/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/share-clusters-via-delegated-OIDC-authentication/_index.en.md
@@ -5,7 +5,7 @@ weight = 80
 
 +++
 
-### Share Clusters via Delegated OIDC Authentication Overview
+## Share Clusters via Delegated OIDC Authentication Overview
 
 The purpose of this feature is to allow using an OIDC provider like `dex` to authenticate to a Kubernetes cluster
 managed by Kubermatic Kubernetes Platform (KKP). This feature can be used to share access to a cluster with other users.
@@ -54,7 +54,7 @@ kubectl get pods
 #Error from server (Forbidden): pods is forbidden: User "user@example.com" cannot list pods in the namespace "default"
 ```
 
-### Prerequisites
+## Prerequisites
 
 In order to enable the feature the necessary flags must be passed to various applications.
 
@@ -124,7 +124,7 @@ dex:
     - https://example.com/api/v1/kubeconfig # issuerRedirectURL
 ```
 
-### Root CA Certificates Chain
+## Root CA Certificates Chain
 
 In order to verify OIDC provider's certificate in `kubermatic-controller-manager` when establishing
 TLS connection, a public root CA certificate is required. Ideally the whole chain including all intermediate
@@ -140,7 +140,7 @@ cat isrgrootx1.pem.txt lets-encrypt-x3-cross-signed.pem.txt > caBundle.pem
 
 This bundle must then be copied verbatim into the `KubermaticConfiguration`.
 
-### Update KKP
+## Update KKP
 
 After all values are set up, it's time to update the KKP master cluster. Update the `oauth` chart first:
 
@@ -158,7 +158,7 @@ kubectl -n kubermatic apply -f kubermaticconfig.yaml
 
 After the operator has reconciled the KKP installation, OIDC auth will become available.
 
-### Role-Based Access Control Predefined Roles
+## Role-Based Access Control Predefined Roles
 
 KKP provides predefined roles and cluster roles to help implement granular permissions for specific resources
 and to simplify access control across the user cluster. All of the default roles and cluster roles are labeled

--- a/content/kubermatic/main/tutorials-howtos/OPA-integration/OPA-integration-Via-UI/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/OPA-integration/OPA-integration-Via-UI/_index.en.md
@@ -5,12 +5,9 @@ weight = 40
 
 +++
 
-## Open Policy Agent (OPA)
-
 [Open Policy Agent](https://www.openpolicyagent.org/) (OPA) is an open-source, general-purpose policy engine that unifies policy enforcement across the stack. We are integrating it with using [Gatekeeper](https://github.com/open-policy-agent/gatekeeper), which is an OPA's Kubernetes-native policy engine. More info about OPA and Gatekeeper can be read from their docs and tutorials.
 
-
-### Admin Panel for OPA Options
+## Admin Panel for OPA Options
 
 As an admin, you will find a few options in the `Admin Panel`. You can access this panel by clicking on the account icon on the top right and select `Admin Panel`.
 
@@ -30,7 +27,7 @@ Here you navigate to the OPA menu and then to Default Constraints.
 
 ![Default Constraints](/img/kubermatic/main/ui/default-constraint-admin.png?height=300px&classes=shadow,border "Default Constraints")
 
-### Cluster Details View
+## Cluster Details View
 
 The cluster details view is extended by some more information if OPA is enabled.
 - `OPA Integration` in the top area is indicating if OPA is enabled or not.
@@ -40,7 +37,7 @@ The cluster details view is extended by some more information if OPA is enabled.
 ![Cluster Details View](/img/kubermatic/main/ui/opa_cluster_view.png?height=500px&classes=shadow,border "Cluster Details View")
 
 
-### Activating OPA
+## Activating OPA
 
 To create a new cluster with OPA enabled you only have to enable the `OPA Integration` checkbox during the cluster creation process. It is placed in Step 2 `Cluster` and can be enabled by default as mentioned in the [Admin Panel for OPA Options]({{< ref "#admin-panel-for-opa-options" >}}) section.
 If you don't know how to create a cluster using the Kubermatic Kubernetes Platform follow our [Project and cluster management]({{< ref "../../project-and-cluster-management" >}}) tutorial.
@@ -103,6 +100,7 @@ Just click on `Add Constraint Template` to create the constraint template.
 Constraint Templates can be edited after clicking on the pencil icon that appears when hovering over one of the rows. The form is identical to the one from creation. In this table you can also delete it if needed.
 
 ![Edit Constraint Template](/img/kubermatic/main/ui/edit_constraint_template.png?height=300px&classes=shadow,border "Cluster Details View")
+
 ### Constraints
 
 Constraints are the filler for rules that are defined by the constraint templates. Constraints provide the parameters which are used in the Constraint Template rule.

--- a/content/kubermatic/main/tutorials-howtos/OPA-integration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/OPA-integration/_index.en.md
@@ -7,7 +7,7 @@ weight = 11
 
 This manual explains how Kubermatic integrates with OPA and how to use it.
 
-### OPA
+## OPA
 
 [OPA](https://www.openpolicyagent.org/) (Open Policy Agent) is an open-source, general-purpose policy engine that unifies
  policy enforcement across the stack.
@@ -18,7 +18,7 @@ More info about OPA and Gatekeeper can be read from their docs and tutorials, bu
 Constraint Template CRD the users can create rule templates whose parameters are then filled out by the corresponding Constraints.
 
 
-### How to activate OPA Integration on your cluster
+## How to activate OPA Integration on your Cluster
 
 The integration is specific per user cluster, meaning that it is activated by a flag in the cluster spec.
 
@@ -38,7 +38,7 @@ spec:
 By setting this flag to true, Kubermatic automatically deploys the needed Gatekeeper components to the control plane
 as well as the user cluster.
 
-### Managing Constraint Templates
+## Managing Constraint Templates
 
 Constraint Templates are managed by the Kubermatic platform admins. Kubermatic introduces a Kubermatic Constraint Template wrapper CRD through which the users can interact with the OPA CT's. The Kubermatic master clusters contain the
 Kubermatic CT's which designated controllers to reconcile to the seed and to user cluster with activated OPA integration as Gatekeeper CT's.
@@ -77,11 +77,11 @@ spec:
 
 Kubermatic Constraint Template corresponds 1:1 to the Gatekeeper Constraint Template.
 
-#### Deleting Constraint Templates
+### Deleting Constraint Templates
 
 Deleting Constraint Templates causes all related Constraints to be deleted as well.
 
-### Managing Constraints
+## Managing Constraints
 
 Constraints are managed similarly to Constraint Templates through Kubermatic CRD wrappers around the Gatekeeper Constraints,
 the difference being that Constraints are managed on the user cluster level. Furthermore, due to the way Gatekeeper works,
@@ -123,7 +123,7 @@ spec:
 - `match` - works the same as [Gatekeeper Constraint matching](https://github.com/open-policy-agent/gatekeeper#constraints)
 - `parameters` - holds the parameters that are used in Constraints. As in Gatekeeper, this can be basically anything that fits the related Constraint Template.
 
-### Default Constraints
+## Default Constraints
 
 Default Constraints allow admins to conveniently apply policies to all OPA enabled clusters.
 This would allow admins an easier way to make sure all user clusters are following some policies (for example security), instead of the current way in which Constraints need to be created for each cluster separately.
@@ -219,9 +219,10 @@ spec:
   parameters:
     labels: ["gatekeeper"]
 ```
-### Disabling Constraint
 
-The constraint can be Disabled/Turned off by setting the `disabled` flag to true in the constraint spec.
+### Disabling Default Constraint
+
+A constraint can be disabled/turned off by setting the `disabled` flag to true in the constraint spec.
 
 To Enable Default Constraints again, you can just remove the `disabled` flag or set it to `false`.
 
@@ -247,8 +248,6 @@ spec:
   parameters:
     labels: ["gatekeeper"]
 ```
-
-#### Disabling Default Constraint
 
 By setting `disabled` flag to true, Kubermatic deletes the constraint from all User clusters.
 
@@ -296,7 +295,7 @@ Deleting Default Constraint causes all related Constraints on the user clusters 
 
 Note: Cluster Admins will not be able to edit/delete Default Constraints
 
-### AllowedRegistry
+## AllowedRegistry
 
 AllowedRegistry allows admins to easily control what image registries can be used in user clusters. This is the first KKP
 inbuilt Constraint and its goal is to make creating Constraint Templates and Default Constraints simpler.
@@ -406,14 +405,14 @@ AllowedRegistries are just a way to make admins life easier.
 When there are no AllowedRegistries, we automatically disable the Default Constraint.
 {{% /notice %}}
 
-### Managing Config
+## Managing Gatekeeper Configuration
 
 Gatekeeper [Config](https://github.com/open-policy-agent/gatekeeper#replicating-data) can also be managed through Kubermatic.
 As Gatekeeper treats it as a kind of singleton CRD resource, Kubermatic just manages this resource directly on the user cluster.
 
 You can manage the config in the user cluster view, per user cluster.
 
-### Removing OPA Integration
+## Removing OPA Integration
 
 OPA integration on a user cluster can simply be removed by disabling the OPA Integration flag on the Cluster object.
 Be advised that this action removes all Constraint Templates, Constraints, and Config related to the cluster.

--- a/content/kubermatic/main/tutorials-howtos/administration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/_index.en.md
@@ -2,9 +2,6 @@
 title = "Administration"
 date = 2021-04-20T14:35:00+02:00
 weight = 15
-
 +++
-
-
 
 This section contains helpful tutorial that can help you with KKP administration. It expantiate on and How-Tos manage global settings such as custom links and how you can use presets to specify default settings for your cluster.

--- a/content/kubermatic/main/tutorials-howtos/administration/admin-panel/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/admin-panel/_index.en.md
@@ -73,7 +73,7 @@ $ kubectl edit kubermaticsetting globalsettings
 **Note:** Custom link `icon` is not required and defaults will be used if field is not specified. `icon` URL can
 point to the images inside the container as well, i.e. `/assets/images/icons/custom/github.svg`.
 
-## Manage Global Settings Via UI
+## Manage Global Settings via UI
 
 The below global settings are managed via UI:
 

--- a/content/kubermatic/main/tutorials-howtos/administration/admin-panel/backup-buckets/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/admin-panel/backup-buckets/_index.en.md
@@ -45,7 +45,7 @@ For security reasons, the API/UI does not offer a way to get the current credent
 To see how to make backups and restore your cluster, check the [Etcd Backup and Restore Tutorial]({{< ref "../../../etcd-backups" >}}).
 
 
-### Default backups
+### Default Backups
 
 Since 2.20, default destinations are required if the automatic etcd backups are configured. A default EtcdBackupConfig
 is created for all the user clusters in the Seed. It has to be a destination that is present in the backup destination list for that Seed.

--- a/content/kubermatic/main/tutorials-howtos/administration/admin-panel/opa-default-constraints/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/admin-panel/opa-default-constraints/_index.en.md
@@ -1,16 +1,14 @@
 +++
-title = "OPA Default Constraint"
+title = "OPA Default Constraints"
 date = 2021-09-08T12:07:15+02:00
 weight = 20
 +++
-
-## Default Constraints
 
 Default Constraints allow admins to conveniently apply policies to all OPA enabled clusters
 This would allow admins an easier way to make sure all user clusters are following some policies (for example security), instead of the current way in which Constraints need to be created for each cluster separately.
 Kubermatic operator/admin creates a Constraint in the admin panel, it gets propagated to seed clusters and user clusters with OPA-integration
 
-### Create Default Constraint
+## Create Default Constraint
 
 In the Admin view navigate to the OPA menu and then to Default Constraints.
 
@@ -38,7 +36,7 @@ selector:
 The Default Constraint created will also show up in the applied cluster view with `Admin Constraint` label
 ![Created Default Constraint on the Cluster](/img/kubermatic/main/ui/default_constraint_cluster_view.png?height=200px&classes=shadow,border "Created Default Constraint on the Cluster")
 
-### Edit Default Constraint
+## Edit Default Constraint
 
 Editing Default Constraint will sync the changes to all the respective constraints on the user clusters.
 
@@ -48,7 +46,7 @@ To edit the constraint click on edit button on the right that appears when hover
 In the appearing dialog you can now edit the Default Constraint.
 ![Edit Constraint Dialog](/img/kubermatic/main/ui/edit-default-constraint-dialog.png?height=350px&classes=shadow,border "Edit Constraint Dialog")
 
-### Filtering Clusters on Default Constraints
+## Filtering Clusters on Default Constraints
 
 {{% notice info %}}
 This is an EE feature.
@@ -80,7 +78,7 @@ for example, for the above use case Default Constraints will be applied to Clust
 
 ![Filtered Cluster with Default Constraint](/img/kubermatic/main/ui/cluster-aws-filter.png?height=400px&classes=shadow,border "Filtered Cluster with Default Constraint")
 
-### Disable Default Constraints
+## Disable Default Constraints
 
 In Admin View to disable Default Constraints, click on the green button under `On/Off`
 ![Disable Default Constraint](/img/kubermatic/main/ui/default-constraint-on.png?height=200px&classes=shadow,border "Disable Default Constraint")
@@ -96,7 +94,7 @@ disabled-default-constraint-cluster-view.png
 Enable the constraint by clicking the same button
 ![Enable Default Constraint](/img/kubermatic/main/ui/disabled-default-constraint.png?height=200px&classes=shadow,border "Enable Default Constraint")
 
-### Delete Default Constraint
+## Delete Default Constraint
 
 Deleting Default Constraint causes all related Constraints on the user clusters to be deleted as well.
 

--- a/content/kubermatic/main/tutorials-howtos/administration/admin-panel/presets-management/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/admin-panel/presets-management/_index.en.md
@@ -8,7 +8,7 @@ weight = 30
 
 With Presets you can specify default settings for new Cluster. Use Presets to reuse property settings across multiple providers.
 
-### Core Concept
+## Core Concept
 
 As a Kubermatic Kubernetes Platform (KKP) administrator with superuser access, you can define Preset types in a Kubernetes Custom Resource Definition (CRD),
 allowing the assignment of new credential types to supported providers. This allows you to define a custom credential type
@@ -28,7 +28,7 @@ Preset selection disables advanced settings. Advanced settings can be used only 
 to mix both kinds of settings.
 {{% /notice %}}
 
-### Example
+## Example
 
 The following example shows an example for a Preset CRD:
 

--- a/content/kubermatic/main/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -5,13 +5,12 @@ weight = 10
 
 +++
 
-## Datacenter concept
+## Datacenter Concept
 
 Datacenters are an integral part of Kubermatic. Depending on the cloud provider, they define a zone that has network connection for all machines, for example for hyperscalers it would be an availability zone.
 Datacenters, as Kubermatic resources, are a part of the Seed resource, and all user clusters of that datacenter are handled by its respected Seed Cluster.
 
 The datacenter structure contains the following fields:
-
 
 - `country` -- Country code of the DC location. It's purely cosmetic and reflected by a flag shown in the UI.
 - `location` -- Optional: Detailed location of the cluster, like "Hamburg" or "Datacenter 7". For informational purposes in the Kubermatic dashboard only.
@@ -199,20 +198,7 @@ Example specs for different providers:
 
 ```
 
-
-## Datacenter management - CE
-
-Datacenters are a part of the Seed resource and need to be managed by an Kubermatic operator on the Seed object.
-
-## Datacenter management - EE
-
-The EE offers 2 different ways to manage the datacenters. One way is using the dynamic datacenters feature through which
-admins can manage Datacenters on Seeds through API/UI. This is the preferred and recommended way. The other way is through the
-`datacenter.yaml` file which needs to be provided to the Kubermatic API server.
-
-### Dynamic Datacenters
-
-The dynamic datacenters are activated by setting the `dynamic-datacenters` flag to `true` on the Kubermatic API server.
+## Dynamic Datacenters
 
 Admins can manage the datacenters through the admin panel:
 ![Dynamic Datacenters](/img/kubermatic/main/ui/dc.png?classes=shadow,border "Dynamic Datacenters View")
@@ -238,98 +224,3 @@ When we are satisfied with our new datacenter, we can use it in the Cluster crea
 To delete the datacenter, just click on the trash icon in the admin panel:
 ![Delete Datacenter](/img/kubermatic/main/ui/dc_delete.png?classes=shadow,border&height=200 "Dynamic Datacenters Delete Dialog")
 *NOTICE: deleting does not affect existing user clusters that were created using this datacenter*
-
-
-### Management through static files - datacenter.yaml
-
-This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file.
-
-In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect.
-
-Example file:
-
-```yaml
-datacenters:
-  #==================================
-  #============== Seeds =============
-  #==================================
-
-  # The name needs to match the a context in the kubeconfig given to the API
-  seed-1:
-    # Defines this datacenter as a seed
-    is_seed: true
-    # Though not used, you must configured a provider spec even for seeds.
-    # The bringyourown provider is a good placeholder, as it requires no
-    # further configuration.
-    spec:
-      bringyourown: ~
-
-  seed-2:
-    is_seed: true
-    spec:
-      bringyourown: ~
-
-  #==================================
-  #======= Node Datacenters =========
-  #==================================
-
-  #==================================
-  #=========== OpenStack ============
-  #==================================
-  # The keys for non-seeds can be freely chosen.
-  openstack-zone-1:
-    # The location is shown in the KKP dashboard
-    # and should be descriptive within each provider (e.g.
-    # for AWS a good location name would be "US East-1").
-    location: Datacenter 2
-
-    # The country is also used by the dashboard to show
-    # the corresponding flag and make it easier to select
-    # the proper region.
-    country: DE
-
-    # The name of the seed to use when creating clusters in
-    # this datacenter; when someone creates a cluster with
-    # nodes in this dc, the master components will live in seed-1.
-    seed: seed-1
-
-    # Configure cloud provider-specific further information.
-    spec:
-      openstack:
-        # Authentication endpoint for Openstack, must be v3
-        auth_url: https://our-openstack-api/v3
-        availability_zone: zone-1
-        region: "region-1"
-        # This DNS server will be set when KKP creates a network
-        dns_servers:
-        - "8.8.8.8"
-        - "8.8.4.4"
-        # Those are default images for nodes which will be shown in the Dashboard.
-        images:
-          ubuntu: "Ubuntu 18.04"
-          centos: "CentOS 7"
-          coreos: "CoreOS"
-        # Enforce the creation of floating IP's for new nodes
-        # Available since v2.9.0
-        enforce_floating_ip: false
-        # Gets mapped to the "manage-security-groups" setting in the cloud config.
-        # See https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
-        # Defaults to true
-        # Available since v2.9.2
-        manage_security_groups: true
-
-  #==================================
-  #========== Digitalocean ==========
-  #==================================
-  do-ams2:
-    location: Amsterdam
-    country: NL
-    seed: seed-1
-    spec:
-      digitalocean:
-        # Digitalocean region for the nodes
-        region: ams2
-```
-
-
-

--- a/content/kubermatic/main/tutorials-howtos/administration/kkp-user/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/kkp-user/_index.en.md
@@ -28,7 +28,7 @@ After the installation of Kubermatic Kubernetes Platform the first account that 
 
 The account is then capable of setting admin permissions via the [dashboard]({{< ref "../admin-panel/administrators" >}}) .
 
-# Granting admin permission via kubectl
+# Granting Admin Permission via kubectl
 
 Make sure the account logged in once at the Kubermatic Dashboard.
 

--- a/content/kubermatic/main/tutorials-howtos/administration/user-settings/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/user-settings/_index.en.md
@@ -7,13 +7,13 @@ weight = 10
 
 This manual explains how to manage KKP user settings via the UI.
 
-### Accessing the User Settings
+## Accessing User Settings
 
 To access the user settings click the `User Settings` entry in the user menu:
 
 ![User Menu](/img/kubermatic/main/ui/admin_panel_access.png?height=300px&classes=shadow,border "Accessing the User Settings")
 
-### User Settings Overview
+## User Settings Overview
 
 ![User Settings](/img/kubermatic/main/ui/user_settings.png?classes=shadow,border "User Settings")
 

--- a/content/kubermatic/main/tutorials-howtos/administration/user-settings/user-ssh-key-agent/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/user-settings/user-ssh-key-agent/_index.en.md
@@ -5,7 +5,7 @@ weight = 6
 
 +++
 
-### User SSH Key Agent Overview
+## Overview
 The user ssh key agent is responsible for syncing the defined user ssh keys to the worker nodes, when users
 attach ssh keys to the user clusters. When users choose to add a user ssh key to a cluster after it was created
 the agent will sync those keys to the worker machines by fetching the ssh keys and write them to the `authorized_keys`
@@ -26,7 +26,7 @@ to disable the agent(during cluster creation), they should take care of adding s
 During the user cluster creation steps(at the second step), the users have the possibility to add a user ssh key and it
 is not affected by the agent, whether it was deployed or not.
 
-### User SSH Key Agent Migration
+## Migration
 Starting from KKP 2.16.0 on-wards, it was made possible to enable and disable the user ssh key agent during cluster creation. Users can
 enable the agent in KKP dashboard as it is mentioned above, or by enabling the newly added `enableUserSSHKeyAgent: true`
 in the cluster spec. For user clusters which were created using KKP 2.15.x and earlier, this has introduced an issue, due to

--- a/content/kubermatic/main/tutorials-howtos/admission-plugins/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/admission-plugins/_index.en.md
@@ -7,7 +7,7 @@ weight = 150
 
 This page explains how to configure [Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) in the Kubermatic Kubernetes Platform.
 
-## How do I turn on an admission controller?
+## Default Admission Controllers
 
 The Kubermatic Kubernetes Platform manages the Kubernetes API server by setting the `enable-admission-plugins` flag with a comma-delimited
 list of admission control plugins to be enabled during cluster creation.

--- a/content/kubermatic/main/tutorials-howtos/applications/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/applications/_index.en.md
@@ -3,6 +3,7 @@ title = "Applications"
 date =  2022-08-03T16:27:43+02:00
 weight = 5
 +++
+
 ## Introduction
 
 KKP Applications offer a seamless experience to add third-party applications into a KKP cluster and offer full [integration with KKP's UI](./add-applications-to-cluster#adding-applications) as well as [GitOps Systems](add-applications-to-cluster#managing-applications-via-gitops).

--- a/content/kubermatic/main/tutorials-howtos/applications/create-application-catalogue/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/applications/create-application-catalogue/_index.en.md
@@ -3,6 +3,7 @@ title = "Creating An Application Catalogue"
 date =  2022-08-03T16:27:43+02:00
 weight = 1
 +++
+
 ## Introduction
 
 This guide targets KKP Admins and details adding Applications to a catalogue, so they can be installed by Cluster Admins.

--- a/content/kubermatic/main/tutorials-howtos/audit-logging/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/audit-logging/_index.en.md
@@ -11,7 +11,7 @@ Audit logging is also a key requirement of the [Kubernetes CIS benchmark](https:
 
 For more details, you can refer to the [upstream documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/).
 
-### Kubermatic Kubernetes Platform (KKP) Support
+## Kubermatic Kubernetes Platform (KKP) Support
 KKP provides two levels of support for the Audit Logging:
 
 * Audit Logging on user-cluster level
@@ -34,7 +34,7 @@ $ kubectl edit -n cluster-<YOUR CLUSTER ID> configmap audit-config
 {{< readfile "kubermatic/main/data/policy.yaml">}}
 ```
 
-#### Audit Policy Presets
+### Audit Policy Presets
 
 KKP supports a set of maintained audit policies as presets in case you do not want to tune the audit policy for yourself.
 A preset can be selected during cluster creation in the UI or by setting the field `auditLogging.policyPreset` on a
@@ -54,7 +54,7 @@ The following presets are available right now:
     - any access (read, write or delete) to `Secrets` and `ConfigMaps` (metadata only, as the request body could include sensitive information)
 - `recommended`: Logs everything in `minimal` plus metadata for any other request. This is the most verbose audit policy preset, but is recommended due to its extended coverage of security recommendations like the CIS Benchmark
 
-#### Custom Output Configuration
+## Custom Output Configuration
 
 In some situations the default behaviour of writing the audit logs to standard output and processing them alongside regular container logs might not be desirable. For those cases, `Cluster` objects support custom configuration for the [fluentbit](https://fluentbit.io/) sidecar via `spec.auditLogging.sidecar` (also see [CRD reference]({{< ref "../../references/crds/#auditloggingsettings" >}})).
 
@@ -97,7 +97,7 @@ spec:
 
 This configures the fluentbit sidecar to flush incoming audit logs every 10 seconds, filters them by a string (`user@example.com`) and writes them to a manually deployed fluentd service available in-cluster.
 
-##### Audit Logs Source Identification
+### Audit Logs Source Identification
 
 Depending on your architecture, it might be advisable to use the sidecar configuration options to enrich logs with metadata, e.g. the cluster name. This is likely necessary to differentiate the source of your audit logs in a central storage location. This can be done via a filter plugin, like this:
 
@@ -113,7 +113,7 @@ Replace `<CLUSTER ID>` with the ID of your cluster.
 
 Future KKP releases may add an environment variable to automatically get the cluster ID or even enrich records with this information by default.
 
-#### User-Cluster Level Audit Logging
+## User Cluster Level Audit Logging
 
 To enable user-cluster level Audit Logging, simply check `Audit Logging` in the KKP dashboard `Create Cluster` page. You can either select "custom" to be able to edit the ConfigMap for audit logging later on or set your cluster up with a [preset](#audit-policy-presets):
 
@@ -123,7 +123,7 @@ For exiting clusters, you can go to the cluster page, edit your cluster and enab
 
 ![Edit Cluster](01-edit-cluster.png)
 
-#### Datacenter Level Audit Logging
+## Datacenter Level Audit Logging
 
 KKP also supports enabling Audit Logging on the datacenter level. In this case, the option is enforced on all user-clusters in the datacenter. The user-cluster level flag is ignored in this case.
 

--- a/content/kubermatic/main/tutorials-howtos/aws-assume-role/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/aws-assume-role/_index.en.md
@@ -9,7 +9,7 @@ AWS provides a feature called [AssumeRole][aws-docs-assume-role] to retrieve tem
 The IAM roles can belong to someone elses AWS account, allowing you to act on their behalf.
 Using KKP you are able to use the `AssumeRole` feature to easily deploy user clusters to AWS accounts that you normally do not have access to.
 
-## How it works
+## How it Works
 
 ![Running user clusters using an assumed IAM role](/img/kubermatic/main/tutorials/aws_assume_role_sequence_diagram.png?width=1000&classes=shadow,border "Running user clusters using an assumed IAM role")
 

--- a/content/kubermatic/main/tutorials-howtos/cluster-templates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/cluster-templates/_index.en.md
@@ -25,7 +25,7 @@ The newly created cluster template is visible in `Cluster Templates` menu:
 
 You can also create a cluster template in this view. You will be redirected to the cluster creation wizard.
 
-## Create Cluster from the Template
+## Create Cluster from Template
 
 On the right side, you can find two action buttons:
  - Create Cluster from Template
@@ -33,13 +33,12 @@ On the right side, you can find two action buttons:
 
 ![Create from cluster template wizard](/img/kubermatic/main/tutorials/cluster_template/actions.png?classes=shadow,border "Action buttons")
 
-### Create Cluster from Template
 During the cluster creation process, the end user can pick the desired template and specify number of cluster instances.
 The cluster template doesn't create any link to the clusters. They work independently.
 
 ![Create from cluster template wizard](/img/kubermatic/main/tutorials/cluster_template/create_cluster.png?classes=shadow,border "Create Clusters from Template")
 
-### Delete Cluster Template
+## Delete Cluster Template
 
 ![Delete from cluster template wizard](/img/kubermatic/main/tutorials/cluster_template/delete_template.png?classes=shadow,border "Delete Cluster Template")
 

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/aks/create-aks/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/aks/create-aks/_index.en.md
@@ -6,7 +6,6 @@ weight = 7
 
 +++
 
-## Create AKS Cluster:
 Create a cluster following these steps:
 
 - Click on `Create External Cluster` button:
@@ -27,9 +26,9 @@ Create a cluster following these steps:
 
 - Click on `Create External Cluster` button
 
-## Configure the cluster:
+## Configure Cluster
 
-### Basic Settings:
+### Basic Settings
 
 - Name: Assign a unique name for this node pool.
 - Kubernetes Version: Select the Kubernetes version that should be used for this cluster. You will be able to upgrade this version after creating the cluster.
@@ -41,7 +40,7 @@ Create a cluster following these steps:
 Resource Group should have sufficient permissions to manage AKS cluster and to pull the Admin kubeconfig.
 {{% /notice %}}
 
-### Primary Node Pool Setting:
+### Primary Node Pool Settings
 
 {{% notice info %}}
 At least one systempool is required in an AKS cluster.
@@ -59,7 +58,7 @@ Node size
 - AutoScaling: Autoscaling is recommended for standard configuration.
     Set the minimum and maximum node counts for this node pool. You cannot set a lower minimum than the current node count in the node pool.
 
-## Create Node Pool:
+## Create Node Pool
 
 ![Add Node Pool](/img/kubermatic/main/tutorials/external_clusters/add_md.png "Add Node Pool")
 

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/eks/create-eks/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/eks/create-eks/_index.en.md
@@ -32,14 +32,14 @@ Create a cluster following these steps:
 
 - Click on `Create External Cluster` button
 
-## Configure the cluster:
+## Configure the Cluster
 
-### Basic Settings:
+### Basic Settings
 - Name: Provide a unique name for your cluster
 - Kubernetes Version: Select the Kubernetes version for this cluster.
 - Cluster Service Role: Select the IAM role to allow the Kubernetes control plane to manage AWS resources on your behalf. This property cannot be changed after the cluster is created.
 
-### Networking:
+### Networking
 - VPC: Select a VPC to use for your EKS cluster resources
 
 - Subnets: Choose the subnets in your VPC where the control plane may place elastic network interfaces (ENIs) to facilitate communication with your cluster.
@@ -51,24 +51,24 @@ Subnets specified must be in at least two different AZs.
 
 Both Subnet and Security Groups list depends on chosen VPC.
 
-## Create EKS NodeGroup:
+## Create EKS NodeGroup
 
 - Click on `Add Machine Deployment`
 
 - Add NodeGroup configurations:
 
-### Basic Settings:
+### Basic Settings
 - Name: Assign a unique name for this node group.
   The node group name should begin with letter or digit and can have any of the following characters: the set of Unicode letters, digits, hyphens and underscores. Maximum length of 63.
 - Kubernetes Version: Cluster Control Plane Version is prefilled.
 - Node IAM Role: Select the IAM role that will be used by the node
 - Disk Size: Select the size of the attached EBS volume for each node.
 
-### Networking:
+### Networking
 - VPC: VPC of the cluster is pre-filled.
 - Subnet: Specify the subnets in your VPC where your nodes will run.
 
-### AutoScaling:
+### Autoscaling
 Node group scaling configuration:
 - Desired Size: Set the desired number of nodes that the group should launch with initially.
 - Max Count: Set the maximum number of nodes that the group can scale out to.

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/gke/create-gke/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/gke/create-gke/_index.en.md
@@ -28,7 +28,7 @@ Create a cluster following these steps:
 
 - Click on `Create External Cluster` button
 
-### Configure the cluster:
+### Configure the Cluster
 
 - Name: Provide a unique name for your cluster.
 - Zone: Select the cluster zone from the dropdown list.
@@ -43,7 +43,7 @@ Create a cluster following these steps:
 
    - Stable: These versions have met all the requirements of the Regular channel and have been shown to be stable and reliable in production, based on the observed performance of running clusters.
 
-### Create Node Pool:
+### Create Node Pool
 
 ![Add Node Pool](/img/kubermatic/main/tutorials/external_clusters/add_md.png "Add Node Pool")
 

--- a/content/kubermatic/main/tutorials-howtos/manage-worker's-node/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/manage-worker's-node/_index.en.md
@@ -4,6 +4,6 @@ date = 2021-04-20T12:16:38+02:00
 weight = 2
 +++
 
-## Manage Worker Nodes via UI and Command-Line
+## Manage Worker Nodes via UI and Commandline
 
 This page describes worker node's management using both command lines and UI. 

--- a/content/kubermatic/main/tutorials-howtos/manage-worker's-node/via-UI/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/manage-worker's-node/via-UI/_index.en.md
@@ -5,7 +5,7 @@ weight = 15
 +++
 
 
-## Find the edit setting
+## Find the Edit Setting
 
 To add or delete a worker node you can easily edit the machine deployment in your cluster. Navigate to the cluster overview, scroll down and hover over `Machine Deployments` and click on the edit icon next to the deployment you want to edit.
 
@@ -15,7 +15,7 @@ In the popup dialog you can now change the worker nodes.
 
 ![Machine deployment overview with opened edit modal](/img/kubermatic/main/ui/md_edit_dialog1.png?height=350px&classes=shadow,border "Machine deployment overview with opened edit modal")
 
-## Edit labels and taints
+## Edit Labels and Taints
 
 If you scroll down in the dialog, you can also edit node labels and taints.
 

--- a/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
@@ -206,7 +206,7 @@ The following values will be written to the reports:
 - Average used cpu millicores
 - Average used memory bytes
 
-## Raw data
+## Raw Data
 
 The data used to aggregate the reports can be accessed via the metering prometheus instance.
 If you desire to store this data for longer than 90days, you need to extract the data from the metering prometheus instance and replicate it to a long term storage of your choice.

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
@@ -16,9 +16,9 @@ When it comes to monitoring, no approach fits all use cases. It's expected that 
 
 You will want to familiarize yourself with the [Installation of the Master / Seed MLA Stack]({{< relref "../installation/" >}}) before reading any further.
 
-## Customer-Cluster Prometheus
+## User Cluster Prometheus
 
-The basic source of metrics is the Prometheus inside each customer cluster namespace. It will track the customer clusters control plane (**IMPORTANT:** it is NOT responsible for the components running in the customer clusters themselves.)
+The basic source of metrics is the Prometheus inside each user cluster namespace. It will track the customer clusters control plane (**IMPORTANT:** it is NOT responsible for the components running in the customer clusters themselves.)
 
 This Prometheus is deployed as part of Kubermatic Kubernetes Platform's (KKP) cluster creation, which means you cannot directly affect its deployment.
 
@@ -77,7 +77,7 @@ clusterNamespacePrometheus:
   disableDefaultScrapingConfigs: true
 ```
 
-## Seed-Cluster Prometheus
+## Seed Cluster Prometheus
 
 This Prometheus is primarily used to collect metrics from the customer clusters and then provide those to Grafana. In contrast to the Prometheus mentioned above, this one is deployed via a [Helm](https://helm.sh) chart and you can use Helm's native customization options.
 

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -27,7 +27,7 @@ Apart from that,  it will claim the following storage from the `kubermatic-fast`
 - 10 Gi volume for Loki Querier
 - 4 x 2 Gi volume for other internal processing services (compactors, store gateways of Cortex and Loki)
 
-### Capacity planning
+### Capacity Planning
 
 {{% notice note %}}
 The most important part of resources consumption of the MLA stack belongs to the storage and computing power used by Cortex and it's components.

--- a/content/kubermatic/main/tutorials-howtos/networking/cni-migration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/cni-migration/_index.en.md
@@ -15,11 +15,11 @@ This procedure will cause temporary outage in the user cluster, so it should be 
 
 {{% /notice %}}
 
-## Migrating User Cluster with the Canal CNI to the Cilium CNI
+## Migrating User Cluster with Canal CNI to Cilium CNI
 
 Before starting, make sure you understand the [Cilium System Requirements](https://docs.cilium.io/en/stable/operations/system_requirements/) and migration steps. Also please note your current CNI type and version, you will need it in a later step.
 
-#### Step 1:
+### Step 1
 
 In order to allow CNI migration, the cluster first needs to be labeled with the `unsafe-cni-migration` label (e.g. `unsafe-cni-migration: "true"`).
 
@@ -29,7 +29,7 @@ By putting this label on your cluster you acknowledge that this type of upgrade 
 
 {{% /notice %}}
 
-#### Step 2:
+### Step 2
 
 At this point, you are able to change the CNI type and version in the Cluster API. Change Cluster `spec.cniPlugin.type` and `spec.cniPlugin.version` to a supported CNI type and version - in our case `cilium` and `v1.11` respectively:
 
@@ -53,7 +53,7 @@ kube-system            cilium-operator-f8447b698-kz267             1/1     Runni
 
 Note that at this point, both Canal and Cilium pods are running. Existing pods are still connected via Canal CNI, but Cilium will be used to connect all new pods.
 
-#### Step 3:
+### Step 3
 
 Restart all already running non-host-networking pods to ensure that Cilium starts managing them:
 
@@ -97,7 +97,7 @@ Image versions    cilium             quay.io/cilium/cilium:v1.11.0@sha256:ea6775
                   cilium-operator    quay.io/cilium/operator-generic:v1.11.0@sha256:b522279577d0d5f1ad7cadaacb7321d1b172d8ae8c8bc816e503c897b420cfe3: 1
 ```
 
-#### Step 4:
+### Step 4
 
 At this point, you can delete all Canal resources from the cluster.
 
@@ -109,20 +109,20 @@ kubectl delete -f https://docs.projectcalico.org/v3.21/manifests/canal.yaml
 
 At this point, your cluster should be running on Cilium CNI.
 
-#### Step 5 (Optional):
+### Step 5 (Optional)
 Consider changing the kube-proxy mode, especially if it was IPVS previously. See [Changing the Kube-Proxy Mode](#changing-the-kube-proxy-mode)
 for more details.
 
-#### Step 6 (Optional):
+### Step 6 (Optional)
 
 As the last step, we recommend to perform rolling restart of machine deployments in the cluster. That will make sure your nodes do not contain any leftovers of the Canal CNI, even if they are not affecting anything.
 
-#### Step 7:
+### Step 7
 
 Please verify that everything works normally in the cluster. If there are any problems, you can revert the migration procedure and go back to the previously used CNI type and version as described in the next section.
 
 
-## Migrating User Cluster with the Cilium CNI to the Canal CNI
+## Migrating User Cluster with Cilium CNI to Canal CNI
 
 Please follow the same steps as in [Migrating User Cluster with the Canal CNI to the Cilium CNI](#migrating-user-cluster-with-the-canal-cni-to-the-cilium-cni), with the following changes:
 
@@ -146,11 +146,11 @@ we strongly recommend migrating to `ebpf` or `iptables` proxy mode after Canal -
 
 Note that `ebpf` is allowed only for Cilium CNI if [Konnectivity]({{< relref "../cni-cluster-network/" >}}#konnectivity) is enabled.
 
-#### Step 1:
+### Step 1
 
 In order to allow kube-proxy mode migration, the cluster still needs to be labeled with the `unsafe-cni-migration` label (e.g. `unsafe-cni-migration: "true"`).
 
-#### Step 2:
+### Step 2
 
 At this point, you are able to change the proxy mode in the Cluster API. Change Cluster `spec.clusterNetwork.proxyMode` to the desired values (e.g. `ebpf`):
 
@@ -158,7 +158,7 @@ At this point, you are able to change the proxy mode in the Cluster API. Change 
 
 - or by editing the cluster CR in the Seed Cluster (`kubectl edit cluster <cluster-name>`).
 
-#### Step 3:
+### Step 3
 When switching to/from ebpf, wait until all Cilium pods are redeployed (you will notice a restart of all Cilium pods).
 It can take up to 5 minutes until this happens.
 
@@ -175,7 +175,7 @@ This can take up to 5 minutes. After the change, manually restart all `kube-prox
 kubectl rollout restart daemonset kube-proxy -n kube-system
 ```
 
-#### Step 4:
+### Step 4
 
 Perform rolling restart of machine deployments in the cluster. That will make sure your nodes do not contain any leftover iptables rules.
 Alternatively, reboot all worker nodes manually.

--- a/content/kubermatic/main/tutorials-howtos/networking/multus/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/multus/_index.en.md
@@ -11,20 +11,20 @@ Multus-CNI enables attaching multiple network interfaces to pods in Kubernetes. 
 
 In KKP, Multus can be installed into user clusters with any [supported CNI]({{< relref "../cni-cluster-network/" >}}). Multus addon can be deployed into a user cluster with a working primary CNI at any time.
 
-## Installing Multus Addon in KKP
+## Installing the Multus Addon in KKP
 Before this addon can be deployed in a KKP user cluster, the KKP installation has to be configured to enable `multus` addon as an [accessible addon]({{< relref "../../../architecture/concept/kkp-concepts/addons/#accessible-addons" >}}). This needs to be done by the KKP installation administrator,
 once per KKP installation.
 
 As an administrator you can use the [AddonConfig](#multus-addonconfig) listed at the end of this page.
 
-## Deploying Multus Addon in a KKP User Cluster
+## Deploying the Multus Addon in a KKP User Cluster
 Once the Multus Addon is installed in KKP, it can be deployed into a user cluster via the KKP UI as shown below:
 
 ![Multus Addon](/img/kubermatic/main/ui/addon_multus.png?height=400px&classes=shadow,border "Multus Addon")
 
 Multus will automatically configure itself with the primary CNI running in the user cluster. If the primary CNI is not yet running at the time of Multus installation, Multus will wait for it for up to 10 minutes.
 
-## Using Multus-CNI
+## Using Multus CNI
 When Multus addon is installed, all pods will be still managed by the primary CNI. At this point, it is possible to define additional networks with `NetworkAttachmentDefinition` custom resources.
 
 As an example, the following `NetworkAttachmentDefinition` defines a network named `macvlan-net` managed by the [macvlan CNI plugin](https://www.cni.dev/plugins/current/main/macvlan/) (a simple standard CNI plugin usually installed together with the primary CNIs):

--- a/content/kubermatic/main/tutorials-howtos/networking/proxy-whitelisting/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/proxy-whitelisting/_index.en.md
@@ -13,7 +13,7 @@ If you use the [KKP offline mode]({{< ref "../../../installation/offline-mode" >
 
 ## KKP Machine Controller
 
-Resources pulled on machine controller nodes
+Resources pulled on machine controller nodes.
 
 ### kubelet - Binary
 

--- a/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/_index.en.md
@@ -29,7 +29,7 @@ To delete a project, move the cursor over the line with the project name and cli
 ![Delete Project](/img/kubermatic/main/tutorials/project_delete.png?classes=shadow,border "Delete Project")
 
 
-### Add an SSH key
+### Add an SSH Key
 
 If you want to ssh into the project VMs, you need to provide your SSH public key. SSH keys are tied to a project. During cluster creation you can choose which SSH keys should be added to nodes. To add an SSH key, navigate to `SSH Keys` in the Dashboard and click on `Add SSH Key`:
 
@@ -42,9 +42,9 @@ This will create a pop up. Enter a unique name and paste the complete content of
 After you click on `Add SSH key`, your key will be created and you can now add it to clusters in the same project.
 
 
-## Manage clusters
+## Manage Clusters
 
-### Create cluster
+### Create Cluster
 
 To create a new cluster, open the Kubermatic Kubernetes Platform (KKP) dashboard, choose a project, select the menu entry `Clusters` and click the button `Create Cluster` on the top right.
 

--- a/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/cluster-defaulting/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/cluster-defaulting/_index.en.md
@@ -10,7 +10,7 @@ This section describes the usage of cluster templates for a seed.
 Cluster templates are designed to standardize and simplify the creation of Kubernetes clusters. A cluster template is a
 reusable cluster template object. At seed level, cluster templates are used to set default values for new created clusters.
 
-## Defaulting cluster template
+## Defaulting Cluster Template
 
 Some required values for new clusters are defaulted by KKP.
 

--- a/content/kubermatic/main/tutorials-howtos/telemetry/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/telemetry/_index.en.md
@@ -10,7 +10,8 @@ Telemetry is an observability tool that can be used to track Kubermatic Kubernet
 Telemetry helm chart can be found in the [Kubermatic repository](https://github.com/kubermatic/kubermatic/tree/main/charts/telemetry), and since Telemetry is an open source tool, the code can be found in [Telemetry-Client repository](https://github.com/kubermatic/telemetry-client).
 
 ## Installation
-### Kubermatic installer
+
+### Kubermatic Installer
 Telemetry will be enabled by default if you use the Kubermatic installer to deploy KKP. For more information about how to use the Kubermatic installer to deploy KKP, please refer to the [installation guide]({{< relref "../../installation/" >}}).
 Kubermatic installer will use a `values.yaml` file to configure all Helm charts, including Telemetry. The following is an example of the configuration of the Telemetry tool:
 


### PR DESCRIPTION
Many headers in our docs were not following consistent language and title casing. This PR tries to make them more consistent, remove headers that are duplicating information, improve the header structure, etc. A few minor content improvements snuck in while I was going over all pages too.