### PR TITLE
Remove last mentions of OpenShift

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/addons/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/addons/_index.en.md
@@ -5,7 +5,7 @@ weight = 20
 
 +++
 
-Addons are specific services and tools extending the functionality of Kubernetes/OpenShift.
+Addons are specific services and tools extending the functionality of Kubernetes.
 
 ## Comparison To KKP Applications
 
@@ -45,26 +45,33 @@ The KKP binaries come with a `kubermatic-installer` tool, which can output a ful
 `KubermaticConfiguration` (`kubermatic-installer print`). This will also include the default configuration for addons and can serve as
 a starting point for adjustments.
 
-```bash
-docker run --rm quay.io/kubermatic/api:KUBERMATIC_VERSION kubermatic-installer print
-#apiVersion: kubermatic.k8c.io/v1
-#kind: KubermaticConfiguration
-#metadata:
-#  name: kubermatic
-#  namespace: kubermatic
-#spec:
-#  ...
-#  userCluster:
-#    addons:
-#      kubernetes: ...
-#      openshift: ...
+```yaml
+apiVersion: kubermatic.k8c.io/v1
+kind: KubermaticConfiguration
+metadata:
+  name: kubermatic
+  namespace: kubermatic
+spec:
+  userCluster:
+    addons:
+      # DefaultManifests is a list of addon manifests to install into all clusters.
+      # Mutually exclusive with "default".
+      defaultManifests: [...]
+      # DockerRepository is the repository containing the Docker image containing
+      # the possible addon manifests.
+      dockerRepository: quay.io/kubermatic/addons
+      # DockerTagSuffix is appended to the tag used for referring to the addons image.
+      # If left empty, the tag will be the KKP version (e.g. "v2.15.0"), with a
+      # suffix it becomes "v2.15.0-SUFFIX".
+      dockerTagSuffix: ""
+[...]
 ```
 
 ### Configuration
 
 To configure which addons shall be installed in all user clusters, update the relevant
 [KubermaticConfiguration]({{< ref "../../../../tutorials-howtos/kkp-configuration" >}}) in the `spec.userCluster.addons`
-section. For Kubernetes and OpenShift, configure a Docker image that contains the required addon manifests
+section. You can configure a Docker image that contains the required addon manifests
 (as YAML files) and an `AddonList` manifest that lists the addons and their requirements. Take a look
 at the default configuration above as a starting point.
 
@@ -267,14 +274,12 @@ After applying above config the UI should look like below:
 ### Custom Addons
 
 All manifests and config files for the default addons are stored in a Docker image, whose name is configured
-in the KubermaticConfiguration at `spec.userClusters.addons.kubernetes.dockerRepository` and
-`spec.userClusters.addons.openshift.dockerRepository`. These default to `quay.io/kubermatic/addons` and
-`quay.io/kubermatic/openshift-addons`, respectively.
+in the KubermaticConfiguration at `spec.userClusters.addons.dockerRepository`. This defaults to `quay.io/kubermatic/addons`.
 
 #### Creating a Docker Image
 
-Depending on the cluster orchestrator, choose the Kubernetes or OpenShift Docker image as the basis for your
-own image. All addon manifest are stored in `/addons/<addonname>`, e.g. `/addons/kube-proxy`. When creating
+It is recommended to choose the default image as the basis for your own image to include default addons.
+All addon manifest are stored in `/addons/<addonname>`, e.g. `/addons/kube-proxy`. When creating
 your own image, copy the manifests into a directory below `/addons`.
 
 Suppose you have this directory structure:

--- a/content/kubermatic/main/tutorials-howtos/upgrading/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/upgrading/version-and-upgrade-configuration/_index.en.md
@@ -5,7 +5,7 @@ weight = 200
 
 +++
 
-This chapter describes how to configure the available Kubernetes/OpenShift versions and how to
+This chapter describes how to configure the available Kubernetes versions and how to
 provide update paths for user clusters.
 
 The list of selectable versions when [specifying cluster name and Kubernetes version]({{< ref "../../project-and-cluster-management" >}}) is defined in the `spec.versions`
@@ -20,7 +20,7 @@ To print the default configuration run `kubermatic-installer print` which output
 
 ### Configuring Versions
 
-The structure for Kubernetes and OpenShift versions is identical. Each contains
+The structure to configure Kubernetes version updates contains:
 
 * `versions` (array) is a list of user-selectable versions. These must be concrete
   [semantic versions](https://semver.org/), wildcards or ranges are not supported.
@@ -38,18 +38,6 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
   * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
-
-Each element of the two orchestrators can be overwritten independently, i.e. you can only override
-the list of allowed and default Kubernetes versions, while still relying on the default value for
-the update paths and all default settings for OpenShift by setting:
-
-```yaml
-spec:
-  versions:
-    kubernetes:
-      versions: ['1.16.0', '1.16.2']
-      default: '1.16.2'
-```
 
 {{% notice note %}}
 It's not possible to add or remove individual elements from the `versions` or `updates` arrays.

--- a/content/kubermatic/v2.21/architecture/concept/kkp-concepts/addons/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/concept/kkp-concepts/addons/_index.en.md
@@ -5,7 +5,7 @@ weight = 20
 
 +++
 
-Addons are specific services and tools extending the functionality of Kubernetes/OpenShift.
+Addons are specific services and tools extending the functionality of Kubernetes.
 
 ## Comparison To KKP Applications
 
@@ -45,26 +45,33 @@ The KKP binaries come with a `kubermatic-installer` tool, which can output a ful
 `KubermaticConfiguration` (`kubermatic-installer print`). This will also include the default configuration for addons and can serve as
 a starting point for adjustments.
 
-```bash
-docker run --rm quay.io/kubermatic/api:KUBERMATIC_VERSION kubermatic-installer print
-#apiVersion: kubermatic.k8c.io/v1
-#kind: KubermaticConfiguration
-#metadata:
-#  name: kubermatic
-#  namespace: kubermatic
-#spec:
-#  ...
-#  userCluster:
-#    addons:
-#      kubernetes: ...
-#      openshift: ...
+```yaml
+apiVersion: kubermatic.k8c.io/v1
+kind: KubermaticConfiguration
+metadata:
+  name: kubermatic
+  namespace: kubermatic
+spec:
+  userCluster:
+    addons:
+      # DefaultManifests is a list of addon manifests to install into all clusters.
+      # Mutually exclusive with "default".
+      defaultManifests: [...]
+      # DockerRepository is the repository containing the Docker image containing
+      # the possible addon manifests.
+      dockerRepository: quay.io/kubermatic/addons
+      # DockerTagSuffix is appended to the tag used for referring to the addons image.
+      # If left empty, the tag will be the KKP version (e.g. "v2.15.0"), with a
+      # suffix it becomes "v2.15.0-SUFFIX".
+      dockerTagSuffix: ""
+[...]
 ```
 
 ### Configuration
 
 To configure which addons shall be installed in all user clusters, update the relevant
 [KubermaticConfiguration]({{< ref "../../../../tutorials-howtos/kkp-configuration" >}}) in the `spec.userCluster.addons`
-section. For Kubernetes and OpenShift, configure a Docker image that contains the required addon manifests
+section. You can configure a Docker image that contains the required addon manifests
 (as YAML files) and an `AddonList` manifest that lists the addons and their requirements. Take a look
 at the default configuration above as a starting point.
 
@@ -267,14 +274,12 @@ After applying above config the UI should look like below:
 ### Custom Addons
 
 All manifests and config files for the default addons are stored in a Docker image, whose name is configured
-in the KubermaticConfiguration at `spec.userClusters.addons.kubernetes.dockerRepository` and
-`spec.userClusters.addons.openshift.dockerRepository`. These default to `quay.io/kubermatic/addons` and
-`quay.io/kubermatic/openshift-addons`, respectively.
+in the KubermaticConfiguration at `spec.userClusters.addons.dockerRepository`. This defaults to `quay.io/kubermatic/addons`.
 
 #### Creating a Docker Image
 
-Depending on the cluster orchestrator, choose the Kubernetes or OpenShift Docker image as the basis for your
-own image. All addon manifest are stored in `/addons/<addonname>`, e.g. `/addons/kube-proxy`. When creating
+It is recommended to choose the default image as the basis for your own image to include default addons.
+All addon manifest are stored in `/addons/<addonname>`, e.g. `/addons/kube-proxy`. When creating
 your own image, copy the manifests into a directory below `/addons`.
 
 Suppose you have this directory structure:
@@ -382,12 +387,6 @@ spec:
             kind: Addon
             metadata:
               name: canal
-              labels:
-                addons.kubermatic.io/ensure: true
-          - apiVersion: kubermatic.k8c.io/v1
-            kind: Addon
-            metadata:
-              name: cilium
               labels:
                 addons.kubermatic.io/ensure: true
           - apiVersion: kubermatic.k8c.io/v1

--- a/content/kubermatic/v2.21/tutorials-howtos/upgrading/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/v2.21/tutorials-howtos/upgrading/version-and-upgrade-configuration/_index.en.md
@@ -5,7 +5,7 @@ weight = 200
 
 +++
 
-This chapter describes how to configure the available Kubernetes/OpenShift versions and how to
+This chapter describes how to configure the available Kubernetes versions and how to
 provide update paths for user clusters.
 
 The list of selectable versions when [specifying cluster name and Kubernetes version]({{< ref "../../project-and-cluster-management" >}}) is defined in the `spec.versions`
@@ -20,7 +20,7 @@ To print the default configuration run `kubermatic-installer print` which output
 
 ### Configuring Versions
 
-The structure for Kubernetes and OpenShift versions is identical. Each contains
+The structure to configure Kubernetes version updates contains:
 
 * `versions` (array) is a list of user-selectable versions. These must be concrete
   [semantic versions](https://semver.org/), wildcards or ranges are not supported.
@@ -38,18 +38,6 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
   * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
-
-Each element of the two orchestrators can be overwritten independently, i.e. you can only override
-the list of allowed and default Kubernetes versions, while still relying on the default value for
-the update paths and all default settings for OpenShift by setting:
-
-```yaml
-spec:
-  versions:
-    kubernetes:
-      versions: ['1.16.0', '1.16.2']
-      default: '1.16.2'
-```
 
 {{% notice note %}}
 It's not possible to add or remove individual elements from the `versions` or `updates` arrays.


### PR DESCRIPTION
There are a couple of mentions of OpenShift support left in our docs which have survived over the years. This PR removes the last traces of them, since OpenShift support is gone for quite some time (I've never personally seen it while being at Kubermatic).