### PR TITLE
Update contribution links and slightly improve landing page language

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,13 +10,13 @@ title = "How Do I Contribute To ...?"
 #  title = "Documentation"
 
   [[contribution.links]]
-  url = "https://docs.kubermatic.com/kubeone/v1.2/how_to_contribute_to_kubeone/"
+  url = "https://docs.kubermatic.com/kubeone/v1.5/tutorials/how-to-contribute-to-kubeone/"
   [contribution.links.image]
   src = "/img/KubeOne-logo.svg"
   alt = ""
 
   [[contribution.links]]
-  url = "https://docs.kubermatic.com/kubermatic/v2.17/tutorials_howtos/how_to_contribute_to_kkp/"
+  url = "https://docs.kubermatic.com/kubermatic/v2.21/how-to-contribute-to-kkp/"
   [contribution.links.image]
   src = "/img/KubermaticKubernetesPlatform-logo.svg"
   alt = ""
@@ -36,7 +36,7 @@ title = "How Do I Contribute To ...?"
   title = "Start Using Kubernetes Today"
 
   [[features.list.items]]
-  text = "Scale like google, more containers with the same amount of devs"
+  text = "Scale like Google, more containers with the same amount of developers"
   [features.list.items.icon]
   src = "/img/icons/auto-scale-icon.svg"
   alt = ""
@@ -69,7 +69,7 @@ title = "How Do I Contribute To ...?"
   alt = ""
 
   [[features.list.items]]
-  text = "Empower your developer team to work with the stack they need"
+  text = "Empower your development team to work with the stack they need"
   [features.list.items.icon]
   src = "/img/icons/person-icon.svg"
   alt = ""


### PR DESCRIPTION
Contribution links on the landing page (docs.kubermatic.com) were pointing to quite old versions for KubeOne and KKP. This updates them.

I also saw the opportunity to slightly improve the language for bullet points below that, so I figured including them makes sense.