### PR TITLE
Remove ARM64 limitation for Canal+ipvs from 2.21 docs

### DIFF
--- a/content/kubermatic/v2.21/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/supported-versions/_index.en.md
@@ -31,14 +31,12 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version  | 1.26 | 1.25 |1.24[^1] | 1.23[^1] | 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2] |
+| KKP version  | 1.26 | 1.25 |1.24     | 1.23     | 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2] |
 | ------------ | ---- | ---- | ------- | -------- | -------- | -------- | -------- | -------- |
 | 2.21.x       | -    | -    | ✓       | ✓        | ✓        | -        | -        | -        |
 | 2.20.x       | -    | -    | -       | ✓[^4]    | ✓        | ✓        | ✓        | -        |
 | 2.19.x       | -    | -    | -       | -        | ✓        | ✓        | ✓        | -        |
 | 2.18.x[^3]   | -    | -    | -       | -        | ✓        | ✓        | ✓        | ✓        |
-
-[^1]: Kubernetes 1.24 and 1.23 are currently not supported on ARM64 clusters with Canal CNI and kube-proxy running in the IPVS mode.
 
 [^2]: Kubernetes 1.19, 1.20, 1.21 and 1.22 releases have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 


### PR DESCRIPTION
As per https://github.com/kubermatic/kubermatic/pull/11766, this will be supported in the next 2.21 patch release.