### PR TITLE
Fix brew install command in KKP install tutorials

### DIFF
--- a/content/kubermatic/main/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-CE/_index.en.md
@@ -99,7 +99,7 @@ The key items to consider while preparing your configuration files are described
 
 There are many more options but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32` (on macOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32` (on macOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`). Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.14/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.14/installation/install_kubermatic/_index.en.md
@@ -102,7 +102,7 @@ In addition to the `values.yaml` for configuring the charts, a number of options
 A minimal configuration for Helm charts sets these options. You can find it in the /examples directory of the tarball.
 The secret keys mentioned below can be generated using any password generator or on the shell using
 `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
-On MacOS, use `brew install gnu-tar` and `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`
+On MacOS, use `brew install coreutils` and `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`
 
 ```yaml
 # Dex is the OpenID Provider for KKP.

--- a/content/kubermatic/v2.14/installation/install_kubermatic_ee/_index.en.md
+++ b/content/kubermatic/v2.14/installation/install_kubermatic_ee/_index.en.md
@@ -102,7 +102,7 @@ In addition to the `values.yaml` for configuring the charts, a number of options
 A minimal configuration for Helm charts sets these options. You can find it in the /examples directory of the tarball.
 The secret keys mentioned below can be generated using any password generator or on the shell using
 `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
-On MacOS, use `brew install gnu-tar` and `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`
+On MacOS, use `brew install coreutils` and `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`
 
 ```yaml
 # Dex is the OpenID Provider for KKP.

--- a/content/kubermatic/v2.15/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.15/installation/install_kubermatic/_index.en.md
@@ -74,7 +74,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.16/installation/install_kubermatic/_index.en.md
+++ b/content/kubermatic/v2.16/installation/install_kubermatic/_index.en.md
@@ -76,7 +76,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.17/guides/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/v2.17/guides/installation/install_kkp_CE/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.18/guides/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/v2.18/guides/installation/install_kkp_CE/_index.en.md
@@ -78,7 +78,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.19/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/v2.19/installation/install_kkp_CE/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.20/installation/install_kkp_CE/_index.en.md
+++ b/content/kubermatic/v2.20/installation/install_kkp_CE/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.20/installation/install_kkp_CE_on_AWS/_index.en.md
+++ b/content/kubermatic/v2.20/installation/install_kkp_CE_on_AWS/_index.en.md
@@ -75,7 +75,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.20/installation/install_kkp_CE_on_Azure/_index.en.md
+++ b/content/kubermatic/v2.20/installation/install_kkp_CE_on_Azure/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.20/installation/install_kkp_CE_on_GCP/_index.en.md
+++ b/content/kubermatic/v2.20/installation/install_kkp_CE_on_GCP/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.20/installation/install_kkp_CE_on_vSphere/_index.en.md
+++ b/content/kubermatic/v2.20/installation/install_kkp_CE_on_vSphere/_index.en.md
@@ -76,7 +76,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.21/installation/install-kkp-CE-on-AWS/_index.en.md
+++ b/content/kubermatic/v2.21/installation/install-kkp-CE-on-AWS/_index.en.md
@@ -75,7 +75,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.21/installation/install-kkp-CE-on-Azure/_index.en.md
+++ b/content/kubermatic/v2.21/installation/install-kkp-CE-on-Azure/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.21/installation/install-kkp-CE-on-GCP/_index.en.md
+++ b/content/kubermatic/v2.21/installation/install-kkp-CE-on-GCP/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.21/installation/install-kkp-CE-on-vSphere/_index.en.md
+++ b/content/kubermatic/v2.21/installation/install-kkp-CE-on-vSphere/_index.en.md
@@ -75,7 +75,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 

--- a/content/kubermatic/v2.21/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/v2.21/installation/install-kkp-CE/_index.en.md
@@ -77,7 +77,7 @@ The key items to configure are:
 
 There are many more options, but these are essential to get a minimal system up and running. The secret keys
 mentioned above can be generated using any password generator or on the shell using
-`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install gnu-tar` and
+`cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`. On MacOS, use `brew install coreutils` and
 `cat /dev/urandom | gtr -dc A-Za-z0-9 | head -c32`. Alternatively, the Kubermatic Installer will suggest some
 properly generated secrets for you when it notices that some are missing, for example:
 


### PR DESCRIPTION
If I'm not mistaken, `brew install gnu-tar` is supposed to install the GNU version of `tar`, but we assume in docs it installs the GNU version of `tr` (`gtr`). `gtr` is supposed to be installed with the `coreutils` formula, so this PR adjusts our docs to recommend installing that formula instead.

/assign @embik 