### PR TITLE
Add some clarifications for expose strategy migration

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/networking/expose-strategies/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/expose-strategies/_index.en.md
@@ -156,6 +156,11 @@ By putting this label on your cluster you acknowledge that this type of upgrade 
 
 {{% /notice %}}
 
+It is recommended to suspend/terminate all workloads (e.g. by draining all active nodes via `kubectl drain`) as all nodes will
+lose connectivity to the cluster control plane upon updating the expose strategy. Therefore, updating the expose strategy
+in the next step will stop the ability to coordinate and properly terminate workloads on existing nodes. A planned shutdown
+might be desired to prevent potential data loss in your application stack.
+
 #### Step 2:
 At this point, you are able to change the expose strategy of the cluster in the Cluster API.
 Change the Cluster `spec.exposeStrategy` to the desired version:
@@ -185,3 +190,6 @@ for md in $(kubectl get machinedeployments -n kube-system --no-headers | awk '{p
   kubectl patch machinedeployment -n kube-system $md --type=merge -p $forceRestartAnnotations
 done
 ```
+
+Afterwards, all `Node` objects that show up as `NotReady` should be deleted. No quick shell script is provided because
+nodes might still be joining the cluster and temporarily show up as `NotReady`. Those should of course not be deleted.


### PR DESCRIPTION
This PR adds two notes to the expose strategy migration:

1. A recommendation to terminate all workloads prior to migration. As Kubernetes won't be able to communicate with kubelets on any nodes, they cannot be properly shut down after the migration. That seems ... dangerous at times. Users should exercise control about that shutdown process in my opinion.
2. A note saying that dead `Nodes` need to be removed.

This is a result of testing (https://github.com/kubermatic/kubermatic/issues/11831).