### PR TITLE
Document Ubuntu 22.04 support since KKP 2.21.2

### DIFF
--- a/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -38,4 +38,5 @@ This table shows the combinations of operating systems and cloud providers that 
 
 There could be more in the future since change is constant. This page will constantly be updated each time there is a new supported operating system.
 
+
 [^1] Supported since KKP 2.21.2.

--- a/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -39,4 +39,4 @@ This table shows the combinations of operating systems and cloud providers that 
 There could be more in the future since change is constant. This page will constantly be updated each time there is a new supported operating system.
 
 
-[^1] Supported since KKP 2.21.2.
+[^1]: Supported since KKP 2.21.2.

--- a/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -11,7 +11,7 @@ Kubermatic supports a multitude of operating systems. One of the unique features
 
 The following operating systems are currently supported by Kubermatic:
 
-* Ubuntu 20.04
+* Ubuntu 20.04 and 22.04[^1]
 * RHEL beginning with 8.0 (support is cloud provider-specific)
 * Flatcar (Stable channel)
 * Rocky Linux beginning with 8.0
@@ -37,3 +37,5 @@ This table shows the combinations of operating systems and cloud providers that 
 | VSphere | ✓ | ✓ | ✓ | ✓ | x | x | ✓ |
 
 There could be more in the future since change is constant. This page will constantly be updated each time there is a new supported operating system.
+
+[^1] Supported since KKP 2.21.2.


### PR DESCRIPTION
Support for Ubuntu 22.04 was added in https://github.com/kubermatic/kubermatic/pull/11072. This PR updates docs accordingly.