### PR TITLE
Uncomment v2.22 to publish release docs

### DIFF
--- a/data/products.yaml
+++ b/data/products.yaml
@@ -11,9 +11,8 @@ kubermatic:
   versions:
     - release: main
       name: main
-    # uncomment when KKP 2.22.0 is released
-    # - release: v2.22
-    #   name: v2.22
+    - release: v2.22
+      name: v2.22
     - release: v2.21
       name: v2.21
     - release: v2.20


### PR DESCRIPTION
This will pull the trigger on publishing the v2.22 documentation.