### PR TITLE
Introduce shortcode for current docs version

### DIFF
--- a/layouts/shortcodes/current_version.html
+++ b/layouts/shortcodes/current_version.html
@@ -1,0 +1,1 @@
+{{ path.Base (index (findRE "^([^/]+)/([^/]+)/" .Page.File.Dir) 0) }}


### PR DESCRIPTION
Introducing a shortcode for retrieving the current version dynamically. This will help us avoid hardcoding the versions in our docs. So instead of having 

```
![KKP Architecture Diagram](/img/kubermatic/v2.21/architecture/combined-master-seed.png)
```

We can simply have:

```
![KKP Architecture Diagram](/img/kubermatic/{{< current_version >}}/architecture/combined-master-seed.png)
```