### PR TITLE
Add note to upgrade guide about in-tree provider upgrade limitations

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -41,3 +41,14 @@ current KKP version.
 [^2]: Kubernetes releases from 1.19 to 1.23 have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.
+
+## Provider Incompatibilities
+
+KKP has some incompatibilities with cloud providers, e.g. because their in-tree cloud provider
+implementation has been removed from upstream Kubernetes. For KKP 2.22.x, the following incompatibilities
+apply:
+
+| Condition                          | Incompatible with Kubernetes | Notes                                                                                             |
+| ---------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| vSphere + in-tree cloud provider   | >= 1.25                      | Must be [migrated to external CCM first]({{< ref "../../../tutorials-howtos/CCM-migration/" >}}). | 
+| OpenStack + in-tree cloud provider | >= 1.26                      | Must be [migrated to external CCM first]({{< ref "../../../tutorials-howtos/CCM-migration/" >}}). | 

--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -33,13 +33,11 @@ current KKP version.
 
 | KKP version          | 1.26 | 1.25 |1.24 | 1.23[^2]| 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2] |
 | -------------------  | ---- | ---- | --- | ------- | -------- | -------- | -------- | -------- |
-| 2.22.x[^not-out-yet] | ✓    | ✓    | ✓   | -       | -        | -        | -        | -        |
+| 2.22.x               | ✓    | ✓    | ✓   | -       | -        | -        | -        | -        |
 | 2.21.x               | -    | -    | ✓   | ✓       | ✓        | -        | -        | -        |
 | 2.20.x               | -    | -    | -   | ✓       | ✓        | ✓        | ✓        | -        |
 
 
 [^2]: Kubernetes releases from 1.19 to 1.23 have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
-
-[^not-out-yet]: KKP 2.22 has not been released yet.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.

--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
@@ -206,6 +206,19 @@ The KKP upgrade migrates operating-system-manager (OSM) custom resources (`Opera
 
 You can find more information on this [in the documentation on how to use OSM in KKP]({{< ref "../../../tutorials-howtos/operating-system-manager/usage/#custom-operatingsystemprofiles" >}}). If you have been applying OSM custom resources through any means, you will need to adjust them accordingly.
 
+### vSphere & OpenStack User Cluster Upgrades
+
+KKP 2.22 introduces limitations to Kubernetes version upgrades for vSphere & OpenStack user clusters when the "in-tree" cloud providers are used. This has been added due to Kubernetes slowly removing provider-specific code from core Kubernetes, instead asking users to rely on external CCM (Cloud Controller Managers) and CSI drivers.
+
+By default, new vSphere and OpenStack user clusters in KKP get created with external cloud provider support. However, some long running user clusters might still be using the in-tree implementations. KKP supports [CCM & CSI migration]({{< ref "../../../tutorials-howtos/CCM-migration/" >}}) for those user clusters. The Kubermatic Dashboard offers information about the current status via the "External CCM/CSI" check under "Misc" in the additional cluster information section.
+
+The limitations in KKP 2.22 are as follows:
+
+- **vSphere** user clusters **with Kubernetes 1.24** and in-tree cloud provider usage cannot be upgraded to 1.25 or higher.
+- **OpenStack** user clusters **with Kubernetes 1.25** and in-tree cloud provider usage cannot be upgraded to 1.26 or higher.
+
+For user clusters with the in-tree cloud provider, KKP will not offer those upgrade paths in the Dashboard. After clusters have been migrated to external CCM & CSI, upgrades to the next minor Kubernetes versions will be available.
+
 ## Next Steps
 
 After finishing the upgrade, check out some of the new features that were added in KKP 2.22:

--- a/content/kubermatic/v2.22/architecture/compatibility/KKP-components-versioning/_index.en.md
+++ b/content/kubermatic/v2.22/architecture/compatibility/KKP-components-versioning/_index.en.md
@@ -16,7 +16,7 @@ of provided software and therefore releases updates regularly that also include 
 | cert-manager | 1.10.1 |
 | gatekeeper | 3.7.2 |
 | iap | 7.3.0 |
-| kubermatic-operator | 9.9.9-dev |
+| kubermatic-operator | 2.22.0|
 | logging/loki | 2.5.0 |
 | logging/promtail | 2.5.0 |
 | minio | RELEASE.2022-06-25T15-50-16Z |

--- a/content/kubermatic/v2.22/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/v2.22/architecture/compatibility/supported-versions/_index.en.md
@@ -41,3 +41,15 @@ current KKP version.
 [^2]: Kubernetes releases from 1.19 to 1.23 have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.
+
+## Provider Incompatibilities
+
+KKP has some incompatibilities with cloud providers, e.g. because their in-tree cloud provider
+implementation has been removed from upstream Kubernetes. For KKP 2.22.x, the following incompatibilities
+apply:
+
+| Condition                          | Incompatible with Kubernetes | Notes                                                                                             |
+| ---------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| vSphere + in-tree cloud provider   | >= 1.25                      | Must be [migrated to external CCM first]({{< ref "../../../tutorials-howtos/CCM-migration/" >}}). | 
+| OpenStack + in-tree cloud provider | >= 1.26                      | Must be [migrated to external CCM first]({{< ref "../../../tutorials-howtos/CCM-migration/" >}}). | 
+

--- a/content/kubermatic/v2.22/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/v2.22/architecture/compatibility/supported-versions/_index.en.md
@@ -33,13 +33,11 @@ current KKP version.
 
 | KKP version          | 1.26 | 1.25 |1.24 | 1.23[^2]| 1.22[^2] | 1.21[^2] | 1.20[^2] | 1.19[^2] |
 | -------------------  | ---- | ---- | --- | ------- | -------- | -------- | -------- | -------- |
-| 2.22.x[^not-out-yet] | ✓    | ✓    | ✓   | -       | -        | -        | -        | -        |
+| 2.22.x               | ✓    | ✓    | ✓   | -       | -        | -        | -        | -        |
 | 2.21.x               | -    | -    | ✓   | ✓       | ✓        | -        | -        | -        |
 | 2.20.x               | -    | -    | -   | ✓       | ✓        | ✓        | ✓        | -        |
 
 
 [^2]: Kubernetes releases from 1.19 to 1.23 have reached End-of-Life (EOL). We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
-
-[^not-out-yet]: KKP 2.22 has not been released yet.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a version is marked as supported, for example KKP 2.19 supports updating clusters from Kubernetes 1.20 to 1.21.

--- a/content/kubermatic/v2.22/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
+++ b/content/kubermatic/v2.22/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
@@ -206,6 +206,19 @@ The KKP upgrade migrates operating-system-manager (OSM) custom resources (`Opera
 
 You can find more information on this [in the documentation on how to use OSM in KKP]({{< ref "../../../tutorials-howtos/operating-system-manager/usage/#custom-operatingsystemprofiles" >}}). If you have been applying OSM custom resources through any means, you will need to adjust them accordingly.
 
+### vSphere & OpenStack User Cluster Upgrades
+
+KKP 2.22 introduces limitations to Kubernetes version upgrades for vSphere & OpenStack user clusters when the "in-tree" cloud providers are used. This has been added due to Kubernetes slowly removing provider-specific code from core Kubernetes, instead asking users to rely on external CCM (Cloud Controller Managers) and CSI drivers.
+
+By default, new vSphere and OpenStack user clusters in KKP get created with external cloud provider support. However, some long running user clusters might still be using the in-tree implementations. KKP supports [CCM & CSI migration]({{< ref "../../../tutorials-howtos/CCM-migration/" >}}) for those user clusters. The Kubermatic Dashboard offers information about the current status via the "External CCM/CSI" check under "Misc" in the additional cluster information section.
+
+The limitations in KKP 2.22 are as follows:
+
+- **vSphere** user clusters **with Kubernetes 1.24** and in-tree cloud provider usage cannot be upgraded to 1.25 or higher.
+- **OpenStack** user clusters **with Kubernetes 1.25** and in-tree cloud provider usage cannot be upgraded to 1.26 or higher.
+
+For user clusters with the in-tree cloud provider, KKP will not offer those upgrade paths in the Dashboard. After clusters have been migrated to external CCM & CSI, upgrades to the next minor Kubernetes versions will be available.
+
 ## Next Steps
 
 After finishing the upgrade, check out some of the new features that were added in KKP 2.22:


### PR DESCRIPTION
We added incompatibilities for vSphere and OpenStack. This adds the information to the upgrade guide and to our compatibility docs.

PRs:
- https://github.com/kubermatic/kubermatic/pull/11951
- https://github.com/kubermatic/kubermatic/pull/11939