### PR TITLE
Shortcode to render external markdown file

### DIFF
--- a/layouts/shortcodes/render_external_markdown.html
+++ b/layouts/shortcodes/render_external_markdown.html
@@ -1,0 +1,3 @@
+{{ $urlToRender := .Get 0 }}
+{{- $getRemoteFileResponse := resources.GetRemote $urlToRender (dict "headers" (dict "Cache-Control" "no-cache" "Connection" "keep-alive")) -}}
+{{- $getRemoteFileResponse.Content | markdownify | safeHTML -}}


### PR DESCRIPTION
Usage:

```
{{< render_external_markdown "https://raw.githubusercontent.com/kubermatic/machine-controller/main/README.md" >}}
```