### PR TITLE
Add child pages with depth to top-level pages

### DIFF
--- a/content/kubeone/main/architecture/requirements/machine-controller/_index.en.md
+++ b/content/kubeone/main/architecture/requirements/machine-controller/_index.en.md
@@ -8,3 +8,4 @@ weight = 20
 See detail pages for specific requirements of the cloud providers used by the Kubermatic machine-controller.
 
 {{% children %}}
+{{% /children %}}

--- a/content/kubermatic/main/architecture/_index.en.md
+++ b/content/kubermatic/main/architecture/_index.en.md
@@ -7,6 +7,8 @@ weight = 5
 
 Kubermatic Kubernetes Platform (KKP) makes full use of Kubernetes cluster to organize and scale workloads, depending on your and your customer's needs. On a high level we differentiate between the Master Cluster, Seed Clusters, and User Clusters.
 
+## Terminology
+
 ### Master Cluster
 
 The **Master Cluster** is a Kubernetes cluster which is responsible for storing the information about users, projects, SSH keys and credentials for infrastructure providers.
@@ -32,6 +34,8 @@ The **User Cluster** is a Kubernetes cluster created and managed by KKP.
 
 KKP has the concept of **Datacenters**, for example "AWS US-East", "DigitalOcean Frankfurt" or a local vSphere deployment. Datacenters are used to specify where user clusters can be created in, so you can choose to only support running user clusters on AWS.
 
+## Deployment Types
+
 ### Small-Scale Deployments
 
 In a typical small-scale setup, pictured below, a single cluster contains KKP and the master components for every user cluster.
@@ -55,3 +59,8 @@ This setup is useful for keeping the latency between the master components of a 
   * DigitalOcean ams1 and lon1
 
 See the [installation documentation]({{< relref "../installation/install-kkp-ce/">}}) for more details on how to setup datacenters.
+
+## Pages
+
+{{% children depth=5 %}}
+{{% /children %}}

--- a/content/kubermatic/main/cheat-sheets/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/_index.en.md
@@ -5,3 +5,8 @@ weight = 60
 +++
 
 This section contains some quick How-To resources that help in simplifying certain tasks such as debugging, or etcd-specific tasks such as restoring etcd from backup.
+
+## Pages
+
+{{% children depth=5 %}}
+{{% /children %}}

--- a/content/kubermatic/main/installation/_index.en.md
+++ b/content/kubermatic/main/installation/_index.en.md
@@ -19,3 +19,9 @@ It is also recommended to make yourself familiar with our [architecture document
 ## Installation Methods
 
 At the moment, the only supported installation method for KKP is using the Kubermatic Installer. We provide an [installation guide for the Community Edition (CE)]({{< ref "./install-kkp-CE/" >}}) that uses this method. Installation for the Enterprise Edition (EE) is fundamentally the same and only requires a adjustments to the CE installation that you can find [here]({{< ref "./install-kkp-EE/" >}}).
+
+## Pages
+
+{{% children depth=5 %}}
+{{% /children %}}
+

--- a/content/kubermatic/main/installation/upgrading/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/_index.en.md
@@ -9,6 +9,7 @@ This section contains important upgrade notes you should read before upgrading K
 ## Upgrade Guides
 
 {{% children %}}
+{{% /children %}}
 
 ## General Guidelines
 

--- a/content/kubermatic/main/references/_index.en.md
+++ b/content/kubermatic/main/references/_index.en.md
@@ -5,3 +5,8 @@ weight = 40
 +++
 
 This section contains a reference of the Kubermatic REST API.
+
+## Pages
+
+{{% children %}}
+{{% /children %}}

--- a/content/kubermatic/main/tutorials-howtos/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/_index.en.md
@@ -14,3 +14,8 @@ Let’s start simple! In the following step-by-step instructions, you’ll learn
 And now let’s dive a little deeper. In our How-To sections, you’ll find helpful information which is necessary for the operation part: How to scale or upgrade the control plane during runtime, how to customize monitoring, logging & alerting or how to set up the monitoring stack.
 
 Our tutorials include surface-level explanations and link to related concept topics for deep explanations.
+
+## Pages
+
+{{% children depth=5 %}}
+{{% /children %}}

--- a/content/kubermatic/v2.22/installation/upgrading/_index.en.md
+++ b/content/kubermatic/v2.22/installation/upgrading/_index.en.md
@@ -9,6 +9,7 @@ This section contains important upgrade notes you should read before upgrading K
 ## Upgrade Guides
 
 {{% children %}}
+{{% /children %}}
 
 ## General Guidelines
 


### PR DESCRIPTION
This adds child pages with depth 5 to all top-level pages (Architecture, Installation, etc).

In my opinion, this can help discover pages in a tree view, but I'd like to hear some thoughts on it.