### PR TITLE
Remove unrelated links to Terraform code

### DIFF
--- a/content/kubermatic/main/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-CE/_index.en.md
@@ -55,8 +55,6 @@ Depending on which choice you make, you will need to have either one or two Kube
 If you would like to run multiple Seeds to scale your setup beyond a single Seed, please check out the [Enterprise Edition]({{< ref "../install-kkp-EE/" >}})
 as that feature is only available there.
 
-We recommended checking our example Terraform configs as a reference of what objects/resources will be created: https://github.com/kubermatic/kubeone/tree/release/v1.5/examples/terraform
-
 ### Set Up Kubernetes
 
 To aid in setting up the Seed and Master Clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/), which can be used to set up a highly-available Kubernetes cluster.

--- a/content/kubermatic/v2.22/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/v2.22/installation/install-kkp-CE/_index.en.md
@@ -55,8 +55,6 @@ Depending on which choice you make, you will need to have either one or two Kube
 If you would like to run multiple Seeds to scale your setup beyond a single Seed, please check out the [Enterprise Edition]({{< ref "../install-kkp-EE/" >}})
 as that feature is only available there.
 
-We recommended checking our example Terraform configs as a reference of what objects/resources will be created: https://github.com/kubermatic/kubeone/tree/release/v1.5/examples/terraform
-
 ### Set Up Kubernetes
 
 To aid in setting up the Seed and Master Clusters, we provide [KubeOne](https://github.com/kubermatic/kubeone/), which can be used to set up a highly-available Kubernetes cluster.


### PR DESCRIPTION
I'm not sure what exactly happened in #1423 and #1424, but these links don't make any sense in this context. They reference Terraform examples for KubeOne, but this is the KKP installation documentation. Unfortunately the PRs did not have any description and were merged without review.