### PR TITLE
Update _index.en.md

### DIFF
--- a/content/kubeone/v1.6/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.6/tutorials/creating-clusters-baremetal/_index.en.md
@@ -232,9 +232,6 @@ controlPlane:
       privateAddress: '172.18.0.1'
       sshUsername: root
       sshPrivateKeyFile: '/home/me/.ssh/id_rsa'
-      taints:
-        - key: "node-role.kubernetes.io/master"
-          effect: "NoSchedule"
 
 staticWorkers:
   hosts:


### PR DESCRIPTION
With this taint the installer fails

```
Error: configuration validation
controlPlane.hosts.taints: Forbidden: "node-role.kubernetes.io/master" taint is forbidden for clusters running Kubernetes 1.25+
```