### PR TITLE
Require setting grafana domain in mla values

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -88,6 +88,7 @@ The prefixes chosen for Grafana and Alertmanager then need to be configured in t
 Let's start with preparing the values.yaml for the IAP Helm Chart. A starting point can be found in the `example/values.example.mla.yaml` file of the installer package:
 
 - Modify the base domain under which your KKP installation is available (`kkp.example.com` in `iap.oidc_issuer_url`).
+- Set `grafana."grafana.ini".server.domain` to match the domain under which you want to expose Grafana (e.g. grafana.kkp.example.com)
 - Modify the base domain, seed name and Grafana prefix as described above (`grafana.seed-cluster-x.kkp.example.com` in `iap.deployments.grafana.ingress.host`).
 - Set `iap.deployments.grafana.client_secret` + `iap.deployments.grafana.encryption_key` and `iap.deployments.alertmanager.client_secret` + `iap.deployments.alertmanager.encryption_key` to the newly generated key values (they can be generated e.g. with `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`).
 - Configure how the users should be authenticated in `iap.deployments.grafana.config` and `iap.deployments.alertmanager.config` (e.g. modify `YOUR_GITHUB_ORG` and `YOUR_GITHUB_TEAM` placeholders). Please check the [OAuth Provider Configuration](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider/) for more details.


### PR DESCRIPTION
Setting grafana.domain allows for features like Grafana short-urls to work properly

We have tried automating this to no good avail. See https://github.com/kubermatic/kubermatic/issues/12332 for more details. As a result we have decided to document this

Fixes: https://github.com/kubermatic/kubermatic/issues/12332