### PR TITLE
Exclude CentOS stream versions from support matrix

### DIFF
--- a/content/kubeone/main/architecture/requirements/machine-controller/vSphere/vSphere.en.md
+++ b/content/kubeone/main/architecture/requirements/machine-controller/vSphere/vSphere.en.md
@@ -20,7 +20,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubeone/v1.3/architecture/requirements/machine_controller/vSphere/vSphere.en.md
+++ b/content/kubeone/v1.3/architecture/requirements/machine_controller/vSphere/vSphere.en.md
@@ -19,7 +19,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubeone/v1.4/architecture/requirements/machine_controller/vSphere/vSphere.en.md
+++ b/content/kubeone/v1.4/architecture/requirements/machine_controller/vSphere/vSphere.en.md
@@ -20,7 +20,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubeone/v1.5/architecture/requirements/machine-controller/vSphere/vSphere.en.md
+++ b/content/kubeone/v1.5/architecture/requirements/machine-controller/vSphere/vSphere.en.md
@@ -20,7 +20,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubeone/v1.6/architecture/requirements/machine-controller/vSphere/vSphere.en.md
+++ b/content/kubeone/v1.6/architecture/requirements/machine-controller/vSphere/vSphere.en.md
@@ -20,7 +20,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubermatic/main/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -15,7 +15,7 @@ The following operating systems are currently supported by Kubermatic:
 * RHEL beginning with 8.0 (support is cloud provider-specific)
 * Flatcar (Stable channel)
 * Rocky Linux beginning with 8.0
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Amazon Linux 2
 
 This table shows the combinations of operating systems and cloud providers that KKP supports:

--- a/content/kubermatic/main/architecture/supported-providers/vsphere/vsphere.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/vsphere/vsphere.en.md
@@ -17,7 +17,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 ### Supported Operating Systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.ova)
 * Ubuntu 22.04 [ova](https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.ova)
 * Flatcar (Stable channel) [ova](https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova)

--- a/content/kubermatic/v2.17/architecture/requirements/support_policy/OS_support_matrix/_index.en.md
+++ b/content/kubermatic/v2.17/architecture/requirements/support_policy/OS_support_matrix/_index.en.md
@@ -12,7 +12,7 @@ Kubermatic supports a multitude of operating systems. One of the unique features
 The operating systems below are currently supported by Kubermatic:
 
 * RHEL beginning with 8.0 (support is cloud provider-specific)
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Ubuntu LTS beginning with 18.04
 * Flatcar (Stable channel)
 * SLES beginning with 15.0 (only on AWS)

--- a/content/kubermatic/v2.18/architecture/requirements/support_policy/OS_support_matrix/_index.en.md
+++ b/content/kubermatic/v2.18/architecture/requirements/support_policy/OS_support_matrix/_index.en.md
@@ -12,7 +12,7 @@ Kubermatic supports a multitude of operating systems. One of the unique features
 The operating systems below are currently supported by Kubermatic:
 
 * RHEL beginning with 8.0 (support is cloud provider-specific)
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Ubuntu LTS beginning with 18.04
 * Flatcar (Stable channel)
 * SLES beginning with 15.0 (only on AWS)

--- a/content/kubermatic/v2.18/architecture/requirements/support_policy/provider_support_matrix/vSphere/vSphere.en.md
+++ b/content/kubermatic/v2.18/architecture/requirements/support_policy/provider_support_matrix/vSphere/vSphere.en.md
@@ -18,7 +18,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubermatic/v2.19/architecture/support_policy/OS_support_matrix/_index.en.md
+++ b/content/kubermatic/v2.19/architecture/support_policy/OS_support_matrix/_index.en.md
@@ -12,7 +12,7 @@ Kubermatic supports a multitude of operating systems. One of the unique features
 The operating systems below are currently supported by Kubermatic:
 
 * RHEL beginning with 8.0 (support is cloud provider-specific)
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Ubuntu LTS beginning with 18.04
 * Flatcar (Stable channel)
 * SLES beginning with 15.0 (only on AWS)

--- a/content/kubermatic/v2.19/architecture/support_policy/provider_support_matrix/vSphere/vSphere.en.md
+++ b/content/kubermatic/v2.19/architecture/support_policy/provider_support_matrix/vSphere/vSphere.en.md
@@ -17,7 +17,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubermatic/v2.20/architecture/support_policy/OS_support_matrix/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/support_policy/OS_support_matrix/_index.en.md
@@ -12,7 +12,7 @@ Kubermatic supports a multitude of operating systems. One of the unique features
 The operating systems below are currently supported by Kubermatic:
 
 * RHEL beginning with 8.0 (support is cloud provider-specific)
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Ubuntu LTS beginning with 18.04
 * Flatcar (Stable channel)
 * SLES beginning with 15.0 (only on AWS)

--- a/content/kubermatic/v2.20/architecture/support_policy/provider_support_matrix/vSphere/vSphere.en.md
+++ b/content/kubermatic/v2.20/architecture/support_policy/provider_support_matrix/vSphere/vSphere.en.md
@@ -17,7 +17,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -16,7 +16,7 @@ The following operating systems are currently supported by Kubermatic:
 * Flatcar (Stable channel)
 * Rocky Linux beginning with 8.0
 * Ubuntu LTS beginning with 18.04
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Amazon Linux 2
 * SLES beginning with 15.0 (only on AWS)
 

--- a/content/kubermatic/v2.21/architecture/supported-providers/vSphere/vSphere.en.md
+++ b/content/kubermatic/v2.21/architecture/supported-providers/vSphere/vSphere.en.md
@@ -17,7 +17,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)

--- a/content/kubermatic/v2.22/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubermatic/v2.22/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -15,7 +15,7 @@ The following operating systems are currently supported by Kubermatic:
 * RHEL beginning with 8.0 (support is cloud provider-specific)
 * Flatcar (Stable channel)
 * Rocky Linux beginning with 8.0
-* CentOS beginning with 7.4
+* CentOS beginning with 7.4 excluding stream versions
 * Amazon Linux 2
 
 This table shows the combinations of operating systems and cloud providers that KKP supports:

--- a/content/kubermatic/v2.22/architecture/supported-providers/vsphere/vsphere.en.md
+++ b/content/kubermatic/v2.22/architecture/supported-providers/vsphere/vsphere.en.md
@@ -15,7 +15,7 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 
 Supported operating systems
 
-* CentOS beginning with 7.4 [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
+* CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
 * CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
 * Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
 * Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)


### PR DESCRIPTION
The claim for CentOS support matrix was worded conclusively. It wasn't clear what CentOS versions are supported and what aren't.

The CentOS versioning is split between Linux and Stream types. KKP intended to support some CentOS Linux 7 (starting with 7.4) and CentOS Linux 8 but didn't intend to promise support for CentOS Stream 8 or CentOS Stream 9.