### PR TITLE
Update KubeOne OS support matrix with Rocky Linux 8

### DIFF
--- a/content/kubeone/main/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubeone/main/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -12,7 +12,7 @@ The following operating systems are supported:
 * Ubuntu 20.04 (Focal)
 * Ubuntu 22.04 (Jammy Jellyfish)
 * CentOS 7
-* CentOS 8
+* Rocky Linux 8
 * RHEL 8.0, 8.1, 8.2, 8.3\*, 8.4\*
 * Flatcar
 * Amazon Linux 2

--- a/content/kubeone/main/architecture/requirements/machine-controller/vSphere/vSphere.en.md
+++ b/content/kubeone/main/architecture/requirements/machine-controller/vSphere/vSphere.en.md
@@ -21,9 +21,9 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 Supported operating systems
 
 * CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
-* CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
-* Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
-* Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)
+* Rocky Linux 8 [qcow2](https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2)
+* Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.ova)
+* Ubuntu 22.04 [ova](https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.ova)
 * Flatcar (Stable channel) [ova](https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova)
 
 #### Importing the OVA

--- a/content/kubeone/v1.6/architecture/compatibility/OS-support-matrix/_index.en.md
+++ b/content/kubeone/v1.6/architecture/compatibility/OS-support-matrix/_index.en.md
@@ -12,7 +12,7 @@ The following operating systems are supported:
 * Ubuntu 20.04 (Focal)
 * Ubuntu 22.04 (Jammy Jellyfish)
 * CentOS 7
-* CentOS 8
+* Rocky Linux 8
 * RHEL 8.0, 8.1, 8.2, 8.3\*, 8.4\*
 * Flatcar
 * Amazon Linux 2

--- a/content/kubeone/v1.6/architecture/requirements/machine-controller/vSphere/vSphere.en.md
+++ b/content/kubeone/v1.6/architecture/requirements/machine-controller/vSphere/vSphere.en.md
@@ -21,9 +21,9 @@ When creating worker nodes for a user cluster, the user can specify an existing 
 Supported operating systems
 
 * CentOS beginning with 7.4 excluding stream versions [qcow2](https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2)
-* CentOS 8 [qcow2](https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2)
-* Ubuntu 18.04 [ova](https://cloud-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.ova)
-* Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.ova)
+* Rocky Linux 8 [qcow2](https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2)
+* Ubuntu 20.04 [ova](https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.ova)
+* Ubuntu 22.04 [ova](https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.ova)
 * Flatcar (Stable channel) [ova](https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova)
 
 #### Importing the OVA


### PR DESCRIPTION
My understanding is that we support Rocky Linux 8 as OS in KubeOne. CentOS 8 is EOL since December 2021, so hopefully no one is using that anymore and we can just replace it with Rocky Linux 8 in our support matrix.