### PR TITLE
Update crd-ref-docs to v0.0.9

### DIFF
--- a/hack/crd-ref-docs.yaml
+++ b/hack/crd-ref-docs.yaml
@@ -1,12 +1,13 @@
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.22
+  kubernetesVersion: 1.26
 
 processor:
   ignoreFields:
     - "TypeMeta$"
     - "apiversion$"
     - "kind$"
+    - "fake$"
 
   ignoreTypes:
     - "Quantity$"

--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -4,15 +4,15 @@ set -euox pipefail
 
 cd $(dirname $0)/..
 
-SOURCE="${GOPATH}/src/github.com/kubermatic/kubermatic/pkg/apis/"
+SOURCE=${SOURCE:-"$(go env GOPATH)/src/github.com/kubermatic/kubermatic/pkg/apis"}
 
 which crd-ref-docs >/dev/null || {
-  echo "running go install github.com/elastic/crd-ref-docs@v0.0.8 in 5s... (ctrl-c to cancel)"
+  echo "running go install github.com/elastic/crd-ref-docs@v0.0.9 in 5s... (ctrl-c to cancel)"
   sleep 5
-  go install github.com/elastic/crd-ref-docs@v0.0.8
+  go install github.com/elastic/crd-ref-docs@v0.0.9
 }
 
-${GOPATH}/bin/crd-ref-docs \
+$(go env GOPATH)/bin/crd-ref-docs \
   --source-path "${SOURCE}" \
   --max-depth 10 \
   --renderer markdown \


### PR DESCRIPTION
https://github.com/elastic/crd-ref-docs/releases/tag/v0.0.9 is out now, so we should upgrade to that. the most important change is that embedded structs get resolved correctly. They are an implementation detail of our API types and users do not care about them, they only want to know what fields are available.