### PR TITLE
Make Seed config a sub-chapter of 'Custom Configuration'

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
@@ -102,7 +102,7 @@ spec:
       }
 ```
 
-#### Seed Configuration
+### Seed Configuration
 
 In some cases a Seed may require an independent OIDC provider. For this reason a `Seed` CRD contains relevant fields under `spec.oidcProviderConfiguration`. Filling those fields results in overwriting a configuration from `KubermaticConfiguration` CRD. The following snippet presents an example of `Seed` CRD configuration:
 

--- a/content/kubermatic/v2.22/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/OIDC-Provider-Configuration/_index.en.md
@@ -102,7 +102,7 @@ spec:
       }
 ```
 
-#### Seed Configuration
+### Seed Configuration
 
 In some cases a Seed may require an independent OIDC provider. For this reason a `Seed` CRD contains relevant fields under `spec.oidcProviderConfiguration`. Filling those fields results in overwriting a configuration from `KubermaticConfiguration` CRD. The following snippet presents an example of `Seed` CRD configuration:
 


### PR DESCRIPTION
This moves the Seed configuration under "Custom Configuration", since it being under "UI Configuration" doesn't make sense.