### PR TITLE
Fix 'getting kubeone' zsh command completion

### DIFF
--- a/content/kubeone/main/getting-kubeone/_index.en.md
+++ b/content/kubeone/main/getting-kubeone/_index.en.md
@@ -141,7 +141,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation

--- a/content/kubeone/v1.0/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.0/getting_kubeone/_index.en.md
@@ -141,7 +141,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation

--- a/content/kubeone/v1.2/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.2/getting_kubeone/_index.en.md
@@ -141,7 +141,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation

--- a/content/kubeone/v1.3/guides/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.3/guides/getting_kubeone/_index.en.md
@@ -140,7 +140,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation

--- a/content/kubeone/v1.4/getting_kubeone/_index.en.md
+++ b/content/kubeone/v1.4/getting_kubeone/_index.en.md
@@ -141,7 +141,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation

--- a/content/kubeone/v1.5/getting-kubeone/_index.en.md
+++ b/content/kubeone/v1.5/getting-kubeone/_index.en.md
@@ -141,7 +141,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation

--- a/content/kubeone/v1.6/getting-kubeone/_index.en.md
+++ b/content/kubeone/v1.6/getting-kubeone/_index.en.md
@@ -141,7 +141,7 @@ source <(kubeone completion zsh)
 To active completion permanently, add the command to your `~/.zshrc` file.
 
 ```
-echo "source <(kubeone completion bash)" >> ~/.zshrc
+echo "source <(kubeone completion zsh)" >> ~/.zshrc
 ```
 
 ### Generating documentation


### PR DESCRIPTION
Prevents copy-paste errors, since sourcing the bash completion script on the .zshrc will generate some error messages.