### PR TITLE
Update compatibility matrix for KubeOne to add Kubernetes 1.27

### DIFF
--- a/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
@@ -20,21 +20,21 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.26  | 1.25  | 1.24  | 1.23[^1] | 1.22[^2] | 1.21[^2] | 1.20[^2] |
-| --------------- | ----- | ----- | ----- | -------- | -------- | -------- | -------- |
-| v1.6            | ✓     | ✓     | ✓     | -        | -        | -        | -        |
-| v1.5            | -     | -     | ✓     | ✓        | ✓        | -        | -        |
-| v1.4            | -     | -     | -     | ✓        | ✓        | ✓        | ✓        |
+| KubeOne version | 1.27  | 1.26  | 1.25  | 1.24[^1] | 1.23[^2] | 1.22[^2] |
+| --------------- | ----- | ----- | ----- | -------- | -------- | -------- |
+| v1.7            | ✓     | ✓     | ✓     | ✓        | -        | -        |
+| v1.6            | -     | ✓     | ✓     | ✓        | -        | -        |
+| v1.5            | -     | -     | -     | ✓        | ✓        | ✓        |
 
-[^1]: Kubernetes 1.23 is scheduled to reach End-of-Life (EOL) on 2022-02-28.
+[^1]: Kubernetes 1.24 is scheduled to reach End-of-Life (EOL) on 2023-07-28.
 We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
-[^2]: Kubernetes 1.22, 1.21 and 1.20 have reached End-of-Life (EOL). We strongly
+[^2]: Kubernetes 1.23 and 1.22 have reached End-of-Life (EOL). We strongly
 recommend upgrading to a supported Kubernetes release as soon as possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
-than the latest Kubernetes release. For example, with 1.26 being the latest
-release, we recommend running at least Kubernetes 1.25.
+than the latest Kubernetes release. For example, with 1.27 being the latest
+release, we recommend running at least Kubernetes 1.26.
 
 [upstream-supported-versions]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
 [kubernetes-issue-93194]: https://github.com/kubernetes/kubernetes/issues/93194

--- a/content/kubeone/v1.6/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/v1.6/architecture/compatibility/supported-versions/_index.en.md
@@ -20,17 +20,17 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.26  | 1.25  | 1.24  | 1.23[^1] | 1.22[^2] | 1.21[^2] | 1.20[^2] |
-| --------------- | ----- | ----- | ----- | -------- | -------- | -------- | -------- |
-| v1.6            | ✓     | ✓     | ✓     | -        | -        | -        | -        |
-| v1.5            | -     | -     | ✓     | ✓        | ✓        | -        | -        |
-| v1.4            | -     | -     | -     | ✓        | ✓        | ✓        | ✓        |
+| KubeOne version | 1.26  | 1.25  | 1.24[^1] | 1.23[^2] | 1.22[^2] | 1.21[^2] | 1.20[^2] |
+| --------------- | ----- | ----- | -------- | -------- | -------- | -------- | -------- |
+| v1.6            | ✓     | ✓     | ✓        | -        | -        | -        | -        |
+| v1.5            | -     | -     | ✓        | ✓        | ✓        | -        | -        |
+| v1.4            | -     | -     | -        | ✓        | ✓        | ✓        | ✓        |
 
-[^1]: Kubernetes 1.23 is scheduled to reach End-of-Life (EOL) on 2022-02-28.
+[^1]: Kubernetes 1.24 is scheduled to reach End-of-Life (EOL) on 2023-07-28.
 We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
-[^2]: Kubernetes 1.22, 1.21 and 1.20 have reached End-of-Life (EOL). We strongly
-recommend upgrading to a supported Kubernetes release as soon as possible.
+[^2]: Kubernetes 1.23, 1.22, 1.21 and 1.20 have reached End-of-Life (EOL).
+We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
 than the latest Kubernetes release. For example, with 1.26 being the latest


### PR DESCRIPTION
This PR updates the compatibility matrix for KubeOne to add Kubernetes 1.27.

/assign @kron4eg 