### PR TITLE
Fix KubermaticConfiguration link on v2.22

### DIFF
--- a/content/kubermatic/v2.22/cheat-sheets/etcd/backup-and-restore/_index.en.md
+++ b/content/kubermatic/v2.22/cheat-sheets/etcd/backup-and-restore/_index.en.md
@@ -30,7 +30,7 @@ The legacy way of enabling the automatic etcd backups through the KubermaticConf
 
 ### Backup and Delete Containers
 
-The new backup controller uses 2 default jobs to for storing backups and deleting them. If needed, it is possible to configure custom jobs in the [KubermaticConfiguration]({{ ref "../../../references/crds#kubermaticseedcontrollerconfiguration" }}).
+The new backup controller uses 2 default jobs to for storing backups and deleting them. If needed, it is possible to configure custom jobs in the [KubermaticConfiguration]({{< ref "../../../references/crds/#kubermaticseedcontrollerconfiguration" >}}).
 
 #### Store Job Container (backupStoreContainer)
 


### PR DESCRIPTION
For some reason this ref changed between versions, rendering incorrectly:

<img width="1151" alt="Screenshot 2023-07-24 at 14 39 13" src="https://github.com/kubermatic/docs/assets/2644445/faa75eee-2bba-4b2c-b6c4-7b864503cf2a">
