### PR TITLE
change machine_controller_machines_total to new kube_node_info metric

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
@@ -167,8 +167,7 @@ Kubelet Metrics:
 - machine_cpu_cores
 - machine_memory_bytes
 
-Other Metrics:
-
+Kube-State Metrics:
 - kube_node_info
 
 The following values will be written to the reports:

--- a/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
@@ -137,7 +137,7 @@ Data used to aggregate the report are stored in a prometheus instance dedicated 
 This metering prometheus instance collects data from user clusters via federation. Originally they are collected from kubelet and cAdvisor.
 Metrics used to aggregate to a report are as follows:
 
- - machine_controller_machines_total
+ - kube_node_info
  - node_cpu_usage_seconds_total
  - machine_cpu_cores
  - machine_memory_bytes
@@ -167,9 +167,9 @@ Kubelet Metrics:
 - machine_cpu_cores
 - machine_memory_bytes
 
-Machine controller Metrics:
+Other Metrics:
 
-- machine_controller_machines_total
+- kube_node_info
 
 The following values will be written to the reports:
 

--- a/content/kubermatic/v2.22/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/metering/_index.en.md
@@ -135,7 +135,7 @@ Data used to aggregate the report are stored in a prometheus instance dedicated 
 This metering prometheus instance collects data from user clusters via federation. Originally they are collected from kubelet and cAdvisor.
 Metrics used to aggregate to a report are as follows:
 
- - machine_controller_machines_total
+ - kube_node_info
  - node_cpu_usage_seconds_total
  - machine_cpu_cores
  - machine_memory_bytes
@@ -165,9 +165,9 @@ Kubelet Metrics:
 - machine_cpu_cores
 - machine_memory_bytes
 
-Machine controller Metrics:
+Other Metrics:
 
-- machine_controller_machines_total
+- kube_node_info
 
 The following values will be written to the reports:
 

--- a/content/kubermatic/v2.22/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/metering/_index.en.md
@@ -165,8 +165,7 @@ Kubelet Metrics:
 - machine_cpu_cores
 - machine_memory_bytes
 
-Other Metrics:
-
+Kube-State Metrics:
 - kube_node_info
 
 The following values will be written to the reports:

--- a/content/kubermatic/v2.23/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/metering/_index.en.md
@@ -167,8 +167,7 @@ Kubelet Metrics:
 - machine_cpu_cores
 - machine_memory_bytes
 
-Other Metrics:
-
+Kube-State Metrics:
 - kube_node_info
 
 The following values will be written to the reports:

--- a/content/kubermatic/v2.23/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/metering/_index.en.md
@@ -137,7 +137,7 @@ Data used to aggregate the report are stored in a prometheus instance dedicated 
 This metering prometheus instance collects data from user clusters via federation. Originally they are collected from kubelet and cAdvisor.
 Metrics used to aggregate to a report are as follows:
 
- - machine_controller_machines_total
+ - kube_node_info
  - node_cpu_usage_seconds_total
  - machine_cpu_cores
  - machine_memory_bytes
@@ -167,9 +167,9 @@ Kubelet Metrics:
 - machine_cpu_cores
 - machine_memory_bytes
 
-Machine controller Metrics:
+Other Metrics:
 
-- machine_controller_machines_total
+- kube_node_info
 
 The following values will be written to the reports:
 


### PR DESCRIPTION
The metric based for nodes in a cluster where changed a while ago from machine_controller_machines_total to kube_node_info metric