### PR TITLE
Reference correct kubermatic-s3-credentials Secret for backup location

### DIFF
--- a/content/kubermatic/main/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -473,7 +473,7 @@ spec:
     defaultDestination: minio
     destinations:
       minio:
-        # use the bucket name chosen during installation.
+        # use the bucket name chosen for the create-minio-backup-bucket Job from above.
         bucketName: kkpbackup
         credentials:
           name: kubermatic-s3-credentials

--- a/content/kubermatic/main/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -476,7 +476,7 @@ spec:
         # use the bucket name chosen during installation.
         bucketName: kkpbackup
         credentials:
-          name: s3-credentials
+          name: kubermatic-s3-credentials
           namespace: kube-system
         endpoint: http://minio.minio.svc.cluster.local:9000
 ```

--- a/content/kubermatic/v2.22/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.22/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -476,7 +476,7 @@ spec:
         # use the bucket name chosen during installation.
         bucketName: kkpbackup
         credentials:
-          name: s3-credentials
+          name: kubermatic-s3-credentials
           namespace: kube-system
         endpoint: http://minio.minio.svc.cluster.local:9000
 ```

--- a/content/kubermatic/v2.23/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.23/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -476,7 +476,7 @@ spec:
         # use the bucket name chosen during installation.
         bucketName: kkpbackup
         credentials:
-          name: s3-credentials
+          name: kubermatic-s3-credentials
           namespace: kube-system
         endpoint: http://minio.minio.svc.cluster.local:9000
 ```


### PR DESCRIPTION
We renamed the `s3-credentials` Secret all the way back in https://github.com/kubermatic/kubermatic/pull/9230, but documentation was either not updated or this section was created from outdated information. This updates the documentation accordingly.