### PR TITLE
Add release notes for v2.23.1, v2.22.5 and v2.21.11

### DIFF
--- a/content/kubermatic/v2.21/release-notes/_index.en.md
+++ b/content/kubermatic/v2.21/release-notes/_index.en.md
@@ -15,6 +15,18 @@ weight = 70
 - [v2.21.8](#v2218)
 - [v2.21.9](#v2219)
 - [v2.21.10](#v22110)
+- [v2.21.11](#v22111)
+
+## [v2.21.11](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.11)
+
+### Bugfixes
+
+- Fix default url configuration of blackbox exporter ([#12412](https://github.com/kubermatic/kubermatic/pull/12412))
+- Metrics server write timeout increased ([#12314](https://github.com/kubermatic/kubermatic/pull/12314))
+
+### Updates
+
+- Update machine-controller to [v1.54.8](https://github.com/kubermatic/machine-controller/releases/tag/v1.54.8) ([#12391](https://github.com/kubermatic/kubermatic/pull/12498))
 
 ## [v2.21.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.10)
 

--- a/content/kubermatic/v2.22/release-notes/_index.en.md
+++ b/content/kubermatic/v2.22/release-notes/_index.en.md
@@ -9,6 +9,24 @@ weight = 70
 - [v2.22.2](#v2222)
 - [v2.22.3](#v2223)
 - [v2.22.4](#v2224)
+- [v2.22.5](#v2225)
+
+## [v2.22.5](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.5)
+
+### Bugfixes
+
+- Fix default url configuration of blackbox exporter ([#12412](https://github.com/kubermatic/kubermatic/pull/12412))
+- Metrics server write timeout increased ([#12314](https://github.com/kubermatic/kubermatic/pull/12314))
+- Alertmanager now allows blackbox exporter to perform healthcheck API call without AuthFailure ([#12217](https://github.com/kubermatic/kubermatic/pull/12217))
+
+### Updates
+
+- Update to Go 1.19.11 ([#12503](https://github.com/kubermatic/kubermatic/pull/12503))
+- Update machine-controller to [v1.56.4](https://github.com/kubermatic/machine-controller/releases/tag/v1.56.4) ([#12392](https://github.com/kubermatic/kubermatic/pull/12497))
+
+### Misc
+
+- Use buildx instead of Buildah to create multi-architecture KKP container images ([#12399](https://github.com/kubermatic/kubermatic/pull/12399))
 
 ## [v2.22.4](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.4)
 

--- a/content/kubermatic/v2.23/release-notes/_index.en.md
+++ b/content/kubermatic/v2.23/release-notes/_index.en.md
@@ -5,6 +5,31 @@ weight = 70
 +++
 
 - [v2.23.0](#v2230)
+- [v2.23.1](#v2231)
+
+## [v2.23.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.1)
+
+### Features
+
+- Made Prometheus helm chart extensible so that external metric storage solutions like Thanos can be easily integrated for seed long-term monitoring ([#12469](https://github.com/kubermatic/kubermatic/pull/12469))
+
+### Bugfixes
+
+- Fix default url configuration of blackbox exporter ([#12412](https://github.com/kubermatic/kubermatic/pull/12412))
+- Hetzner CSI: recreate CSIDriver to allow upgrade from 1.6.0 to 2.2.0 ([#12432](https://github.com/kubermatic/kubermatic/pull/12432))
+- Replace `irate` with `rate` for node cpu usage graphs ([#12427](https://github.com/kubermatic/kubermatic/pull/12427))
+- The Kubermatic Installer will now validate the existing Minio filesystem before attempting a `kubermatic-seed` stack installation ([#12493](https://github.com/kubermatic/kubermatic/pull/12493))
+
+### Updates
+
+- Update to Go 1.20.6 ([#12502](https://github.com/kubermatic/kubermatic/pull/12502))
+- Update Cilium CNI to 1.13.4, marking 1.13.0 as deprecated but kept 1.13.3 because 1.13.4 breaks IPSec support ([#12478](https://github.com/kubermatic/kubermatic/pull/12478))
+- Update machine-controller to [v1.57.1](https://github.com/kubermatic/machine-controller/releases/tag/v1.57.1) ([#12492](https://github.com/kubermatic/kubermatic/pull/12492))
+
+### Misc
+
+- Support for configuring multiple networks for vSphere ([#12458](https://github.com/kubermatic/kubermatic/pull/12458))
+- Support for configuring IPFamilies and IPFamilyPolicy for nodeport-proxy ([#12472](https://github.com/kubermatic/kubermatic/pull/12472))
 
 ## [v2.23.0](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.0)
 


### PR DESCRIPTION
We forgot to publish release notes for the July 2023 patch releases. This follows up on that.