### PR TITLE
Document parameter for parallel CCM service reconciliation

### DIFF
--- a/content/kubeone/main/guides/addons/_index.en.md
+++ b/content/kubeone/main/guides/addons/_index.en.md
@@ -203,7 +203,7 @@ or passed as parameter on the respective CCM addon):
 
 | Parameter     | Description                                                             |
 | ------------- | ----------------------------------------------------------------------- |
-| `CCM_CONCURRENT_SERVICE_SYNCS` | Sets the parallel `Service` (load balancer) reconciles in the CCM. If not set, this is "1". The value for this parameter is a number, but needs to be wrapped in quotes. |
+| `CCM_CONCURRENT_SERVICE_SYNCS` | Sets the parallel `Service` (load balancer) reconciles in the CCM. If not set, this is "1". The value for this parameter is a number, but needs to be wrapped in quotes. **Warning**: Setting this parameter will result in higher CPU and network consumption. It might also trigger rate limits with your cloud provider APIs. Be very conservative about increasing this number. |
 
 ## Reconciling Addons
 

--- a/content/kubeone/main/guides/addons/_index.en.md
+++ b/content/kubeone/main/guides/addons/_index.en.md
@@ -201,8 +201,8 @@ Some embedded addons can be configured via "well-known" parameters. They are doc
 All external CCMs support being configured via parameters (either passed as global parameter
 or passed as parameter on the respective CCM addon):
 
-| Parameter     | Description                     |
-| ------------- | ------------------------------- |
+| Parameter     | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
 | `CCM_CONCURRENT_SERVICE_SYNCS` | Sets the parallel `Service` (load balancer) reconciles in the CCM. If not set, this is "1". The value for this parameter is a number, but needs to be wrapped in quotes. |
 
 ## Reconciling Addons

--- a/content/kubeone/main/guides/addons/_index.en.md
+++ b/content/kubeone/main/guides/addons/_index.en.md
@@ -201,8 +201,8 @@ Some embedded addons can be configured via "well-known" parameters. They are doc
 All external CCMs support being configured via parameters (either passed as global parameter
 or passed as parameter on the respective CCM addon):
 
-| Parameter     | Description                                                      |
-| ------------- | ---------------------------------------------------------------- |
+| Parameter     | Description                                                             |
+| ------------- | ----------------------------------------------------------------------- |
 | `CCM_CONCURRENT_SERVICE_SYNCS` | Sets the parallel `Service` (load balancer) reconciles in the CCM. If not set, this is "1". The value for this parameter is a number, but needs to be wrapped in quotes. |
 
 ## Reconciling Addons

--- a/content/kubeone/main/guides/addons/_index.en.md
+++ b/content/kubeone/main/guides/addons/_index.en.md
@@ -192,6 +192,19 @@ addons:
       key2: value2
 ```
 
+### Well-known Parameters
+
+Some embedded addons can be configured via "well-known" parameters. They are documented below.
+
+#### External CCMs
+
+All external CCMs support being configured via parameters (either passed as global parameter
+or passed as parameter on the respective CCM addon):
+
+| Parameter     | Description                     |
+| ------------- | ------------------------------- |
+| `CCM_CONCURRENT_SERVICE_SYNCS` | Sets the parallel `Service` (load balancer) reconciles in the CCM. If not set, this is "1". The value for this parameter is a number, but needs to be wrapped in quotes. |
+
 ## Reconciling Addons
 
 The addons are reconciled after initializing and joining the control plane


### PR DESCRIPTION
This is the documentation companion PR to https://github.com/kubermatic/kubeone/pull/2916, documenting the newly added parameter that can be passed to the CCM addons to configure parallel reconciliation of `Service` objects.