### PR TITLE
Bump Hugo version on Netlify to v0.118.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-HUGO_VERSION = "0.75.1"
+HUGO_VERSION = "0.118.2"
 
 [context.production]
 command = "hugo --minify"


### PR DESCRIPTION
We keep running into problems with `hugo` running into a "concurrent map read/write" error. I _believe_ this is caused by hugo being on a really old version ([0.75.1](https://github.com/gohugoio/hugo/releases/tag/v0.75.1) is three years old!), so I would like to try with a new hugo version.

WDYT @serg? Is this a good idea? I'm not a Netlify expert.