### PR TITLE
Correct support matrix for KubeOne 1.6

### DIFF
--- a/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
@@ -23,7 +23,7 @@ according to the table below.
 | KubeOne version | 1.28  | 1.27  | 1.26  | 1.25  | 1.24[^1] |
 | --------------- | ----- | ----- | ----- | ----- | -------- |
 | v1.7            | -     | ✓     | ✓     | -     | -        |
-| v1.6            | -     | ✓     | ✓     | ✓     | ✓        |
+| v1.6            | -     | -     | ✓     | ✓     | ✓        |
 
 [^1]: Kubernetes 1.24 has reached End-of-Life (EOL) on 2023-07-28.
 We strongly recommend upgrading to a supported Kubernetes release as soon as possible.

--- a/content/kubeone/v1.7/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/v1.7/architecture/compatibility/supported-versions/_index.en.md
@@ -23,7 +23,7 @@ according to the table below.
 | KubeOne version | 1.28  | 1.27  | 1.26  | 1.25  | 1.24[^1] |
 | --------------- | ----- | ----- | ----- | ----- | -------- |
 | v1.7            | -     | ✓     | ✓     | -     | -        |
-| v1.6            | -     | ✓     | ✓     | ✓     | ✓        |
+| v1.6            | -     | -     | ✓     | ✓     | ✓        |
 
 [^1]: Kubernetes 1.24 has reached End-of-Life (EOL) on 2023-07-28.
 We strongly recommend upgrading to a supported Kubernetes release as soon as possible.


### PR DESCRIPTION
We were notified that the support matrix for KubeOne said that 1.6 supports Kubernetes 1.27. That's not the case and probably a copy-paste mistake in #1492.