### PR TITLE
Mark user cluster MLA as optional, not alpha

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -128,7 +128,7 @@ Once the User Cluster MLA stack is installed in all necessary seed clusters, it 
 
 ### Enabling MLA Feature in KKP Configuration
 
-Since the User Cluster MLA feature is in alpha stage, it has to be explicitly enabled via a feature gate in the `KubermaticConfiguration`, e.g.:
+Since the User Cluster MLA feature is optional and might be subject to change in the future, it has to be explicitly enabled via a feature gate in the `KubermaticConfiguration`, e.g.:
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1

--- a/content/kubermatic/v2.23/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -128,7 +128,7 @@ Once the User Cluster MLA stack is installed in all necessary seed clusters, it 
 
 ### Enabling MLA Feature in KKP Configuration
 
-Since the User Cluster MLA feature is in alpha stage, it has to be explicitly enabled via a feature gate in the `KubermaticConfiguration`, e.g.:
+Since the User Cluster MLA feature is optional and might be subject to change in the future, it has to be explicitly enabled via a feature gate in the `KubermaticConfiguration`, e.g.:
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1


### PR DESCRIPTION
The user cluster MLA stack has been around for a while. We probably should mark it as optional, not alpha.