### PR TITLE
Update Kubernetes support matrix for 2.24

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -45,7 +45,7 @@ marked as supported, for example KKP 2.19 supports updating clusters from Kubern
 ## Provider Incompatibilities
 
 KKP has some incompatibilities with cloud providers, e.g. because their in-tree cloud provider
-implementation has been removed from upstream Kubernetes. For KKP 2.23.x, the following incompatibilities
+implementation has been removed from upstream Kubernetes. For KKP 2.24.x, the following incompatibilities
 apply:
 
 | Condition                          | Incompatible with Kubernetes | Notes                                                                                             |

--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -15,10 +15,7 @@ As time passes, patch versions of KKP will support new patch versions of Kuberne
 that have been released since, as well as drop old patch versions if they are
 affected by critical bugs.
 
-KKP will typically drop support of minor versions of Kubernetes which have gone EOL,
-even during the lifecycle of a KKP minor version (e.g. from 2.16.1 to 2.16.2).
-This of course results in any minor version of KKP being eventually limited to two
-and later one minor version of Kubernetes.
+KKP will typically drop support of minor versions of Kubernetes which have gone EOL.
 
 One notable exception is when upgrading from an older version of Kubernetes might
 require extensive migration of loads running within the updated clusters (e.g. API
@@ -31,14 +28,13 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version          | 1.27 | 1.26 | 1.25 | 1.24[^2] | 1.23[^2]| 1.22[^2] |
-| -------------------  | ---- | ---- | ---- | -------- | ------- | -------- |
-| 2.24.x               | ✓    | ✓    | ✓    | --      | --      | --       |
-| 2.23.x               | ✓    | ✓    | ✓    | ✓       | --      | --       |
-| 2.22.x               | --   | ✓    | ✓    | ✓       | --      | --       |
-| 2.21.x               | --   | --   | --   | ✓       | ✓       | ✓        |
+| KKP version          | 1.28 | 1.27 | 1.26 | 1.25[^2] | 1.24[^2] |
+| -------------------  | ---- | ---- | ---- | -------- | -------- |
+| 2.24.x               | ✓    | ✓    | ✓    | --       | --       |
+| 2.23.x               | --   | ✓    | ✓    | ✓        | ✓        |
+| 2.22.x               | --   | --   | ✓    | ✓        | ✓        |
 
-[^2]: Kubernetes releases below version 1.25 have reached End-of-Life (EOL). We strongly
+[^2]: Kubernetes releases below version 1.26 have reached End-of-Life (EOL). We strongly
 recommend upgrading to a supported Kubernetes release as soon as possible. Refer to the
 [Kubernetes website](https://kubernetes.io/releases/) for more information on the supported
 releases.


### PR DESCRIPTION
We are removing 1.25 support in KKP 2.24 and haven't updated the support matrix in a while (missing 1.28 support, for example).

I'm also removing the note that we are dropping Kubernetes minor releases that went EOL in KKP patch releases. This has not been a policy of sig-release for a while, so let's remove it from public communication.