### PR TITLE
Add `kind: ConfigMap` in snippet for custom CA configuration

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -170,6 +170,7 @@ spec:
   # This configures the global default CA bundle, which is used on the
   # master cluster and on all seeds, userclusters.
   caBundle:
+    kind: ConfigMap
     # name of the ConfigMap;
     # must be in the same namespace as KKP
     name: ca-bundle

--- a/content/kubermatic/v2.22/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -170,6 +170,7 @@ spec:
   # This configures the global default CA bundle, which is used on the
   # master cluster and on all seeds, userclusters.
   caBundle:
+    kind: ConfigMap
     # name of the ConfigMap;
     # must be in the same namespace as KKP
     name: ca-bundle

--- a/content/kubermatic/v2.23/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -170,6 +170,7 @@ spec:
   # This configures the global default CA bundle, which is used on the
   # master cluster and on all seeds, userclusters.
   caBundle:
+    kind: ConfigMap
     # name of the ConfigMap;
     # must be in the same namespace as KKP
     name: ca-bundle


### PR DESCRIPTION
When configuring a custom CA bundle, you need to set `kind: ConfigMap` in `spec.caBundle`. Otherwise, KKP complains about the missing kind.