### PR TITLE
Update 2.22 documentation to disable cert-manager integration

### DIFF
--- a/content/kubermatic/v2.22/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -53,6 +53,7 @@ For KKP, update the `KubermaticConfiguration` and configure `spec.ingress.certif
 spec:
   ingress:
     certificateIssuer:
+      kind: ClusterIssuer # or Issuer, depending on your scenario.
       name: my-own-ca-issuer
 ```
 
@@ -65,10 +66,12 @@ the new issuer:
 ```yaml
 dex:
   certIssuer:
+    kind: ClusterIssuer # or Issuer, depending on your scenario.
     name: my-own-ca-issuer
 
 iap:
   certIssuer:
+    kind: ClusterIssuer # or Issuer, depending on your scenario.
     name: my-own-ca-issuer
 ```
 
@@ -183,14 +186,13 @@ The KKP Operator manages a single Ingress for the KKP API/dashboard. This by def
 the required annotations and spec settings for usage with cert-manager. However, if the cert-manager
 integration is disabled, the cluster admin is free to manage these settings themselves.
 
-To disable the cert-manager integration, set the `spec.ingress.certificateIssuer.name` to an empty string
+To disable cert-manager integration, set `spec.ingress.certificateIssuer` as empty
 in the `KubermaticConfiguration`:
 
 ```yaml
 spec:
   ingress:
-    certificateIssuer:
-      name: ""
+    certificateIssuer: {}
 ```
 
 It is now possible to set `spec.tls` on the `kubermatic` Ingress to a custom certificate:


### PR DESCRIPTION
Follow-up to #1536, also updating the respective documentation in 2.22.