### PR TITLE
bump Hugo to 0.119.0

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -21,7 +21,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/docs.git"
     spec:
       containers:
-      - image: quay.io/kubermatic/hugo:0.75.1-0
+      - image: quay.io/kubermatic/hugo:0.119.0-0
         command:
         - "./hack/ci/verify-hugo.sh"
         resources:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -26,9 +26,7 @@ presubmits:
         - "./hack/ci/verify-hugo.sh"
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
+            cpu: 250m
             memory: 512Mi
 
   - name: pre-docs-verify-remark-lint

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ preview:
 		--name kubermatic-docs \
 		-p 1313:1313 \
 		-w /docs \
-		-v `pwd`:/docs quay.io/kubermatic/hugo:0.75.1-0 \
+		-v `pwd`:/docs quay.io/kubermatic/hugo:0.119.0-0 \
 		hugo server -D -F --bind 0.0.0.0
 
 .PHONY: runbook

--- a/README.md
+++ b/README.md
@@ -33,17 +33,13 @@ Feedback and discussion are available on [the mailing list][11].
 
 * Please familiarize yourself with the [Code of Conduct][4] before contributing.
 * See [CONTRIBUTING.md][2] for instructions on the developer certificate of origin that we require.
-* Read how [we're using ZenHub][13] for project and roadmap planning
 
 ### Pull requests
 
 * We welcome pull requests. Feel free to dig through the [issues][1] and jump in.
-
-
 
 [1]: https://github.com/kubermatic/docs/issues
 [2]: https://github.com/kubermatic/docs/blob/master/CONTRIBUTING.md
 [4]: https://github.com/kubermatic/docs/blob/master/CODE_OF_CONDUCT.md
 
 [11]: https://groups.google.com/forum/#!forum/kubermatic-dev
-[13]: https://github.com/kubermatic/docs/blob/master/docs/zenhub.md

--- a/hack/ci/verify-hugo.sh
+++ b/hack/ci/verify-hugo.sh
@@ -12,7 +12,7 @@ trap "cleanup" EXIT SIGINT
 cleanup
 
 echo "Checking if the site can be built with Hugo..."
-hugo --logFile hugo.log
+hugo | tee hugo.log
 
 if grep -q "WARN" hugo.log; then
   echo "Warnings occurred."

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-HUGO_VERSION = "0.118.2"
+HUGO_VERSION = "0.119.0"
 
 [context.production]
 command = "hugo --minify"


### PR DESCRIPTION
I released a new kubermatic/hugo image and now we can have a consistent version everywhere (0.119.0). Maybe this will also finally fix the concurrent map access panic that sometimes happens.