### PR TITLE
Update documentation to disable cert-manager integration

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -187,12 +187,12 @@ the required annotations and spec settings for usage with cert-manager. However,
 integration is disabled, the cluster admin is free to manage these settings themselves.
 
 To disable cert-manager integration, set `spec.ingress.certificateIssuer` as empty
-in the `KubermaticConfiguration`:
+in the `KubermaticConfiguration` or omit setting the field entirely:
 
 ```yaml
 spec:
   ingress:
-    certificateIssuer: {}
+    certificateIssuer: null
 ```
 
 It is now possible to set `spec.tls` on the `kubermatic` Ingress to a custom certificate:

--- a/content/kubermatic/v2.22/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -75,7 +75,7 @@ iap:
     name: my-own-ca-issuer
 ```
 
-Re-deploy the `iap` Helm chart to perform the changes and update the Certificate resources.
+Re-deploy the `iap` Helm chart to perform the changes and update the `Certificate` resources.
 
 ### External
 
@@ -187,12 +187,12 @@ the required annotations and spec settings for usage with cert-manager. However,
 integration is disabled, the cluster admin is free to manage these settings themselves.
 
 To disable cert-manager integration, set `spec.ingress.certificateIssuer` as empty
-in the `KubermaticConfiguration`:
+in the `KubermaticConfiguration` or omit setting the field entirely:
 
 ```yaml
 spec:
   ingress:
-    certificateIssuer: {}
+    certificateIssuer: null
 ```
 
 It is now possible to set `spec.tls` on the `kubermatic` Ingress to a custom certificate:

--- a/content/kubermatic/v2.23/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/KKP-configuration/custom-certificates/_index.en.md
@@ -187,12 +187,12 @@ the required annotations and spec settings for usage with cert-manager. However,
 integration is disabled, the cluster admin is free to manage these settings themselves.
 
 To disable cert-manager integration, set `spec.ingress.certificateIssuer` as empty
-in the `KubermaticConfiguration`:
+in the `KubermaticConfiguration` or omit setting the field entirely:
 
 ```yaml
 spec:
   ingress:
-    certificateIssuer: {}
+    certificateIssuer: null
 ```
 
 It is now possible to set `spec.tls` on the `kubermatic` Ingress to a custom certificate:


### PR DESCRIPTION
followup to htps://github.com/kubermatic/docs/pull/1536, I made an error when validating the instructions for v2.23.x, this is now operational and confirmed by the user https://github.com/kubermatic/kubermatic/issues/12674#issuecomment-1780088061.