### PR TITLE
fix AWS Permissions for KKP > 1.22

### DIFF
--- a/content/kubermatic/main/architecture/supported-providers/aws/_index.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/aws/_index.en.md
@@ -60,6 +60,7 @@ Ensure that the assigned policy contains at least the following permissions. Pol
             "Effect": "Allow",
             "Action": [
                 "ec2:*",
+                "iam:TagInstanceProfile",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateRule",
                 "elasticloadbalancing:CreateTargetGroup",

--- a/content/kubermatic/v2.23/architecture/supported-providers/aws/aws.en.md
+++ b/content/kubermatic/v2.23/architecture/supported-providers/aws/aws.en.md
@@ -61,6 +61,7 @@ Ensure that the assigned policy contains at least the following permissions. Pol
             "Effect": "Allow",
             "Action": [
                 "ec2:*",
+                "iam:TagInstanceProfile",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateRule",
                 "elasticloadbalancing:CreateTargetGroup",


### PR DESCRIPTION
Based on the used role at our demo environment, the documented AWS role was missing the  permission `TagInstanceProfile`. 
