### PR TITLE
Update KubeOne compatibility matrix after adding 1.28 support

### DIFF
--- a/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
@@ -20,16 +20,16 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.28  | 1.27  | 1.26  | 1.25  | 1.24[^1] |
-| --------------- | ----- | ----- | ----- | ----- | -------- |
-| v1.7            | -     | ✓     | ✓     | -     | -        |
-| v1.6            | -     | -     | ✓     | ✓     | ✓        |
+| KubeOne version | 1.28  | 1.27  | 1.26  | 1.25[^1] |
+| --------------- | ----- | ----- | ----- | -------- |
+| v1.8            | ✓     | ✓     | ✓     | ✓        |
+| v1.7            | -     | ✓     | ✓     | ✓        |
 
-[^1]: Kubernetes 1.24 has reached End-of-Life (EOL) on 2023-07-28.
+[^1]: Kubernetes 1.25 has reached End-of-Life (EOL) on 2023-10-28.
 We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
-than the latest Kubernetes release. For example, with 1.27 being the latest
-release, we recommend running at least Kubernetes 1.26.
+than the latest Kubernetes release. For example, with 1.28 being the latest
+release, we recommend running at least Kubernetes 1.27.
 
 [upstream-supported-versions]: https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions

--- a/content/kubeone/v1.7/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/v1.7/architecture/compatibility/supported-versions/_index.en.md
@@ -20,13 +20,14 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.28  | 1.27  | 1.26  | 1.25  | 1.24[^1] |
-| --------------- | ----- | ----- | ----- | ----- | -------- |
-| v1.7            | -     | ✓     | ✓     | -     | -        |
-| v1.6            | -     | -     | ✓     | ✓     | ✓        |
+| KubeOne version | 1.28  | 1.27  | 1.26  | 1.25[^1] | 1.24[^1] |
+| --------------- | ----- | ----- | ----- | -------- | -------- |
+| v1.7            | -     | ✓     | ✓     | ✓        | -        |
+| v1.6            | -     | -     | ✓     | ✓        | ✓        |
 
-[^1]: Kubernetes 1.24 has reached End-of-Life (EOL) on 2023-07-28.
-We strongly recommend upgrading to a supported Kubernetes release as soon as possible.
+[^1]: Kubernetes 1.25 and 1.24 have reached End-of-Life (EOL) on 2023-10-28 and
+2023-07-28, respectively, We strongly recommend upgrading to a supported
+Kubernetes release as soon as possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
 than the latest Kubernetes release. For example, with 1.27 being the latest


### PR DESCRIPTION
- Add Kubernetes 1.28 as a supported version for KubeOne 1.8
- Add Kubernetes 1.25 as a supported version for KubeOne 1.7. For some reason, 1.25 was marked as unsupported, which is not correct (reference: https://github.com/kubermatic/kubeone/blob/v1.7.0/pkg/apis/kubeone/validation/validation.go#L42)

/assign @kron4eg @ahmedwaleedmalik 