### PR TITLE
Sort components list alphabetically

### DIFF
--- a/content/kubermatic/v2.24/architecture/compatibility/KKP-components-versioning/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/compatibility/KKP-components-versioning/_index.en.md
@@ -10,33 +10,33 @@ weight = 2
 The following list is only applicable for the KKP version that is currently available. Kubermatic has a strong emphasis on security and reliability
 of provided software and therefore releases updates regularly that also include component updates.
 
-| KKP Component                  | Version                        |
-| ---                            | ---                            |
-| iap                            | 7.4.0                          |
-| minio                          | RELEASE.2023-05-04T21-44-30Z   |
-| monitoring/prometheus          | 2.43.1                         |
-| monitoring/helm-exporter       | 1.2.5                          |
-| monitoring/node-exporter       | 1.5.0                          |
-| monitoring/alertmanager        | 0.25.0                         |
-| monitoring/karma               | 0.114                          |
-| monitoring/kube-state-metrics  | 2.8.2                          |
-| monitoring/grafana             | 9.5.1                          |
-| monitoring/blackbox-exporter   | 0.23.0                         |
-| local-kubevirt                 | 1.0.0                          |
-| kubermatic-operator            | 9.9.9-dev                      |
-| cert-manager                   | 1.12.2                         |
-| oauth                          | 2.36.0                         |
+| KKP Components                 | Version                        |
+| ------------------------------ | ------------------------------ |
 | backup/velero                  | 1.10.1                         |
-| s3-exporter                    | 0.6                            |
-| mla/loki-distributed           | 2.6.1                          |
-| mla/mla-secrets                | 0.1.0                          |
-| mla/minio                      | RELEASE.2022-09-17T00-09-45Z   |
-| mla/consul                     | 1.14.2                         |
-| mla/minio-lifecycle-mgr        | 0.1.0                          |
+| cert-manager                   | 1.12.2                         |
+| iap                            | 7.4.0                          |
+| kubermatic-operator            | 9.9.9-dev                      |
+| local-kubevirt                 | 1.0.0                          |
+| logging/loki                   | 2.5.0                          |
+| logging/promtail               | 2.5.0                          |
+| minio                          | RELEASE.2023-05-04T21-44-30Z   |
 | mla/alertmanager-proxy         | 0.2.1                          |
+| mla/consul                     | 1.14.2                         |
 | mla/cortex                     | 1.13.1                         |
 | mla/grafana                    | 9.3.1                          |
-| telemetry                      | 0.4.1                          |
+| mla/loki-distributed           | 2.6.1                          |
+| mla/minio-lifecycle-mgr        | 0.1.0                          |
+| mla/minio                      | RELEASE.2022-09-17T00-09-45Z   |
+| mla/mla-secrets                | 0.1.0                          |
+| monitoring/alertmanager        | 0.25.0                         |
+| monitoring/blackbox-exporter   | 0.23.0                         |
+| monitoring/grafana             | 9.5.1                          |
+| monitoring/helm-exporter       | 1.2.5                          |
+| monitoring/karma               | 0.114                          |
+| monitoring/kube-state-metrics  | 2.8.2                          |
+| monitoring/node-exporter       | 1.5.0                          |
+| monitoring/prometheus          | 2.43.1                         |
 | nginx-ingress-controller       | 1.9.3                          |
-| logging/promtail               | 2.5.0                          |
-| logging/loki                   | 2.5.0                          |
+| oauth                          | 2.36.0                         |
+| s3-exporter                    | 0.6                            |
+| telemetry                      | 0.4.1                          |


### PR DESCRIPTION
The components list generated by the `hack/prepare-docs.sh` script is not sorted, which it is for previous (e.g. the 2.23 component list) ones.