### PR TITLE
Set max-height on KubeLB logo

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,13 +6,13 @@ description = "Learn more about KKP, KubeOne and KubeCarrier through the officia
 title = "How Do I Contribute To ...?"
 
   [[contribution.links]]
-  url = "https://docs.kubermatic.com/kubeone/v1.6/tutorials/how-to-contribute-to-kubeone/"
+  url = "https://docs.kubermatic.com/kubeone/v1.7/tutorials/how-to-contribute-to-kubeone/"
   [contribution.links.image]
   src = "/img/KubeOne-logo.svg"
   alt = ""
 
   [[contribution.links]]
-  url = "https://docs.kubermatic.com/kubermatic/v2.22/how-to-contribute-to-kkp/"
+  url = "https://docs.kubermatic.com/kubermatic/v2.24/how-to-contribute-to-kkp/"
   [contribution.links.image]
   src = "/img/KubermaticKubernetesPlatform-logo.svg"
   alt = ""

--- a/content/kubelb/_index.en.md
+++ b/content/kubelb/_index.en.md
@@ -5,7 +5,7 @@ weight = 6
 description = "Learn how you can use Kubermatic KubeLB to centrally provision and manage load balancers across multiple cloud and on-premise environments."
 +++
 
-![KubeLB logo](/img/kubelb/common/logo.png?classes=height=50)
+![KubeLB logo](/img/kubelb/common/logo.png?classes=logo-height)
 
 ## What is KubeLB?
 

--- a/themes/kubermatic-docs/assets/scss/_helpers.scss
+++ b/themes/kubermatic-docs/assets/scss/_helpers.scss
@@ -1,0 +1,3 @@
+.logo-height {
+    max-height: 100px;
+}

--- a/themes/kubermatic-docs/assets/scss/app.scss
+++ b/themes/kubermatic-docs/assets/scss/app.scss
@@ -10,3 +10,4 @@
 @import "home";
 @import "theme-kubermatic";
 @import "tabs";
+@import "helpers";


### PR DESCRIPTION
The KubeLB logo is a bit ... large on bigger screen. This adds a max-height helper class so it doesn't grow past a certain point, much more in line with logos on the other landing pages.

![Screenshot 2023-11-08 at 14 26 05](https://github.com/kubermatic/docs/assets/10295525/86c3a301-872e-4de5-ab50-fd4f53e580c9)
