### PR TITLE
Add KKP 2.24 Release Notes

### DIFF
--- a/content/kubermatic/main/release-notes/_index.en.md
+++ b/content/kubermatic/main/release-notes/_index.en.md
@@ -1,0 +1,11 @@
++++
+title = "Release Notes"
+date = 2023-11-14T15:00:00+01:00
+weight = 70
++++
+
+- [v2.XX.0](#v2XX0)
+
+## [v2.XX.0](https://github.com/kubermatic/kubermatic/releases/tag/v2.XX.0)
+
+Before upgrading, make sure to read the [general upgrade guidelines](https://docs.kubermatic.com/kubermatic/v2.XX/installation/upgrading/). Consider tweaking `seedControllerManager.maximumParallelReconciles` to ensure user cluster reconciliations will not cause resource exhaustion on seed clusters. A [full upgrade guide is available from the official documentation](https://docs.kubermatic.com/kubermatic/v2.XX/installation/upgrading/upgrade-from-2.WW-to-2.XX/).

--- a/content/kubermatic/v2.21/release-notes/_index.en.md
+++ b/content/kubermatic/v2.21/release-notes/_index.en.md
@@ -19,6 +19,15 @@ weight = 70
 - [v2.21.12](#v22112)
 - [v2.21.13](#v22113)
 - [v2.21.14](#v22113)
+- [v2.21.15](#v22115)
+
+## [v2.21.15](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.15)
+
+With this release, support for KKP v2.21.x ceases. Please upgrade to a supported version of KKP in the near future.
+
+### Bugfixes
+
+- Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12794](https://github.com/kubermatic/kubermatic/pull/12794))
 
 ## [v2.21.14](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.14)
 
@@ -263,7 +272,7 @@ This release includes updated Kubernetes versions that fix CVE-2022-3162 and CVE
 - Update metering to version 1.0.1 ([#11293](https://github.com/kubermatic/kubermatic/pull/11293))
     * Add average-used-cpu-millicores to Cluster and Namespace reports
     * Add average-available-cpu-millicores add average-cluster-machines field to Cluster reports
-    * Fix a bug that causes wrong values if metric is not continuously present for the aggregation window 
+    * Fix a bug that causes wrong values if metric is not continuously present for the aggregation window
 
 ### Upcoming Changes
 

--- a/content/kubermatic/v2.21/release-notes/_index.en.md
+++ b/content/kubermatic/v2.21/release-notes/_index.en.md
@@ -23,7 +23,7 @@ weight = 70
 
 ## [v2.21.15](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.15)
 
-With this release, support for KKP v2.21.x ceases. Please upgrade to a supported version of KKP in the near future.
+With this release, support for KKP v2.21.x [ceases](https://youtu.be/vZw35VUBdzo?t=169). Please upgrade to a supported version of KKP in the near future.
 
 ### Bugfixes
 

--- a/content/kubermatic/v2.22/release-notes/_index.en.md
+++ b/content/kubermatic/v2.22/release-notes/_index.en.md
@@ -14,6 +14,20 @@ weight = 70
 - [v2.22.7](#v2227)
 - [v2.22.8](#v2228)
 - [v2.22.9](#v2228)
+- [v2.22.10](#v22210)
+
+## [v2.22.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.10)
+
+### Action Required
+
+- **ACTION REQUIRED (EE ONLY):** Update metering component to v1.0.5, fixing highly inaccurate data in cluster reports. Reports generated in KKP v2.23.2+ or v2.22.5+ do not represent actual consumption. Ad-hoc reports for time frames that need correct consumption data can be generated [by following our documentation](https://docs.kubermatic.com/kubermatic/v2.23/tutorials-howtos/metering/#custom-reports) ([#12824](https://github.com/kubermatic/kubermatic/pull/12824))
+
+### Bugfixes
+
+- Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12793](https://github.com/kubermatic/kubermatic/pull/12793))
+- Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12817](https://github.com/kubermatic/kubermatic/pull/12817))
+- Fix empty panels in Grafana dashboard "Resource Usage per Namespace" for Master/Seed MLA ([#12833](https://github.com/kubermatic/kubermatic/pull/12833))
+- Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error ([#12806](https://github.com/kubermatic/kubermatic/pull/12806))
 
 ## [v2.22.9](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.9)
 
@@ -296,7 +310,7 @@ KubeVirt cloud provider support is leaving the "technical preview" phase and is 
 - Add new field  `ReconciliationInterval` in `ApplicationInstallation` to force reconciliation, even if the `ApplicationInstallation` CR has not changed ([#11467](https://github.com/kubermatic/kubermatic/pull/11467))
 - Extend `ApplicationDefinition` and `ApplicationInstallation` CRD with `DeployOptions.HelmDeployOptions` to control how applications are deployed with `Helm`([#11608](https://github.com/kubermatic/kubermatic/pull/11608))
     - ApplicationInstallation: set condition ready to `unknown` with reason `InstallationInProgress` before starting the installation
-    - ApplicationInstallation: don't try to install / upgrade the application if the max number of retries is exceeded 
+    - ApplicationInstallation: don't try to install / upgrade the application if the max number of retries is exceeded
 - Use string Version type for `ApplicationInstallation` CRD ([#11359](https://github.com/kubermatic/kubermatic/pull/11359))
 - Make uninstall for Applications idempotent ([#11622](https://github.com/kubermatic/kubermatic/pull/11622))
 - Add validating and defaulting webhook for Application deployOptions ([#11633](https://github.com/kubermatic/kubermatic/pull/11633))
@@ -548,7 +562,7 @@ Konnectivity is now GA.
 - Update metering to version 1.0.1 ([#11282](https://github.com/kubermatic/kubermatic/pull/11282))
     - Add average-used-cpu-millicores to Cluster and Namespace reports
     - Add average-available-cpu-millicores add average-cluster-machines field to Cluster reports
-    - Fix a bug that causes wrong values if metric is not continuously present for the aggregation window 
+    - Fix a bug that causes wrong values if metric is not continuously present for the aggregation window
 
 ### Miscellaneous
 
@@ -584,7 +598,7 @@ Konnectivity is now GA.
 - Add API endpoints for KubeVirt that allow using project-scoped Presets as credentials ([#5509](https://github.com/kubermatic/dashboard/pull/5509))
 - Add API endpoints for Nutanix that allow using project-scoped Presets as credentials ([#5154](https://github.com/kubermatic/dashboard/pull/5154))
 - Add API endpoints for OpenStack that allow using project-scoped Presets as credentials ([#5489](https://github.com/kubermatic/dashboard/pull/5489))
-    - ACTION REQUIRED: Headers for API operations `listOpenstackServerGroups` and `listOpenstackSubnetPools` have been renamed from `Tenant`, `TenantID`, `Project`, `ProjectID` to `OpenstackTenant`, `OpenstackTenantID`, `OpenstackProject` and `OpenstackProjectID`, respectively 
+    - ACTION REQUIRED: Headers for API operations `listOpenstackServerGroups` and `listOpenstackSubnetPools` have been renamed from `Tenant`, `TenantID`, `Project`, `ProjectID` to `OpenstackTenant`, `OpenstackTenantID`, `OpenstackProject` and `OpenstackProjectID`, respectively
 - Add API endpoints for VMware Cloud Director that allow using project-scoped Presets as credentials ([#5512](https://github.com/kubermatic/dashboard/pull/5512))
 - Add API endpoints for vSphere that allow using project-scoped Presets as credentials ([#5508](https://github.com/kubermatic/dashboard/pull/5508))
 - Add API endpoints for GKE that allow using project-scoped Presets as credentials ([#11156](https://github.com/kubermatic/kubermatic/pull/11156))

--- a/content/kubermatic/v2.23/release-notes/_index.en.md
+++ b/content/kubermatic/v2.23/release-notes/_index.en.md
@@ -10,6 +10,20 @@ weight = 70
 - [v2.23.3](#v2233)
 - [v2.23.5](#v2235)
 - [v2.23.6](#v2236)
+- [v2.23.7](#v2237)
+
+## [v2.23.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.7)
+
+### Action Required
+
+- **ACTION REQUIRED (EE ONLY):** Update metering component to v1.0.5, fixing highly inaccurate data in cluster reports. Reports generated in KKP v2.23.2+ or v2.22.5+ do not represent actual consumption. Ad-hoc reports for time frames that need correct consumption data can be generated [by following our documentation](https://docs.kubermatic.com/kubermatic/v2.23/tutorials-howtos/metering/#custom-reports) ([#12823](https://github.com/kubermatic/kubermatic/pull/12823))
+
+### Bugfixes
+
+- Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12792](https://github.com/kubermatic/kubermatic/pull/12792))
+- Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12814](https://github.com/kubermatic/kubermatic/pull/12814))
+- Fix empty panels in Grafana dashboard "Resource Usage per Namespace" for Master/Seed MLA ([#12816](https://github.com/kubermatic/kubermatic/pull/12816))
+- Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error ([#12806](https://github.com/kubermatic/kubermatic/pull/12806))
 
 ## [v2.23.6](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.6)
 
@@ -120,9 +134,9 @@ Before upgrading, make sure to read the [general upgrade guidelines](https://doc
 ### Breaking Changes
 
 - Move to Egress based cluster isolation network policies for KubeVirt ([#12329](https://github.com/kubermatic/kubermatic/pull/12329))
-  - **ACTION REQUIRED:** Custom Network policies for KubeVirt datacenters might need adjustment 
+  - **ACTION REQUIRED:** Custom Network policies for KubeVirt datacenters might need adjustment
 - The `kubermatic-installer` now recognizes CSIDrivers automatically and will use them when creating the `kubermatic-fast` StorageClass. Admins can still choose to simply copy the default StorageClass if it's heavily customized by continuing to specify `--storageclass copy-default` ([#12012](https://github.com/kubermatic/kubermatic/pull/12012))
-  - **ACTION REQUIRED:** The flag value `gce` was renamed to `gcp` for `--storageclass` 
+  - **ACTION REQUIRED:** The flag value `gce` was renamed to `gcp` for `--storageclass`
 - Introduce `EnableShareCluster` flag in `KubermaticSettings` to toggle the share cluster feature for the dashboard ([#11950](https://github.com/kubermatic/kubermatic/pull/11950))
   - **ACTION REQUIRED:** `share_kubeconfig` field in the UI configuration for KubermaticConfiguration has been replaced with `EnableShareCluster` flag in KubermaticSettings. `share_kubeconfig` is no-op and will be ignored by the dashboard
 
@@ -134,7 +148,7 @@ Before upgrading, make sure to read the [general upgrade guidelines](https://doc
 
 - Add short name for  Application  CRDs ([#12017](https://github.com/kubermatic/kubermatic/pull/12017))
     - `applicationdefinition` -> `appdef`, e.g `kubectl get appdef`
-    - `applicationinstallation` -> `appinstall`, e.g `kubectl get appinstall` 
+    - `applicationinstallation` -> `appinstall`, e.g `kubectl get appinstall`
 - Support added to specify the suffix `dockerTagSuffix` in `KubermaticConfiguration` for dashboard images. With `dockerTagSuffix` the tag becomes <CURRENT_KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX" ([#12056](https://github.com/kubermatic/kubermatic/pull/12056))
 - Add support for disabling Changelog popup in `KubermaticSettings` ([#12175](https://github.com/kubermatic/kubermatic/pull/12175))
 - Add support for enforcing/enabling auto-updates and updates on first boot for Machine Deployments in `KubermaticSettings` ([#12152](https://github.com/kubermatic/kubermatic/pull/12152))
@@ -261,7 +275,7 @@ Before upgrading, make sure to read the [general upgrade guidelines](https://doc
 - Add support for ca-bundle to metering cronjobs ([#11979](https://github.com/kubermatic/kubermatic/pull/11979))
 - Update Metering to v1.0.3 ([#12035](https://github.com/kubermatic/kubermatic/pull/12035))
     - Add non machine-controller managed machines to `average-cluster-machines`. Note that this is based on a new metric that will be collected together in the same release, therefore information prior this update is not available
-    - Fixes a bug that leads to low CPU usage values* Remove redundant label quotation 
+    - Fixes a bug that leads to low CPU usage values* Remove redundant label quotation
 - Fix metering CronJobs after KKP upgrades ([#12139](https://github.com/kubermatic/kubermatic/pull/12139))
 - Fix a bug that lead to metering reports overwriting each other when used with multiple seeds. Report names now include the Seed name as a Prefix ([#12221](https://github.com/kubermatic/kubermatic/pull/12221))
 
@@ -348,7 +362,7 @@ Before upgrading, make sure to read the [general upgrade guidelines](https://doc
 #### Bugfixes
 
 - UI/UX improvements for vSphere credentials in provider settings step ([#5959](https://github.com/kubermatic/dashboard/pull/5959))
-    - By default, username/password will be configured and dedicated credentials will be used to configure infra management user for vSphere 
+    - By default, username/password will be configured and dedicated credentials will be used to configure infra management user for vSphere
 - Add cache busting mechanism for theme styles ([#5943](https://github.com/kubermatic/dashboard/pull/5943))
 - Allow removing cluster label when PodNodeSelector admission plugin and clusterDefaultNodeSelector namespace are set ([#5981](https://github.com/kubermatic/dashboard/pull/5981))
 - Allow updating of the `clusterNetwork.proxyMode` via the KKP API (PATCH endpoint) ([#5803](https://github.com/kubermatic/dashboard/pull/5803))

--- a/content/kubermatic/v2.24/release-notes/_index.en.md
+++ b/content/kubermatic/v2.24/release-notes/_index.en.md
@@ -1,0 +1,229 @@
++++
+title = "Release Notes"
+date = 2023-11-14T15:00:00+01:00
+weight = 70
++++
+
+- [v2.24.0](#v2240)
+
+## [v2.24.0](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.0)
+
+Before upgrading, make sure to read the [general upgrade guidelines](https://docs.kubermatic.com/kubermatic/v2.24/installation/upgrading/). Consider tweaking `seedControllerManager.maximumParallelReconciles` to ensure user cluster reconciliations will not cause resource exhaustion on seed clusters. A [full upgrade guide is available from the official documentation](https://docs.kubermatic.com/kubermatic/v2.24/installation/upgrading/upgrade-from-2.23-to-2.24/).
+
+### Read Before Upgrading
+
+- **ACTION REQUIRED:** legacy backup controller has been removed. Before upgrading, please change to the backup and restore feature that uses [backup destinations](https://docs.kubermatic.com/kubermatic/v2.24/tutorials-howtos/etcd-backups/) if the legacy controller is still in use ([#12473](https://github.com/kubermatic/kubermatic/pull/12473))
+- `s3-storeuploader` has been removed ([#12473](https://github.com/kubermatic/kubermatic/pull/12473))
+- OpenVPN for control plane to node connectivity has been deprecated. It will be removed in future releases of KKP. Upgrading all user cluster to Konnectivity is strongly recommended ([#12691](https://github.com/kubermatic/kubermatic/pull/12691))
+- User clusters require upgrading to Kubernetes 1.26 prior to upgrading to KKP 2.24 ([#12740](https://github.com/kubermatic/kubermatic/pull/12740))
+
+### Action Required
+
+- **ACTION REQUIRED (EE ONLY):** Update metering component to v1.1.1, fixing highly inaccurate data in cluster reports. Reports generated in KKP v2.23.2+ or v2.22.5+ do not represent actual consumption. Ad-hoc reports for time frames that need correct consumption data can be generated [by following our documentation](https://docs.kubermatic.com/kubermatic/v2.24/tutorials-howtos/metering/#custom-reports) ([#12822](https://github.com/kubermatic/kubermatic/pull/12822))
+
+### API Changes
+
+- The field `vmNetName` in `Cluster` and `Preset` resources for vSphere clusters is deprecated and `networks` should be used instead ([#12444](https://github.com/kubermatic/kubermatic/pull/12444))
+- The field `konnectivityEnabled` in `Cluster` resources is deprecated. Clusters should set this to `true` to migrate off OpenVPN as Konnectivity being enabled will be assumed in future KKP releases ([#12691](https://github.com/kubermatic/kubermatic/pull/12691))
+- Set Cilium as default CNI for user clusters ([#12752](https://github.com/kubermatic/kubermatic/pull/12752))
+
+### Supported Kubernetes Versions
+
+- Add support for Kubernetes 1.28 ([#12593](https://github.com/kubermatic/kubermatic/pull/12593))
+- Add support for Kubernetes 1.26.9, 1.27.6 and 1.28.2 ([#12638](https://github.com/kubermatic/kubermatic/pull/12638))
+- Set default Kubernetes version to 1.27.6 ([#12638](https://github.com/kubermatic/kubermatic/pull/12638))
+- Remove support for Kubernetes 1.24 ([#12570](https://github.com/kubermatic/kubermatic/pull/12570))
+- Remove support for Kubernetes 1.25 ([#12740](https://github.com/kubermatic/kubermatic/pull/12740))
+
+#### Supported Versions
+
+- v1.26.1
+- v1.26.4
+- v1.26.6
+- v1.26.9
+- v1.27.3
+- v1.27.6 (default)
+- v1.28.2
+
+### KubeLB (Enterprise Edition only)
+
+This release adds support for [KubeLB](https://docs.kubermatic.com/kubelb/), a cloud native multi-tenant load balancing solution by Kubermatic.
+
+- Add KubeLB integration with KKP; introduce KubeLB as a first-class citizen in KKP ([#12667](https://github.com/kubermatic/kubermatic/pull/12667))
+- Extend cluster health status with KubeLB health check ([#12685](https://github.com/kubermatic/kubermatic/pull/12685))
+- Support for enforcing KubeLB at the datacenter level ([#12685](https://github.com/kubermatic/kubermatic/pull/12685))
+- Support to configure node address type for KubeLB at the datacenter level ([#12715](https://github.com/kubermatic/kubermatic/pull/12715))
+- Update KubeLB CCM image to v0.4.0 ([#12786](https://github.com/kubermatic/kubermatic/pull/12786))
+
+### Metering (Enterprise Edition only)
+
+- Following fields are removed from metering reports ([#12545](https://github.com/kubermatic/kubermatic/pull/12545))
+  - Cluster reports
+    - Removal of `total-used-cpu-seconds`, use `average-used-cpu-millicores` instead
+    - Removal of `average-available-cpu-cores`, use `average-available-cpu-millicores` instead
+  - Namespace reports
+    - Removal of `total-used-cpu-seconds`, use `average-used-cpu-millicores` instead
+- Add `monthly` parameter for metering monthly report generation ([#12544](https://github.com/kubermatic/kubermatic/pull/12544))
+- Update metering component to v1.1.1, fixing highly inaccurate data in cluster reports (see [Action Required](#action-required) for more details) ([#12822](https://github.com/kubermatic/kubermatic/pull/12822))
+
+### Cloud Providers
+
+#### Azure
+
+- Remove Azure NSG rules that only duplicated rules always present in NSGs ([#12565](https://github.com/kubermatic/kubermatic/pull/12565))
+- The `icmp_allow_all` rule of the Azure NSG created for each cluster now only allows ICMP and takes precedence over the TCP and UDP catch-all rules that were guarding it ([#12559](https://github.com/kubermatic/kubermatic/pull/12559))
+
+#### vSphere
+
+- Support for configuring multiple networks for vSphere ([#12444](https://github.com/kubermatic/kubermatic/pull/12444))
+- Support for propagating vSphere cluster tags to folders created by KKP ([#12581](https://github.com/kubermatic/kubermatic/pull/12581))
+- Update vSphere CCM to 1.27.2 for Kubernetes 1.27 user clusters ([#12599](https://github.com/kubermatic/kubermatic/pull/12599))
+- If a vSphere cluster uses a custom datastore, the Seed's default datastore should not be validated ([#12655](https://github.com/kubermatic/kubermatic/pull/12655))
+- Add `basePath` optional configuration for vSphere clusters that will be used to construct a cluster-specific folder path (`<root path>/<base path>/<cluster ID>` or `<base path>/<cluster ID>`) ([#12668](https://github.com/kubermatic/kubermatic/pull/12668))
+- Fix a bug where datastore cluster value was not being propagated to the CSI driver ([#12474](https://github.com/kubermatic/kubermatic/pull/12474))
+- Migrate `CSIDriver` `csi.vsphere.vmware.com` to no longer advertise inline ephemeral volumes as supported ([#12813](https://github.com/kubermatic/kubermatic/pull/12813))
+
+#### DigitalOcean
+
+- Digitalocean CCM versions now depend on the user cluster version, following the loose [upstream compatibility guarantees](https://github.com/digitalocean/digitalocean-cloud-controller-manager#releases) ([#12600](https://github.com/kubermatic/kubermatic/pull/12600))
+
+#### Hetzner
+
+- Hetzner CSI: recreate CSIDriver to allow upgrade from 1.6.0 to 2.2.0 ([#12432](https://github.com/kubermatic/kubermatic/pull/12432))
+- EE: Correctly validate Hetzner API response for server type while calculating resource requirements and for networks while validating cloud spec ([#12716](https://github.com/kubermatic/kubermatic/pull/12716))
+
+### CNIs
+
+#### Cilium
+
+- Set Cilium as default CNI for user clusters ([#12752](https://github.com/kubermatic/kubermatic/pull/12752))
+- Add support for Cilium 1.14.3 and 1.13.8 and deprecate previous patch releases, mitigating CVE-2023-44487, CVE-2023-39347, CVE-2023-41333, CVE-2023-41332 ([#12761](https://github.com/kubermatic/kubermatic/pull/12761))
+- Update Cilium v1.11 and v1.12 patch releases to v1.11.20 and v1.12.13 ([#12561](https://github.com/kubermatic/kubermatic/pull/12561))
+- Remove and replace deprecated `clusterPoolIPv4PodCIDR` and `clusterPoolIPv6PodCIDR` Helm value with `clusterPoolIPv4PodCIDRList` and `clusterPoolIPv6PodCIDRList` for Cilium 1.13+ ([#12561](https://github.com/kubermatic/kubermatic/pull/12561))
+
+#### Canal
+
+- Add support for Canal v3.26.1 ([#12561](https://github.com/kubermatic/kubermatic/pull/12561))
+- Deprecate Canal v3.23 ([#12561](https://github.com/kubermatic/kubermatic/pull/12561))
+- Mark all Canal CRDs with preserveUnknownFields: false ([#12538](https://github.com/kubermatic/kubermatic/pull/12538))
+
+### MLA
+
+- Mark MLA Grafana dashboards as non-editable as they are managed by KKP ([#12626](https://github.com/kubermatic/kubermatic/pull/12626))
+- Fix configuration live reload for monitoring-agent and logging-agent ([#12507](https://github.com/kubermatic/kubermatic/pull/12507))
+- Grafana Kubernetes dashboard will not repeatedly ask to be saved ([#12614](https://github.com/kubermatic/kubermatic/pull/12614))
+- Replace `irate` with `rate` for node cpu usage graphs ([#12427](https://github.com/kubermatic/kubermatic/pull/12427))
+- The `kube_service_labels` metric was not scraped with all expected labels, due to a change in labels on the kube-state-metrics service. The related scraping config was adapted accordingly ([#12551](https://github.com/kubermatic/kubermatic/pull/12551))
+- Fix default url configuration of Blacbox exporter ([#12412](https://github.com/kubermatic/kubermatic/pull/12412))
+- Fix several Prometheus record and alert rules ([#12533](https://github.com/kubermatic/kubermatic/pull/12533))
+- Made Prometheus Helm chart extensible so that external metric storage solutions like Thanos can be easily integrated for seed long-term monitoring ([#12425](https://github.com/kubermatic/kubermatic/pull/12425))
+- Fixes for the Kubernetes overview dashboard in Grafana ([#12520](https://github.com/kubermatic/kubermatic/pull/12520))
+- Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12814](https://github.com/kubermatic/kubermatic/pull/12814))
+- Fix empty panels in Grafana dashboard "Resource Usage per Namespace" for Master/Seed MLA ([#12816](https://github.com/kubermatic/kubermatic/pull/12816))
+
+### New Features
+
+- EE: Default ApplicationCatalog can be deployed via `--deploy-default-app-catalog` flag ([#12623](https://github.com/kubermatic/kubermatic/pull/12623))
+- Add `disableCsiDriver` as optional field on `Cluster` and `Seed` resources to disable CSI driver deployment. This can be configured at a user cluster and datacenter level. If the admin disables CSI drivers at a datacenter level then the user is prohibited from enabling them at the user cluster level ([#12515](https://github.com/kubermatic/kubermatic/pull/12515))
+- Introduce `DisableAdminKubeconfig` flag in `KubermaticSettings` to disable the admin kubeconfig feature from dashboard ([#12679](https://github.com/kubermatic/kubermatic/pull/12679))
+- Disabled CSI addon on user clusters where it was enabled & then disabled using `DisableCSIDriver` option. The CSI addon is removed only if the CSI drivers created by it are not in use ([#12621](https://github.com/kubermatic/kubermatic/pull/12621))
+- Extend `kubermatic-installer mirror-images` command with an option to export a tarball instead of syncing to a remote repository. This can be helpful in airgapped scenarios ([#12613](https://github.com/kubermatic/kubermatic/pull/12613))
+- Extend MinIO configuration options to allow enabling MinIO console access and exposing MinIO API and console via Ingress ([#12683](https://github.com/kubermatic/kubermatic/pull/12683))
+- New configuration option for Dex (`oauth` chart): Allow modification of web frontend issuer ([#12608](https://github.com/kubermatic/kubermatic/pull/12608))
+- Support for configuring IPFamilies and IPFamilyPolicy for nodeport-proxy ([#12472](https://github.com/kubermatic/kubermatic/pull/12472))
+- Support for configuring OIDC username and group prefix for user clusters ([#12648](https://github.com/kubermatic/kubermatic/pull/12648))
+- Support for configuring the Dex theme via values file ([#12560](https://github.com/kubermatic/kubermatic/pull/12560))
+- Switch backup containers to use `etcd-launcher snapshot` for creating etcd database snapshots ([#12462](https://github.com/kubermatic/kubermatic/pull/12462))
+- Use OCI VM images as preconfigured default for local KubeVirt setup ([#12534](https://github.com/kubermatic/kubermatic/pull/12534))
+- Allow to modify allocation range in IPAM Pools ([#12423](https://github.com/kubermatic/kubermatic/pull/12423))
+
+### Bugfixes
+
+- Add missing cluster-autoscaler release for user clusters using Kubernetes 1.27 ([#12597](https://github.com/kubermatic/kubermatic/pull/12597))
+- Add missing images from envoy-agent `DaemonSet` in Tunneling expose strategy when running `kubermatic-installer mirror-images` ([#12537](https://github.com/kubermatic/kubermatic/pull/12537))
+- Fix always defaulting allowed node port IP ranges for user clusters to 0.0.0.0/0 and ::/0, even when a more specific IP range was given ([#12589](https://github.com/kubermatic/kubermatic/pull/12589))
+- Fix an issue in Applications, which resulted in "empty git-upload-pack given" errors for git sources ([#12487](https://github.com/kubermatic/kubermatic/pull/12487))
+- Fix an issue in the `kubermatic-installer mirror-images` command, which led to failure on the mla-consul chart ([#12513](https://github.com/kubermatic/kubermatic/pull/12513))
+- Fix an issue where IPv6 IPs were being ignored when determining the address of a user cluster ([#12505](https://github.com/kubermatic/kubermatic/pull/12505))
+- Fix node-labeller controller not applying the `x-kubernetes.io/distribution` label to RHEL nodes ([#12751](https://github.com/kubermatic/kubermatic/pull/12751))
+- Fix reconcile loop for `seed-proxy-token` Secret on Kubernetes 1.27 ([#12557](https://github.com/kubermatic/kubermatic/pull/12557))
+- Increase memory limit of kube-state-metrics addon to 600Mi ([#12692](https://github.com/kubermatic/kubermatic/pull/12692))
+- `kubermatic-installer` will now validate the existing MinIO filesystem before attempting a `kubermatic-seed` stack installation ([#12477](https://github.com/kubermatic/kubermatic/pull/12477))
+- Increase default CPU limits for KKP API/seed/master-controller-managers to prevent general slowness ([#12764](https://github.com/kubermatic/kubermatic/pull/12764))
+- Extend project-synchronizer controller in kubermatic-master-controller-manager to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12791](https://github.com/kubermatic/kubermatic/pull/12791))
+
+### Updates
+
+- Update Vertical Pod Autoscaler to 0.14.0 ([#12604](https://github.com/kubermatic/kubermatic/pull/12604))
+- Update `d3fk/s3cmd` to version (latest "arch-stable") with `fb4c4dcf` hash ([#12640](https://github.com/kubermatic/kubermatic/pull/12640))
+- Update cert-manager to 1.12.2 ([#12443](https://github.com/kubermatic/kubermatic/pull/12443))
+- Update curl in `kubermatic/util` image and `mla/grafana` chart to 8.4.0 (CVE-2023-38545 and CVE-2023-38546 do not affect KKP) ([#12694](https://github.com/kubermatic/kubermatic/pull/12694))
+- Update `quay.io/kubermatic/util` (helper image) to 2.3.1 (includes curl version patched against CVE-2023-38545 and CVE-2023-38546) ([#12726](https://github.com/kubermatic/kubermatic/pull/12726))
+- Update etcd for user clusters to 3.5.9 ([#12453](https://github.com/kubermatic/kubermatic/pull/12453))
+- Update KubeVirt chart for the installer local command to 1.0.0 ([#12470](https://github.com/kubermatic/kubermatic/pull/12470))
+- Update metering Prometheus to next LTS version 2.45.0 ([#12532](https://github.com/kubermatic/kubermatic/pull/12532))
+- Update metrics-server for all deployments to 0.6.4 ([#12516](https://github.com/kubermatic/kubermatic/pull/12516))
+- Update nginx-ingress-controller to 1.9.3 (fixes CVE-2023-44487, HTTP/2 rapid reset attack) ([#12712](https://github.com/kubermatic/kubermatic/pull/12712))
+- Update supported Kubernetes releases for EKS/AKS ([#12579](https://github.com/kubermatic/kubermatic/pull/12579))
+- Update telemetry-agent to 0.4.1 ([#12572](https://github.com/kubermatic/kubermatic/pull/12572))
+- Update controller-runtime to 0.16.1 and Kubernetes libraries to 1.28 ([#12609](https://github.com/kubermatic/kubermatic/pull/12609))
+- Update Go to 1.21.3 ([#12697](https://github.com/kubermatic/kubermatic/pull/12697))
+- Update KubeVirt CDI for local installer to 1.57.0 ([#12605](https://github.com/kubermatic/kubermatic/pull/12605))
+- Add Kubernetes 1.28 to EKS versions, remove Kubernetes 1.23 ([#12789](https://github.com/kubermatic/kubermatic/pull/12789))
+- Update machine-controller to [v1.58.0](https://github.com/kubermatic/machine-controller/releases/tag/v1.58.0) ([#12825](https://github.com/kubermatic/kubermatic/pull/12825))
+- Update operating-system-manager to [v1.4.0](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.4.0) ([#12826](https://github.com/kubermatic/kubermatic/pull/12826))
+
+### Miscellaneous
+
+- Use `etcd-launcher` to check if etcd is running before starting kube-apiserver and to defragment etcd clusters ([#12450](https://github.com/kubermatic/kubermatic/pull/12450))
+- Create a `NetworkPolicy` for user cluster kube-apiserver to access the Seed Kubernetes API ([#12569](https://github.com/kubermatic/kubermatic/pull/12569))
+- Improve `http-prober` performance in user clusters with a lot of CRDs ([#12634](https://github.com/kubermatic/kubermatic/pull/12634))
+- Update Velero helm chart's apiVersion to v2; Helm 3 & above would be required to install it ([#12765](https://github.com/kubermatic/kubermatic/pull/12765))
+
+### Dashboard & API
+
+#### Cleanup
+
+- Remove unused v1 endpoints for KKP API ([#6116](https://github.com/kubermatic/dashboard/pull/6116))
+
+#### Bugfixes
+
+- Add operating system profile to the machine deployment patch object ([#6264](https://github.com/kubermatic/dashboard/pull/6264))
+- Add vertical scroll to the install Addon dialog ([#6123](https://github.com/kubermatic/dashboard/pull/6123))
+- Allow expansion of sidenav on small screen sizes ([#6218](https://github.com/kubermatic/dashboard/pull/6218))
+- Fix a bug where available version upgrades for CNI plugins were not being properly deduced ([#6317](https://github.com/kubermatic/dashboard/pull/6317))
+- Fix a bug where network and IPv6 subnet pool options were not loading during Openstack cluster creation ([#6120](https://github.com/kubermatic/dashboard/pull/6120))
+- Fix a bug where project scope endpoints for GCP were working only with the presets instead of one of presets or credentials ([#6078](https://github.com/kubermatic/dashboard/pull/6078))
+- CE: Fix a bug where the values configured for vSphere, Hetzner, and Nutanix nodes were not being persisted ([#6171](https://github.com/kubermatic/dashboard/pull/6171))
+- Fix an issue where a custom OSP value was not selected when editing/customizing cluster template ([#6325](https://github.com/kubermatic/dashboard/pull/6325))
+- Fix docs link about OIDC groups on user settings page ([#6208](https://github.com/kubermatic/dashboard/pull/6208))
+- Fix listing events for external clusters ([#6337](https://github.com/kubermatic/dashboard/pull/6337))
+- Fix support for keycloak OIDC logout. New field `oidc_provider` was introduced to support OIDC provider specific configurations. Configuring `oidc_provider` as `keycloak` will properly configure the logout workflow ([#6144](https://github.com/kubermatic/dashboard/pull/6144))
+- Fix the default value for CNI plugin version ([#6258](https://github.com/kubermatic/dashboard/pull/6258))
+- Fix the empty `id_token_hint` value when logout from Keycloak ([#6248](https://github.com/kubermatic/dashboard/pull/6248))
+- Fix: vSphere tags for initial machine deployments ([#6179](https://github.com/kubermatic/dashboard/pull/6179))
+- OpenStack: Fix project and projectID header propagation for project scoped endpoints ([#6082](https://github.com/kubermatic/dashboard/pull/6082))
+- Openstack: take `TenantID` into account while listing networks, security groups and subnet pools ([#6156](https://github.com/kubermatic/dashboard/pull/6156))
+- VMware Cloud Director: fix an issue where the API Token from preset was not being sourced to the cluster ([#6196](https://github.com/kubermatic/dashboard/pull/6196))
+- Fix `Enable Share Cluster` button in Admin Settings ([#6340](https://github.com/kubermatic/dashboard/pull/6340))
+- Fix an issue where `clusterDefaultNodeSelector` label was being added back on opening of edit cluster dialog ([#6362](https://github.com/kubermatic/dashboard/pull/6362))
+- Fix issue with managing clusters if some seeds are down ([#6374](https://github.com/kubermatic/dashboard/pull/6374))
+
+#### New Features
+
+- Support for enabling/disabling operating systems for machines of user clusters ([#6070](https://github.com/kubermatic/dashboard/pull/6070))
+- Add functionality to configure `basePath` in preset and cluster for vSphere ([#6281](https://github.com/kubermatic/dashboard/pull/6281))
+- Add support for encrypted root volumes in AWS ([#6125](https://github.com/kubermatic/dashboard/pull/6125))
+- Add VM anti-affinity setting for vSphere machine deployments ([#6068](https://github.com/kubermatic/dashboard/pull/6068))
+- EE: Support for configuring KubeLB for user clusters ([#6256](https://github.com/kubermatic/dashboard/pull/6256))
+- Support for configuring multiple networks for vSphere ([#6069](https://github.com/kubermatic/dashboard/pull/6069))
+- Support for disabling admin kubeconfig endpoint ([#6246](https://github.com/kubermatic/dashboard/pull/6246))
+- Support multiple NodePort allowed IP ranges ([#6188](https://github.com/kubermatic/dashboard/pull/6188))
+- Update default CNI plugin to `Cilium` ([#6328](https://github.com/kubermatic/dashboard/pull/6328))
+- VMware Cloud Director: Support for configuring placement and sizing policy for machines ([#6094](https://github.com/kubermatic/dashboard/pull/6094))
+- Enforce Konnectivity value because OpenVPN support is now deprecated ([#6361](https://github.com/kubermatic/dashboard/pull/6361))
+
+### Updates
+
+- Update to Go 1.21.3 ([#6268](https://github.com/kubermatic/dashboard/pull/6268))
+- Update web-terminal image to kubectl 1.27, Helm 3.12.3 and curl 8.4.0 ([#6283](https://github.com/kubermatic/dashboard/pull/6283))


### PR DESCRIPTION
This also adds the release notes for today's patch releases and it adds a basically blank page to main, so that for 2.25 I won't have to grep and guess where to put the changelog.