### PR TITLE
Reference custom certificates from CE installation guide

### DIFF
--- a/content/kubermatic/main/installation/install-kkp-ce/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ce/_index.en.md
@@ -290,13 +290,20 @@ to apply your changes.
 
 ## Update DNS & TLS
 
+By default, KKP uses cert-manager to generate TLS certificates for the platform.
+
+{{% notice info %}}
+Check out [Custom Certificates]({{< ref "../../tutorials-howtos/kkp-configuration/custom-certificates/" >}}) if you
+want to provide a static certificate and disable cert-manager integration.
+For certificates coming from a **private CA** it is necessary to add the CA to the **CA bundle** used by KKP.
+{{% /notice %}}
+
 ### Configure ClusterIssuers
 
-By default, KKP installation uses cert-manager to generate TLS certificates for the platform. If you didn't decide to
-change the settings (`.spec.ingress.certificateIssuer.name` in `kubermatic.yaml`), you need to create a `ClusterIssuer` object, named
-`letsencrypt-prod` to enable cert-manager to issue the certificates. Example of this file can be found below. If you
-adjusted this configuration option while preparing the configuration files, make sure to change the `ClusterIssuer`
-resource name accordingly.
+If you didn't decide to change the settings (`.spec.ingress.certificateIssuer.name` in `kubermatic.yaml`),
+you need to create a `ClusterIssuer` object, named `letsencrypt-prod` to enable cert-manager to issue the certificates.
+An example of this file can be found below. If you adjusted this configuration option while preparing the configuration
+files, make sure to change the `ClusterIssuer` resource name accordingly.
 
 For other possible options, please refer to the [external documentation](https://cert-manager.io/docs/configuration/).
 

--- a/content/kubermatic/main/tutorials-howtos/kkp-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-configuration/custom-certificates/_index.en.md
@@ -9,10 +9,10 @@ weight = 130
 KKP 2.17+ allows to configure a "CA bundle" (a set of CA certificates) on the master cluster.
 This CA bundle is then automatically
 
-* copied into each Seed Cluster
-* copied into each User Cluster namespace
-* copied into each User Cluster (into the `kube-system` namespace)
-* used for various components, like the KKP API, machine-controller, User Cluster kube-apiserver, etc.
+* copied into each seed cluster
+* copied into each user cluster namespace
+* copied into each user cluster (into the `kube-system` namespace)
+* used for various components, like the KKP API, machine-controller, user cluster kube-apiserver, etc.
 
 Changes to the CA bundle are automatically reconciled across these locations. If the CA bundle
 is invalid, no further reconciliation happens, so if the master cluster's CA bundle breaks,


### PR DESCRIPTION
The "custom certificates" guide was hidden away in tutorials and not mentioned during the main installation walkthrough. This PR adds a reference.

I've also tried to improve the documentation for custom certificates; Some pitfalls are not spelled out explicitly (e.g. if you use a custom certificate, its CA needs to be in the CA bundle; otherwise some things like user cluster OIDC authentication won't work).