### PR TITLE
Launch v2.24.0 documentation

### DIFF
--- a/content/kubermatic/v2.24/release-notes/_index.en.md
+++ b/content/kubermatic/v2.24/release-notes/_index.en.md
@@ -208,6 +208,7 @@ This release adds support for [KubeLB](https://docs.kubermatic.com/kubelb/), a c
 - Fix `Enable Share Cluster` button in Admin Settings ([#6340](https://github.com/kubermatic/dashboard/pull/6340))
 - Fix an issue where `clusterDefaultNodeSelector` label was being added back on opening of edit cluster dialog ([#6362](https://github.com/kubermatic/dashboard/pull/6362))
 - Fix issue with managing clusters if some seeds are down ([#6374](https://github.com/kubermatic/dashboard/pull/6374))
+- Fix a bug where API call to list projects was failing due to slowness ([#6385](https://github.com/kubermatic/dashboard/pull/6385))
 
 #### New Features
 

--- a/data/products.yaml
+++ b/data/products.yaml
@@ -11,6 +11,8 @@ kubermatic:
   versions:
     - release: main
       name: main
+    - release: v2.24
+      name: v2.24
     - release: v2.23
       name: v2.23
     - release: v2.22


### PR DESCRIPTION
This publishes the v2.24 documentation to docs.kubermatic.com 🎉 

/hold

Until v2.24.0 is out.