### PR TITLE
Add changelog for v2.23.8 and add warning to v2.23.7

### DIFF
--- a/content/kubermatic/v2.23/release-notes/_index.en.md
+++ b/content/kubermatic/v2.23/release-notes/_index.en.md
@@ -11,8 +11,19 @@ weight = 70
 - [v2.23.5](#v2235)
 - [v2.23.6](#v2236)
 - [v2.23.7](#v2237)
+- [v2.23.8](#v2238)
+
+## [v2.23.8](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.8)
+
+### Dashboard
+
+- Fix a bug where the API call to list projects was failing due to slowness ([#6385](https://github.com/kubermatic/dashboard/pull/6385))
 
 ## [v2.23.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.7)
+
+{{% notice warning %}}
+A regression for the KKP dashboard has been discovered in this release that will prevent loading the project overview in most situations. See [dashboard#6384](https://github.com/kubermatic/dashboard/issues/6384) for details. It is strongly recommended to upgrade to [v2.23.8](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.8) instead.
+{{% /notice %}}
 
 ### Action Required
 


### PR DESCRIPTION
We don't have a v2.23.8 changelog entry on docs.kubermatic.com yet, this adds it. In addition, it replicates the warning given on the GitHub release for v2.23.7 to our documentation.