### PR TITLE
Remove mention of installer during MinIO manual migration

### DIFF
--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
@@ -55,7 +55,7 @@ $ kubectl --namespace minio scale deployment/minio --replicas=0
 $ kubectl --namespace minio delete pvc minio-data
 #persistentvolumeclaim "minio-data" deleted
 
-# re-install MinIO chart manually or re-run the KKP installer
+# re-install MinIO chart manually
 $ helm --namespace minio upgrade minio ./charts/minio --values myhelmvalues.yaml
 #Release "minio" has been upgraded. Happy Helming!
 #NAME: minio

--- a/content/kubermatic/v2.23/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
+++ b/content/kubermatic/v2.23/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
@@ -56,7 +56,7 @@ $ kubectl --namespace minio scale deployment/minio --replicas=0
 $ kubectl --namespace minio delete pvc minio-data
 #persistentvolumeclaim "minio-data" deleted
 
-# re-install MinIO chart manually or re-run the KKP installer
+# re-install MinIO chart manually
 $ helm --namespace minio upgrade minio ./charts/minio --values myhelmvalues.yaml
 #Release "minio" has been upgraded. Happy Helming!
 #NAME: minio

--- a/content/kubermatic/v2.24/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
+++ b/content/kubermatic/v2.24/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
@@ -56,7 +56,7 @@ $ kubectl --namespace minio scale deployment/minio --replicas=0
 $ kubectl --namespace minio delete pvc minio-data
 #persistentvolumeclaim "minio-data" deleted
 
-# re-install MinIO chart manually or re-run the KKP installer
+# re-install MinIO chart manually
 $ helm --namespace minio upgrade minio ./charts/minio --values myhelmvalues.yaml
 #Release "minio" has been upgraded. Happy Helming!
 #NAME: minio


### PR DESCRIPTION
Re-running the installer as part of this migration doesn't work, because it will fail with

```
time="2023-11-23T11:36:40Z" level=info msg="🚦 Validating existing installation…"
time="2023-11-23T11:36:40Z" level=error msg="⛔ Cannot proceed with the installation:"
time="2023-11-23T11:36:40Z" level=error msg="   expected exactly 1 Minio Pod, but found 0; cannot exec and check PVC contents"
time="2023-11-23T11:36:40Z" level=error msg="❌ Operation failed: preflight checks have failed."
```