### PR TITLE
vsphere permissions documentation fix

### DIFF
--- a/content/kubermatic/main/architecture/supported-providers/vsphere/_index.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/vsphere/_index.en.md
@@ -270,11 +270,23 @@ Network.Assign
 {{% tab name="k8c-user-datastore-propagate" %}}
 ##### Role `k8c-user-datastore-propagate`
 * Granted at **datastore / datastore cluster** level, propagated
+* Also provides permission to create vSphere tags for a dedicated category, which are required by KKP seed controller manager
+* Please note below points about tagging.
+
+**Note**: If a category id is assigned to a user cluster, KKP would claim the ownership of any tags it creates. KKP would try to delete tags assigned to the cluster upon cluster deletion. Thus, make sure that the assigned category isn't shared across other lingering resources.
+
+**Note**: Tags can be attached to machine deployments regardless if the tags are created via KKP or not.
+If a tag was not attached to the user cluster, machine controller will only detach it.
 * Permissions
   * Datastore
     * Allocate space
     * Browse datastore
     * Low level file operations
+  * vSphere Tagging
+    * Assign or Unassign vSphere Tag
+    * Assign or Unassign vSphere Tag on an Object
+    * Create vSphere Tag
+    * Delete vSphere Tag
 
 ---
 
@@ -283,6 +295,13 @@ $ govc role.ls k8c-user-datastore-propagate
 Datastore.AllocateSpace
 Datastore.Browse
 Datastore.FileManagement
+InventoryService.Tagging.CreateTag
+InventoryService.Tagging.DeleteTag
+InventoryService.Tagging.AttachTag
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
 ```
 {{% /tab %}}
 {{% tab name="k8c-user-folder-propagate" %}}
@@ -302,8 +321,11 @@ Datastore.FileManagement
     * Interaction
     * Provisioning
     * Snapshot management
-  * vShere Tagging
-    * Assign or Unassign vSphere Tag on Object
+  * vSphere Tagging
+    * Assign or Unassign vSphere Tag
+    * Assign or Unassign vSphere Tag on an Object
+    * Create vSphere Tag
+    * Delete vSphere Tag
 
 ---
 
@@ -312,6 +334,9 @@ $ govc role.ls k8c-user-folder-propagate
 Folder.Create
 Folder.Delete
 Global.SetCustomField
+InventoryService.Tagging.CreateTag
+InventoryService.Tagging.DeleteTag
+InventoryService.Tagging.AttachTag
 InventoryService.Tagging.ObjectAttachable
 System.Anonymous
 System.Read
@@ -401,39 +426,6 @@ VirtualMachine.State.RenameSnapshot
 VirtualMachine.State.RevertToSnapshot
 
 ```
-{{% /tab %}}
-{{% tab name="k8c-user-tags" %}}
-
-**Note**: If a category id is assigned to a user cluster, KKP would claim the ownership of any tags
-it creates. KKP would try to delete tags assigned to the cluster upon cluster deletion. Thus, make sure that the assigned
-category isn't shared across other lingering resources.
-
-**Note**: Tags can be attached to machine deployments regardless if the tags are created via KKP or not.
-If a tag was not attached to the user cluster, machine controller will only detach it.
-
-##### Role `k8c-user-tags`
-* Granted at datacenter level, propagated
-* Provides permission to create vSphere tags for a dedicated category, which are required by KKP seed controller manager
-* Permissions
-  * vSphere Tagging
-    * Assign or Unassign vSphere Tag
-    * Assign or Unassign vSphere Tag on an Object
-    * Create vSphere Tag
-    * Delete vSphere Tag
-
----
-
-```
-$ govc role.ls k8c-user-tags
-InventoryService.Tagging.CreateTag
-InventoryService.Tagging.DeleteTag
-InventoryService.Tagging.AttachTag
-InventoryService.Tagging.ObjectAttachable
-System.Anonymous
-System.Read
-System.View
-```
-
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/kubermatic/v2.23/architecture/supported-providers/vsphere/vsphere.en.md
+++ b/content/kubermatic/v2.23/architecture/supported-providers/vsphere/vsphere.en.md
@@ -270,11 +270,23 @@ Network.Assign
 {{% tab name="k8c-user-datastore-propagate" %}}
 ##### Role `k8c-user-datastore-propagate`
 * Granted at **datastore / datastore cluster** level, propagated
+* Also provides permission to create vSphere tags for a dedicated category, which are required by KKP seed controller manager
+* Please note below points about tagging.
+
+**Note**: If a category id is assigned to a user cluster, KKP would claim the ownership of any tags it creates. KKP would try to delete tags assigned to the cluster upon cluster deletion. Thus, make sure that the assigned category isn't shared across other lingering resources.
+
+**Note**: Tags can be attached to machine deployments regardless if the tags are created via KKP or not.
+If a tag was not attached to the user cluster, machine controller will only detach it.
 * Permissions
   * Datastore
     * Allocate space
     * Browse datastore
     * Low level file operations
+  * vSphere Tagging
+    * Assign or Unassign vSphere Tag
+    * Assign or Unassign vSphere Tag on an Object
+    * Create vSphere Tag
+    * Delete vSphere Tag
 
 ---
 
@@ -283,6 +295,13 @@ $ govc role.ls k8c-user-datastore-propagate
 Datastore.AllocateSpace
 Datastore.Browse
 Datastore.FileManagement
+InventoryService.Tagging.CreateTag
+InventoryService.Tagging.DeleteTag
+InventoryService.Tagging.AttachTag
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
 ```
 {{% /tab %}}
 {{% tab name="k8c-user-folder-propagate" %}}
@@ -302,8 +321,11 @@ Datastore.FileManagement
     * Interaction
     * Provisioning
     * Snapshot management
-  * vShere Tagging
-    * Assign or Unassign vSphere Tag on Object
+  * vSphere Tagging
+    * Assign or Unassign vSphere Tag
+    * Assign or Unassign vSphere Tag on an Object
+    * Create vSphere Tag
+    * Delete vSphere Tag
 
 ---
 
@@ -312,6 +334,9 @@ $ govc role.ls k8c-user-folder-propagate
 Folder.Create
 Folder.Delete
 Global.SetCustomField
+InventoryService.Tagging.CreateTag
+InventoryService.Tagging.DeleteTag
+InventoryService.Tagging.AttachTag
 InventoryService.Tagging.ObjectAttachable
 System.Anonymous
 System.Read
@@ -401,39 +426,6 @@ VirtualMachine.State.RenameSnapshot
 VirtualMachine.State.RevertToSnapshot
 
 ```
-{{% /tab %}}
-{{% tab name="k8c-user-tags" %}}
-
-**Note**: If a category id is assigned to a user cluster, KKP would claim the ownership of any tags
-it creates. KKP would try to delete tags assigned to the cluster upon cluster deletion. Thus, make sure that the assigned
-category isn't shared across other lingering resources.
-
-**Note**: Tags can be attached to machine deployments regardless if the tags are created via KKP or not.
-If a tag was not attached to the user cluster, machine controller will only detach it.
-
-##### Role `k8c-user-tags`
-* Granted at datacenter level, propagated
-* Provides permission to create vSphere tags for a dedicated category, which are required by KKP seed controller manager
-* Permissions
-  * vSphere Tagging
-    * Assign or Unassign vSphere Tag
-    * Assign or Unassign vSphere Tag on an Object
-    * Create vSphere Tag
-    * Delete vSphere Tag
-
----
-
-```
-$ govc role.ls k8c-user-tags
-InventoryService.Tagging.CreateTag
-InventoryService.Tagging.DeleteTag
-InventoryService.Tagging.AttachTag
-InventoryService.Tagging.ObjectAttachable
-System.Anonymous
-System.Read
-System.View
-```
-
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/kubermatic/v2.24/architecture/supported-providers/vsphere/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/supported-providers/vsphere/_index.en.md
@@ -270,11 +270,23 @@ Network.Assign
 {{% tab name="k8c-user-datastore-propagate" %}}
 ##### Role `k8c-user-datastore-propagate`
 * Granted at **datastore / datastore cluster** level, propagated
+* Also provides permission to create vSphere tags for a dedicated category, which are required by KKP seed controller manager
+* Please note below points about tagging.
+
+**Note**: If a category id is assigned to a user cluster, KKP would claim the ownership of any tags it creates. KKP would try to delete tags assigned to the cluster upon cluster deletion. Thus, make sure that the assigned category isn't shared across other lingering resources.
+
+**Note**: Tags can be attached to machine deployments regardless if the tags are created via KKP or not.
+If a tag was not attached to the user cluster, machine controller will only detach it.
 * Permissions
   * Datastore
     * Allocate space
     * Browse datastore
     * Low level file operations
+  * vSphere Tagging
+    * Assign or Unassign vSphere Tag
+    * Assign or Unassign vSphere Tag on an Object
+    * Create vSphere Tag
+    * Delete vSphere Tag
 
 ---
 
@@ -283,6 +295,13 @@ $ govc role.ls k8c-user-datastore-propagate
 Datastore.AllocateSpace
 Datastore.Browse
 Datastore.FileManagement
+InventoryService.Tagging.CreateTag
+InventoryService.Tagging.DeleteTag
+InventoryService.Tagging.AttachTag
+InventoryService.Tagging.ObjectAttachable
+System.Anonymous
+System.Read
+System.View
 ```
 {{% /tab %}}
 {{% tab name="k8c-user-folder-propagate" %}}
@@ -302,8 +321,11 @@ Datastore.FileManagement
     * Interaction
     * Provisioning
     * Snapshot management
-  * vShere Tagging
-    * Assign or Unassign vSphere Tag on Object
+  * vSphere Tagging
+    * Assign or Unassign vSphere Tag
+    * Assign or Unassign vSphere Tag on an Object
+    * Create vSphere Tag
+    * Delete vSphere Tag
 
 ---
 
@@ -312,6 +334,9 @@ $ govc role.ls k8c-user-folder-propagate
 Folder.Create
 Folder.Delete
 Global.SetCustomField
+InventoryService.Tagging.CreateTag
+InventoryService.Tagging.DeleteTag
+InventoryService.Tagging.AttachTag
 InventoryService.Tagging.ObjectAttachable
 System.Anonymous
 System.Read
@@ -401,39 +426,6 @@ VirtualMachine.State.RenameSnapshot
 VirtualMachine.State.RevertToSnapshot
 
 ```
-{{% /tab %}}
-{{% tab name="k8c-user-tags" %}}
-
-**Note**: If a category id is assigned to a user cluster, KKP would claim the ownership of any tags
-it creates. KKP would try to delete tags assigned to the cluster upon cluster deletion. Thus, make sure that the assigned
-category isn't shared across other lingering resources.
-
-**Note**: Tags can be attached to machine deployments regardless if the tags are created via KKP or not.
-If a tag was not attached to the user cluster, machine controller will only detach it.
-
-##### Role `k8c-user-tags`
-* Granted at datacenter level, propagated
-* Provides permission to create vSphere tags for a dedicated category, which are required by KKP seed controller manager
-* Permissions
-  * vSphere Tagging
-    * Assign or Unassign vSphere Tag
-    * Assign or Unassign vSphere Tag on an Object
-    * Create vSphere Tag
-    * Delete vSphere Tag
-
----
-
-```
-$ govc role.ls k8c-user-tags
-InventoryService.Tagging.CreateTag
-InventoryService.Tagging.DeleteTag
-InventoryService.Tagging.AttachTag
-InventoryService.Tagging.ObjectAttachable
-System.Anonymous
-System.Read
-System.View
-```
-
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
Based on reports and observations at multiple vsphere based KKP installation, it is clear that newly added kkp-tags related permissions were conflicting with existing permissions. We needed to get them merged properly.

This docs Pr moves those permissions in appropriate propagated and non-propagated roles so that the roles can be applied properly at vcenter UI.