### PR TITLE
Cleanup of redundant section - Terminology from installation docs

### DIFF
--- a/content/kubermatic/main/installation/install-kkp-ce/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ce/_index.en.md
@@ -14,16 +14,6 @@ Typically the setup of KKP cluster, including creation of a base Kubernetes clus
 
 Expected skills and knowledge for the installation: moderate level of familiarity with cloud services (like AWS, Azure, GCP ore others) and familiarity with container and Kubernetes technologies, constructs, and configurations.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Requirements
 
 {{% notice warning %}}

--- a/content/kubermatic/main/installation/install-kkp-ce/add-seed-cluster/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ce/add-seed-cluster/_index.en.md
@@ -25,14 +25,6 @@ environment, please refer to the [Enterprise Edition]({{< ref "../../install-kkp
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
 ## Overview
 
 The setup procedure for seed clusters happens in multiple stages:

--- a/content/kubermatic/main/installation/install-kkp-ee/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ee/_index.en.md
@@ -15,16 +15,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is identical to the [installation process for the Community Edition]({{< ref "../install-kkp-ce" >}}),

--- a/content/kubermatic/main/installation/install-kkp-ee/add-seed-cluster/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ee/add-seed-cluster/_index.en.md
@@ -14,16 +14,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is almost identical to the [seed setup process for the Community Edition]({{< ref "../../install-kkp-ce/add-seed-cluster" >}}),

--- a/content/kubermatic/v2.22/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/v2.22/installation/install-kkp-CE/_index.en.md
@@ -14,16 +14,6 @@ A full setup takes between 1-2 hours depending on your configuration and infrast
 
 Expected skills and knowledge for the installation: moderate level of familiarity with cloud services (like AWS, Azure, GCP ore others) and familiarity with container and Kubernetes technologies, constructs, and configurations.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Requirements
 
 {{% notice warning %}}

--- a/content/kubermatic/v2.22/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.22/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -25,14 +25,6 @@ environment, please refer to the [Enterprise Edition]({{< ref "../../install-kkp
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
 ## Overview
 
 The setup procedure for seed clusters happens in multiple stages:

--- a/content/kubermatic/v2.22/installation/install-kkp-EE/_index.en.md
+++ b/content/kubermatic/v2.22/installation/install-kkp-EE/_index.en.md
@@ -15,16 +15,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is identical to the [installation process for the Community Edition]({{< ref "../install-kkp-CE" >}}),

--- a/content/kubermatic/v2.22/installation/install-kkp-EE/add-seed-cluster-EE/_index.en.md
+++ b/content/kubermatic/v2.22/installation/install-kkp-EE/add-seed-cluster-EE/_index.en.md
@@ -14,16 +14,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is almost identical to the [seed setup process for the Community Edition]({{< ref "../../install-kkp-CE/add-seed-cluster-CE/" >}}),

--- a/content/kubermatic/v2.23/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/v2.23/installation/install-kkp-CE/_index.en.md
@@ -14,16 +14,6 @@ A full setup takes between 1-2 hours depending on your configuration and infrast
 
 Expected skills and knowledge for the installation: moderate level of familiarity with cloud services (like AWS, Azure, GCP ore others) and familiarity with container and Kubernetes technologies, constructs, and configurations.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Requirements
 
 {{% notice warning %}}

--- a/content/kubermatic/v2.23/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.23/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -25,14 +25,6 @@ environment, please refer to the [Enterprise Edition]({{< ref "../../install-kkp
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
 ## Overview
 
 The setup procedure for seed clusters happens in multiple stages:

--- a/content/kubermatic/v2.23/installation/install-kkp-EE/_index.en.md
+++ b/content/kubermatic/v2.23/installation/install-kkp-EE/_index.en.md
@@ -15,16 +15,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is identical to the [installation process for the Community Edition]({{< ref "../install-kkp-CE" >}}),

--- a/content/kubermatic/v2.23/installation/install-kkp-EE/add-seed-cluster-EE/_index.en.md
+++ b/content/kubermatic/v2.23/installation/install-kkp-EE/add-seed-cluster-EE/_index.en.md
@@ -14,16 +14,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is almost identical to the [seed setup process for the Community Edition]({{< ref "../../install-kkp-CE/add-seed-cluster-CE/" >}}),

--- a/content/kubermatic/v2.24/installation/install-kkp-CE/_index.en.md
+++ b/content/kubermatic/v2.24/installation/install-kkp-CE/_index.en.md
@@ -14,16 +14,6 @@ Typically the setup of KKP cluster, including creation of a base Kubernetes clus
 
 Expected skills and knowledge for the installation: moderate level of familiarity with cloud services (like AWS, Azure, GCP ore others) and familiarity with container and Kubernetes technologies, constructs, and configurations.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Requirements
 
 {{% notice warning %}}

--- a/content/kubermatic/v2.24/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.24/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -25,14 +25,6 @@ environment, please refer to the [Enterprise Edition]({{< ref "../../install-kkp
 Please refer to the [architecture]({{< ref "../../../architecture/" >}}) diagrams for more information
 about the cluster relationships.
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
 ## Overview
 
 The setup procedure for seed clusters happens in multiple stages:

--- a/content/kubermatic/v2.24/installation/install-kkp-EE/_index.en.md
+++ b/content/kubermatic/v2.24/installation/install-kkp-EE/_index.en.md
@@ -15,16 +15,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is identical to the [installation process for the Community Edition]({{< ref "../install-kkp-CE" >}}),

--- a/content/kubermatic/v2.24/installation/install-kkp-EE/add-seed-cluster-EE/_index.en.md
+++ b/content/kubermatic/v2.24/installation/install-kkp-EE/add-seed-cluster-EE/_index.en.md
@@ -14,16 +14,6 @@ At the moment you need to be invited to get access to Kubermatic's EE Docker rep
 Please [contact sales](mailto:sales@kubermatic.com) to receive your credentials.
 {{% /notice %}}
 
-## Terminology
-
-In this chapter, you will find the following KKP-specific terms:
-
-* **Master Cluster** -- A Kubernetes cluster which is responsible for storing central information about users, projects and SSH keys. It hosts the KKP master components and might also act as a seed cluster.
-* **Seed Cluster** -- A Kubernetes cluster which is responsible for hosting the control plane components (kube-apiserver, kube-scheduler, kube-controller-manager, etcd and more) of a User Cluster.
-* **User Cluster** -- A Kubernetes cluster created and managed by KKP, hosting applications managed by users.
-
-It is also recommended to make yourself familiar with our [architecture documentation]({{< ref "../../../architecture/" >}}).
-
 ## Installation
 
 The installation procedure is almost identical to the [seed setup process for the Community Edition]({{< ref "../../install-kkp-CE/add-seed-cluster-CE/" >}}),


### PR DESCRIPTION
Removing redundant Terminology section as the terms are listed in the [Architecture](https://docs.kubermatic.com/kubermatic/main/architecture/)  and [Installation](https://docs.kubermatic.com/kubermatic/main/installation/) documentations and reference to those documentation are already provided wherever needed. 
To make the master/seed installation docs more precise. :) 