### PR TITLE
Merge sig-virtualization to sig-cluster-management

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ approvers:
   - sig-app-management
   - sig-cluster-management
   - sig-networking
-  - sig-virtualization
   - toschneck
   - themue
   - scheeles
@@ -15,6 +14,5 @@ reviewers:
   - sig-app-management
   - sig-cluster-management
   - sig-networking
-  - sig-virtualization
   - pso
   - scheeles

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,6 +41,3 @@ aliases:
     - ahmadhamzh
     - ahmedwaleedmalik
     - waseem826
-  sig-virtualization:
-    - cnvergence
-    - wozniakjan


### PR DESCRIPTION
As discussed in the sig meetings, sig-virtualization will merge under the sig-cluster-management