### PR TITLE
Use correct example syntax for backups-restic addon in KubeOne

### DIFF
--- a/content/kubeone/main/examples/addons-backup/_index.en.md
+++ b/content/kubeone/main/examples/addons-backup/_index.en.md
@@ -42,9 +42,9 @@ addons:
   addons:
     - name: backups-restic
       params:
-        resticPassword: "some-secret-value-here"
-        s3Bucket: "name-of-the-s3-bucket"
-        awsDefaultRegion: "default-AWS-region"
+        resticPassword: "<some-secret-value-here>"
+        s3Bucket: "s3:s3.amazonaws.com/<backup-bucket-name>"
+        awsDefaultRegion: "<default-AWS-region>"
 ```
 
 Original [addon source][backups-addon-src] can be found in kubeone repository.

--- a/content/kubeone/v1.5/examples/addons-backup/_index.en.md
+++ b/content/kubeone/v1.5/examples/addons-backup/_index.en.md
@@ -42,9 +42,9 @@ addons:
   addons:
     - name: backups-restic
       params:
-        resticPassword: "some-secret-value-here"
-        s3Bucket: "name-of-the-s3-bucket"
-        awsDefaultRegion: "default-AWS-region"
+        resticPassword: "<some-secret-value-here>"
+        s3Bucket: "s3:s3.amazonaws.com/<backup-bucket-name>"
+        awsDefaultRegion: "<default-AWS-region>"
 ```
 
 Original [addon source][backups-addon-src] can be found in kubeone repository.

--- a/content/kubeone/v1.6/examples/addons-backup/_index.en.md
+++ b/content/kubeone/v1.6/examples/addons-backup/_index.en.md
@@ -42,9 +42,9 @@ addons:
   addons:
     - name: backups-restic
       params:
-        resticPassword: "some-secret-value-here"
-        s3Bucket: "name-of-the-s3-bucket"
-        awsDefaultRegion: "default-AWS-region"
+        resticPassword: "<some-secret-value-here>"
+        s3Bucket: "s3:s3.amazonaws.com/<backup-bucket-name>"
+        awsDefaultRegion: "<default-AWS-region>"
 ```
 
 Original [addon source][backups-addon-src] can be found in kubeone repository.

--- a/content/kubeone/v1.7/examples/addons-backup/_index.en.md
+++ b/content/kubeone/v1.7/examples/addons-backup/_index.en.md
@@ -42,9 +42,9 @@ addons:
   addons:
     - name: backups-restic
       params:
-        resticPassword: "some-secret-value-here"
-        s3Bucket: "name-of-the-s3-bucket"
-        awsDefaultRegion: "default-AWS-region"
+        resticPassword: "<some-secret-value-here>"
+        s3Bucket: "s3:s3.amazonaws.com/<backup-bucket-name>"
+        awsDefaultRegion: "<default-AWS-region>"
 ```
 
 Original [addon source][backups-addon-src] can be found in kubeone repository.


### PR DESCRIPTION
As per https://github.com/kubermatic/kubeone/pull/2981, the `backups-restic` addon was incorrectly documented. This updates the existing documentation as per the current behaviour, as changing it would be a breaking change.