### PR TITLE
Document Kubevirt incompatibility with Cilium

### DIFF
--- a/content/kubermatic/main/architecture/supported-providers/kubevirt/_index.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/kubevirt/_index.en.md
@@ -31,7 +31,11 @@ The setup has been successfully tested with:
 * CRI: containerd
 * CNI: Canal
 
-Other CRIs and CNIs should work too. However, they were not tested, so it is possible to discover issues.
+Other CRIs and CNIs might work too. However, they were not tested, so it is possible to discover issues.
+
+{{% notice warning %}}
+Currently, it is not possible to use Cilium on the KubeVirt infrastructure cluster because of lacking support for the [Pod MAC Address Specification](https://github.com/cilium/cilium/issues/22119).
+{{% /notice %}}
 
 {{% notice note %}}
 To achieve the best possible performance it is recommended to run the setup on bare metal hosts with a hardware virtualization support.

--- a/content/kubermatic/v2.22/architecture/supported-providers/kubevirt/kubevirt.en.md
+++ b/content/kubermatic/v2.22/architecture/supported-providers/kubevirt/kubevirt.en.md
@@ -31,7 +31,11 @@ The setup has been successfully tested with:
 * CRI: containerd
 * CNI: Canal
 
-Other CRIs and CNIs should work too. However, they were not tested, so it is possible to discover issues.
+Other CRIs and CNIs might work too. However, they were not tested, so it is possible to discover issues.
+
+{{% notice warning %}}
+Currently, it is not possible to use Cilium on the KubeVirt infrastructure cluster because of lacking support for the [Pod MAC Address Specification](https://github.com/cilium/cilium/issues/22119).
+{{% /notice %}}
 
 {{% notice note %}}
 To achieve the best possible performance it is recommended to run the setup on bare metal hosts with a hardware virtualization support.

--- a/content/kubermatic/v2.23/architecture/supported-providers/kubevirt/kubevirt.en.md
+++ b/content/kubermatic/v2.23/architecture/supported-providers/kubevirt/kubevirt.en.md
@@ -31,7 +31,11 @@ The setup has been successfully tested with:
 * CRI: containerd
 * CNI: Canal
 
-Other CRIs and CNIs should work too. However, they were not tested, so it is possible to discover issues.
+Other CRIs and CNIs might work too. However, they were not tested, so it is possible to discover issues.
+
+{{% notice warning %}}
+Currently, it is not possible to use Cilium on the KubeVirt infrastructure cluster because of lacking support for the [Pod MAC Address Specification](https://github.com/cilium/cilium/issues/22119).
+{{% /notice %}}
 
 {{% notice note %}}
 To achieve the best possible performance it is recommended to run the setup on bare metal hosts with a hardware virtualization support.

--- a/content/kubermatic/v2.24/architecture/supported-providers/kubevirt/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/supported-providers/kubevirt/_index.en.md
@@ -31,7 +31,11 @@ The setup has been successfully tested with:
 * CRI: containerd
 * CNI: Canal
 
-Other CRIs and CNIs should work too. However, they were not tested, so it is possible to discover issues.
+Other CRIs and CNIs might work too. However, they were not tested, so it is possible to discover issues.
+
+{{% notice warning %}}
+Currently, it is not possible to use Cilium on the KubeVirt infrastructure cluster because of lacking support for the [Pod MAC Address Specification](https://github.com/cilium/cilium/issues/22119).
+{{% /notice %}}
 
 {{% notice note %}}
 To achieve the best possible performance it is recommended to run the setup on bare metal hosts with a hardware virtualization support.


### PR DESCRIPTION
Cilium doesn't support specifying Pod's MAC address and therefore it can't be used for the KubeVirt infrastructure cluster. KubeVirt infrastructure clusters that use Cilium are not able to start VMs created by KKP/machine-controller.

Upstream reference: https://github.com/cilium/cilium/issues/22119

/assign @moadqassem @embik 
cc @toschneck  