### PR TITLE
Update manual etcd restore procedure

### DIFF
--- a/content/kubermatic/main/cheat-sheets/etcd/legacy-restore/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/etcd/legacy-restore/_index.en.md
@@ -5,6 +5,13 @@ weight = 20
 
 +++
 
+{{% notice warning %}}
+This page documents a **manual** restore procedure in case the legacy backup controllers were used to create
+the backup object in question. KKP v2.24 has removed the legacy backup controllers. The current implementation
+supports [automated restores]({{< ref "../../../tutorials-howtos/etcd-backups/" >}}), so this procedure should 
+**not** be used. Use the restore functionality in KKP directly instead.
+{{% /notice %}}
+
 ## Intro
 
 The etcds of the user-clusters are being backed up on a configured interval.
@@ -62,7 +69,26 @@ cd /var/run/etcd/
 # This command is specific to each member.
 export MEMBER=etcd-0
 export CLUSTER_ID=xxxxxxxxxx
+```
 
+#### With etcd-launcher Enabled
+
+If `etcd-launcher` is enabled (which it is by default since KKP v2.22), the restore command needs to use TLS-enabled endpoints:
+
+```bash
+etcdctl snapshot restore snapshot.db \
+  --name ${MEMBER} \
+  --initial-cluster etcd-0=https://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-1=https://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-2=https://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --initial-cluster-token ${CLUSTER_ID} \
+  --initial-advertise-peer-urls https://${MEMBER}.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --data-dir /var/run/etcd/pod_${MEMBER}/
+```
+
+#### With etcd-launcher Disabled
+
+If `etcd-launcher` is disabled (which is not recommended), the restore command needs to use plain HTTP networking:
+
+```bash
 etcdctl snapshot restore snapshot.db \
   --name ${MEMBER} \
   --initial-cluster etcd-0=http://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380 \

--- a/content/kubermatic/main/cheat-sheets/etcd/replace-a-member/_index.en.md
+++ b/content/kubermatic/main/cheat-sheets/etcd/replace-a-member/_index.en.md
@@ -7,7 +7,7 @@ weight = 10
 
 ## Intro
 
-As the etcd gets managed by a StatefulSet with PVC's, replacing a member should mostly never needed.
+As the etcd gets managed by a StatefulSet with PVCs, replacing a member should mostly never needed.
 Scenarios though could be:
 
 - A PV of an etcd member got corrupted or even deleted

--- a/content/kubermatic/main/installation/install-kkp-ce/add-seed-cluster/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ce/add-seed-cluster/_index.en.md
@@ -250,7 +250,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.2.0
+          image: quay.io/kubermatic/util:2.4.0
           args:
             - /bin/sh
             - -c

--- a/content/kubermatic/v2.22/cheat-sheets/etcd/legacy-restore/_index.en.md
+++ b/content/kubermatic/v2.22/cheat-sheets/etcd/legacy-restore/_index.en.md
@@ -5,6 +5,13 @@ weight = 20
 
 +++
 
+{{% notice warning %}}
+This page documents a **manual** restore procedure in case the legacy backup controllers were used to create
+the backup object in question. Legacy backup controllers will be removed in a future release. The current implementation
+supports [automated restores]({{< ref "../../../tutorials-howtos/etcd-backups/" >}}), so this procedure should 
+**not** be used. Use the restore functionality in KKP directly instead.
+{{% /notice %}}
+
 ## Intro
 
 The etcds of the user-clusters are being backed up on a configured interval.
@@ -62,7 +69,26 @@ cd /var/run/etcd/
 # This command is specific to each member.
 export MEMBER=etcd-0
 export CLUSTER_ID=xxxxxxxxxx
+```
 
+#### With etcd-launcher Enabled
+
+If `etcd-launcher` is enabled (which it is by default since KKP v2.22), the restore command needs to use TLS-enabled endpoints:
+
+```bash
+etcdctl snapshot restore snapshot.db \
+  --name ${MEMBER} \
+  --initial-cluster etcd-0=https://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-1=https://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-2=https://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --initial-cluster-token ${CLUSTER_ID} \
+  --initial-advertise-peer-urls https://${MEMBER}.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --data-dir /var/run/etcd/pod_${MEMBER}/
+```
+
+#### With etcd-launcher Disabled
+
+If `etcd-launcher` is disabled (which is not recommended), the restore command needs to use plain HTTP networking:
+
+```bash
 etcdctl snapshot restore snapshot.db \
   --name ${MEMBER} \
   --initial-cluster etcd-0=http://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380 \

--- a/content/kubermatic/v2.22/cheat-sheets/etcd/replace-a-member/_index.en.md
+++ b/content/kubermatic/v2.22/cheat-sheets/etcd/replace-a-member/_index.en.md
@@ -7,7 +7,7 @@ weight = 10
 
 ## Intro
 
-As the etcd gets managed by a StatefulSet with PVC's, replacing a member should mostly never needed.
+As the etcd gets managed by a StatefulSet with PVCs, replacing a member should mostly never needed.
 Scenarios though could be:
 
 - A PV of an etcd member got corrupted or even deleted

--- a/content/kubermatic/v2.23/cheat-sheets/etcd/legacy-restore/_index.en.md
+++ b/content/kubermatic/v2.23/cheat-sheets/etcd/legacy-restore/_index.en.md
@@ -5,6 +5,13 @@ weight = 20
 
 +++
 
+{{% notice warning %}}
+This page documents a **manual** restore procedure in case the legacy backup controllers were used to create
+the backup object in question. KKP v2.24 will remove the legacy backup controllers. The current implementation
+supports [automated restores]({{< ref "../../../tutorials-howtos/etcd-backups/" >}}), so this procedure should 
+**not** be used. Use the restore functionality in KKP directly instead.
+{{% /notice %}}
+
 ## Intro
 
 The etcds of the user-clusters are being backed up on a configured interval.
@@ -62,7 +69,26 @@ cd /var/run/etcd/
 # This command is specific to each member.
 export MEMBER=etcd-0
 export CLUSTER_ID=xxxxxxxxxx
+```
 
+#### With etcd-launcher Enabled
+
+If `etcd-launcher` is enabled (which it is by default since KKP v2.22), the restore command needs to use TLS-enabled endpoints:
+
+```bash
+etcdctl snapshot restore snapshot.db \
+  --name ${MEMBER} \
+  --initial-cluster etcd-0=https://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-1=https://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-2=https://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --initial-cluster-token ${CLUSTER_ID} \
+  --initial-advertise-peer-urls https://${MEMBER}.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --data-dir /var/run/etcd/pod_${MEMBER}/
+```
+
+#### With etcd-launcher Disabled
+
+If `etcd-launcher` is disabled (which is not recommended), the restore command needs to use plain HTTP networking:
+
+```bash
 etcdctl snapshot restore snapshot.db \
   --name ${MEMBER} \
   --initial-cluster etcd-0=http://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380 \

--- a/content/kubermatic/v2.23/cheat-sheets/etcd/replace-a-member/_index.en.md
+++ b/content/kubermatic/v2.23/cheat-sheets/etcd/replace-a-member/_index.en.md
@@ -7,7 +7,7 @@ weight = 10
 
 ## Intro
 
-As the etcd gets managed by a StatefulSet with PVC's, replacing a member should mostly never needed.
+As the etcd gets managed by a StatefulSet with PVCs, replacing a member should mostly never needed.
 Scenarios though could be:
 
 - A PV of an etcd member got corrupted or even deleted

--- a/content/kubermatic/v2.23/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.23/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -246,7 +246,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.2.0
+          image: quay.io/kubermatic/util:2.4.0
           args:
             - /bin/sh
             - -c

--- a/content/kubermatic/v2.24/cheat-sheets/etcd/legacy-restore/_index.en.md
+++ b/content/kubermatic/v2.24/cheat-sheets/etcd/legacy-restore/_index.en.md
@@ -5,6 +5,13 @@ weight = 20
 
 +++
 
+{{% notice warning %}}
+This page documents a **manual** restore procedure in case the legacy backup controllers were used to create
+the backup object in question. KKP v2.24 has removed the legacy backup controllers. The current implementation
+supports [automated restores]({{< ref "../../../tutorials-howtos/etcd-backups/" >}}), so this procedure should 
+**not** be used. Use the restore functionality in KKP directly instead.
+{{% /notice %}}
+
 ## Intro
 
 The etcds of the user-clusters are being backed up on a configured interval.
@@ -62,7 +69,26 @@ cd /var/run/etcd/
 # This command is specific to each member.
 export MEMBER=etcd-0
 export CLUSTER_ID=xxxxxxxxxx
+```
 
+#### With etcd-launcher Enabled
+
+If `etcd-launcher` is enabled (which it is by default since KKP v2.22), the restore command needs to use TLS-enabled endpoints:
+
+```bash
+etcdctl snapshot restore snapshot.db \
+  --name ${MEMBER} \
+  --initial-cluster etcd-0=https://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-1=https://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381,etcd-2=https://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --initial-cluster-token ${CLUSTER_ID} \
+  --initial-advertise-peer-urls https://${MEMBER}.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2381 \
+  --data-dir /var/run/etcd/pod_${MEMBER}/
+```
+
+#### With etcd-launcher Disabled
+
+If `etcd-launcher` is disabled (which is not recommended), the restore command needs to use plain HTTP networking:
+
+```bash
 etcdctl snapshot restore snapshot.db \
   --name ${MEMBER} \
   --initial-cluster etcd-0=http://etcd-0.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-${CLUSTER_ID}.svc.cluster.local:2380 \

--- a/content/kubermatic/v2.24/cheat-sheets/etcd/replace-a-member/_index.en.md
+++ b/content/kubermatic/v2.24/cheat-sheets/etcd/replace-a-member/_index.en.md
@@ -7,7 +7,7 @@ weight = 10
 
 ## Intro
 
-As the etcd gets managed by a StatefulSet with PVC's, replacing a member should mostly never needed.
+As the etcd gets managed by a StatefulSet with PVCs, replacing a member should mostly never needed.
 Scenarios though could be:
 
 - A PV of an etcd member got corrupted or even deleted

--- a/content/kubermatic/v2.24/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
+++ b/content/kubermatic/v2.24/installation/install-kkp-CE/add-seed-cluster-CE/_index.en.md
@@ -250,7 +250,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.2.0
+          image: quay.io/kubermatic/util:2.4.0
           args:
             - /bin/sh
             - -c


### PR DESCRIPTION
Our docs were incorrect when trying to restore from legacy backups but already using etcd-launcher (since we migrated everyone in KKP v2.22 to it, essentially). This came back to bite me in the manual cluster restore I had to do on the captain.

This PR updates the manual restore procedure accordingly, but also puts a word of warning on it - no one should have to do manual restores anymore, it's all automated with the "new" backup controllers.