### PR TITLE
document certificate renewal within kubeone

### DIFF
--- a/content/kubeone/main/guides/certificate-management/_index.en.md
+++ b/content/kubeone/main/guides/certificate-management/_index.en.md
@@ -1,0 +1,18 @@
++++
+title = "Certificate Management"
+date = 2024-01-10T15:50:00+02:00
++++
+
+## Certificate Renewal
+
+{{% notice warning %}}
+In general, kubeone automatically updates certificates that are within 90 days of expiry automatically when updating your cluster. If you keep cluster updates in line with the [Kubernetes Support Period](https://kubernetes.io/releases/patch-releases/#support-period), there should be no need to manually re-new certificates.
+{{% /notice %}}
+
+In case you want to manually update your certificates, you can run the following:
+
+```sh
+kubeone apply --force-upgrade
+```
+
+This will renew all of your certificates and restart the kube-apiserver to make use of the updated certificates, assuming your certificates are within 90 days of expiry.


### PR DESCRIPTION
Hi, as this came up a two times in support tickets, I wanted to document this.

The ideas behind my wording were the following:
* I wanted to document the 90days period your certificates need to be within, before they are renewed, since I could not find that in the docs
* I wanted to document, that there is no need for a kubeadm command, but that kubeone can do it directly as long as you pass the `--force-upgrade` flag
* I wanted to give the user a clear warning that this should not be needed if they update their clusters regularly.

I am hoping these points come across in what I have written. ptal.

I am also happy to backport this to other kubeone versions of the documentation as well, just want to hear your opinion on the wording first before doing so.