### PR TITLE
Updated release notes to include Feb 2024 out-of-band patch changelog

### DIFF
--- a/content/kubermatic/v2.24/release-notes/_index.en.md
+++ b/content/kubermatic/v2.24/release-notes/_index.en.md
@@ -8,8 +8,20 @@ weight = 70
 - [v2.24.1](#v2241)
 - [v2.24.2](#v2242)
 - [v2.24.3](#v2243)
+- [v2.24.4](#v2244)
 
-## [2.24.3](https://github.com/kubermatic/kubermatic/releases/tag/2.24.3)
+## [v2.24.4](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.4)
+
+### Bugfixes
+
+- Fix the panic of the seed controller manager while checking CSI addon usage for user clusters, when a user cluster has PVs which were migrated from the in-tree provisioner to the CSI provisioner ([#13126](https://github.com/kubermatic/kubermatic/pull/13126))
+
+### New Feature
+
+- We maintain now a dedicated docker image for the conformance tester, mainly for internal use ([#13113](https://github.com/kubermatic/kubermatic/pull/13113))
+
+
+## [v2.24.3](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.3)
 
 ### Bugfixes
 


### PR DESCRIPTION
Taken from https://github.com/kubermatic/kubermatic/pull/13129.

/hold

until releases are out.