### PR TITLE
fix app name: cert-manager is the official, real name

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/_index.en.md
@@ -10,7 +10,7 @@ weight = 3
 Here is the list of the applications that come as part of the Default Applications Catalog offering from the KKP(EE) installation.
 
 * [ArgoCD]({{< ref "./argocd/" >}})
-* [CertManager]({{< ref "./cert-manager/" >}})
+* [cert-manager]({{< ref "./cert-manager/" >}})
 * [Falco]({{< ref "./falco/" >}})
 * [Flux2]({{< ref "./flux2/" >}})
 * [K8sGPT]({{< ref "./k8sgpt/" >}})

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -1,37 +1,37 @@
 +++
-title = "Cert Manager Application"
-linkTitle = "Cert-Manager"
+title = "cert-manager Application"
+linkTitle = "cert-manager"
 enterprise = true
 date = 2024-01-16T12:57:00+02:00
 weight = 3
 
 +++
 
-# What is Cert-Manager?
+# What is cert-manager?
 
-Cert-Manager adds certificates and certificate issuers as resource types in Kubernetes clusters. It simplifies the process of obtaining, renewing and using certificates.
+cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters. It simplifies the process of obtaining, renewing and using certificates.
 
 It can issue certificates from a variety of supported sources, including Let's Encrypt, HashiCorp Vault, and Venafi as well as private PKI.
 
 It will ensure certificates are valid and up to date, and attempt to renew certificates at a configured time before expiry.
 
-For more information on the Cert-Manager, please refer to the [official documentation](https://cert-manager.io/)
+For more information on the cert-manager, please refer to the [official documentation](https://cert-manager.io/)
 
 # How to deploy?
 
-Cert-Manager is available as part of the KKP's default application catalog. 
+cert-manager is available as part of the KKP's default application catalog.
 It can be deployed to the user cluster either during the cluster creation or after the cluster is ready(existing cluster) from the Applications tab via UI.
 
-* Select the Cert-Manager application from the Application Catalog.
+* Select the cert-manager application from the Application Catalog.
 
-![Select Cert-Manager Application](/img/kubermatic/common/applications/default-apps-catalog/01-select-application-cert-manager-app.png)
+![Select cert-manager Application](/img/kubermatic/common/applications/default-apps-catalog/01-select-application-cert-manager-app.png)
 
 * Under the Settings section, select and provide appropriate details and clck `-> Next` button.
 
-![Settings for Cert-Manager Application](/img/kubermatic/common/applications/default-apps-catalog/02-settings-cert-manager-app.png)
+![Settings for cert-manager Application](/img/kubermatic/common/applications/default-apps-catalog/02-settings-cert-manager-app.png)
 
-* Under the Application values page section, check the default values and add values if any required to be configured explicitly. Finally click on the `+ Add Application` to deploy the Cert-Manager application to the user cluster.
+* Under the Application values page section, check the default values and add values if any required to be configured explicitly. Finally click on the `+ Add Application` to deploy the cert-manager application to the user cluster.
 
-![Application Values for Cert-Manager Application](/img/kubermatic/common/applications/default-apps-catalog/03-applicationvalues-cert-manager-app.png)
+![Application Values for cert-manager Application](/img/kubermatic/common/applications/default-apps-catalog/03-applicationvalues-cert-manager-app.png)
 
 A full list of available Helm values is on [cert-manager's ArtifactHub page](https://artifacthub.io/packages/helm/cert-manager/cert-manager).


### PR DESCRIPTION
See https://cert-manager.io/docs/faq/#how-to-write-cert-manager

> cert-manager should always be written in lowercase. Even when it would normally be capitalized such as in titles or at the start of sentences. A hyphen should always be used between the words, don't replace it with a space and don't remove it.