### PR TITLE
rip out kubecarrier docs, gently without removing them

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -4,9 +4,9 @@ This document describes the documentation process for Kubermatic projects.
 
 ## What must be documented?
 
-All user-facing changes must be documented. Documentation for KKP,
-KubeOne, and KubeCarrier is located in this repository. Documentation for
-other projects is usually located in the respective repository.
+All user-facing changes must be documented. Documentation for KKP and KubeOne
+is located in this repository. Documentation for other projects is usually
+located in the respective repository.
 
 ## How are changes documented?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubermatic Products Documentation
 
-Kubermatic Kubernetes Platform which is a Cluster-as-a-Service, KubeOne which is used to manage highly available Kubernetes clusters and Kubecarrier which is an application management for thousands of apps are Kubermatic products that provides managed Kubernetes for your infrastructure.
+Kubermatic Kubernetes Platform is a Cluster-as-a-Service platform and KubeOne is used to manage highly available Kubernetes clusters are Kubermatic products that provides managed Kubernetes for your infrastructure.
 
 These products allow you to set up Kubernetes clusters easily and make sure that your clusters are available and up-to-date at all times, thus allowing you to focus on developing your services.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Docs"
-description = "Learn more about KKP, KubeOne and KubeCarrier through the official Kubermatic documentation"
+description = "Learn more about KKP and KubeOne through the official Kubermatic documentation"
 
 [contribution]
 title = "How Do I Contribute To ...?"
@@ -15,12 +15,6 @@ title = "How Do I Contribute To ...?"
   url = "https://docs.kubermatic.com/kubermatic/v2.24/how-to-contribute-to-kkp/"
   [contribution.links.image]
   src = "/img/KubermaticKubernetesPlatform-logo.svg"
-  alt = ""
-
- [[contribution.links]]
-  url = "https://docs.kubermatic.com/kubecarrier/v0.3/tutorials_howtos/how_to_contribute_to_kubecarrier/"
-  [contribution.links.image]
-  src = "/img/KubeCarrier-logo.svg"
   alt = ""
 
 [features]

--- a/data/products.yaml
+++ b/data/products.yaml
@@ -61,22 +61,6 @@ kubeone:
       name: v1.2
     - release: v1.0
       name: v1.0
-kubecarrier:
-  name: KubeCarrier
-  logo: "img/KubeCarrier-logo.svg"
-  title: KubeCarrier
-  description: The operator of operators. Centrally manage all your services and applications across multiple clusters, clouds and regions with Kubernetes native API and tooling.
-  weight: 3
-  shareImage: img/Docs-KubeCarrier-share.jpg
-  versions:
-    - release: master
-      name: master
-    - release: v0.3
-      name: v0.3
-    - release: v0.2
-      name: v0.2
-    - release: v0.1
-      name: v0.1
 operatingsystemmanager:
   name: operatingsystemmanager
   logo: "/img/operatingsystemmanager/common/operating-system-manager-logo.png"

--- a/hack/README.md
+++ b/hack/README.md
@@ -21,7 +21,7 @@ Usage:
   prepare-release.sh -p <PRODUCT> -v <VERSION>
 
 Flags:
-  -p    Product selection. One of 'kubermatic', 'kubeone', 'kubecarrier'. (env: PRODUCT)
+  -p    Product selection. One of 'kubermatic', 'kubeone'. (env: PRODUCT)
   -v    Version of the upcoming release. (env: VERSION)
   -k    Location of kubermatic/kubermatic working copy. (env: KUBERMATIC_DIR, default: '../kubermatic')
   -h    Print this help.

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -12,7 +12,7 @@ usage() {
   echo "  prepare-release.sh -p <PRODUCT> -v <VERSION>"
   echo
   echo "Flags:"
-  echo "  -p    Product selection. One of 'kubermatic', 'kubeone', 'kubecarrier'. (env: PRODUCT)"
+  echo "  -p    Product selection. One of 'kubermatic', 'kubeone'. (env: PRODUCT)"
   echo "  -v    Version of the upcoming release. (env: VERSION)"
   echo "  -k    Location of kubermatic/kubermatic working copy. (env: KUBERMATIC_DIR, default: '../kubermatic')"
   echo "  -h    Print this help."
@@ -59,7 +59,7 @@ done
 [[ $VERSION ]] ||
   (usage; exit 1)
 
-[[ $PRODUCT =~ ^(kubermatic|kubeone|kubecarrier)$ ]] ||
+[[ $PRODUCT =~ ^(kubermatic|kubeone)$ ]] ||
   (usage; exit 1)
 
 # Default value if unset

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
     "@context": "https://schema.org",
     "@type": "WebPage",
     "name": "Kubermatic Documentation",
-    "description": "Learn more about Kubermatic Kubernetes Platform, KubeOne and KubeCarrier through the official Kubermatic documentation",
+    "description": "Learn more about Kubermatic Kubernetes Platform and KubeOne through the official Kubermatic documentation",
     "publisher": {
       "@type": "Corporation",
       "name": "Kubermatic",


### PR DESCRIPTION
As per Sebastian's request, we remove the KubeCarrier docs now finally.