### PR TITLE
Add Flatcar to supported OSes for GCP and VCD

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/os-support-matrix/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/os-support-matrix/_index.en.md
@@ -26,12 +26,12 @@ This table shows the combinations of operating systems and cloud providers that 
 | Azure                 | ✓ | ✓ | ✓ | ✓ | x | ✓ |
 | Digitalocean          | ✓ | ✓ | x | x | x | ✓ |
 | Equinix Metal         | ✓ | ✓ | ✓ | x | x | ✓ |
-| Google Cloud Platform | ✓ | x | x | x | x | x |
+| Google Cloud Platform | ✓ | x | ✓ | x | x | x |
 | Hetzner               | ✓ | x[^1] | x | x | x | ✓ |
 | KubeVirt              | ✓ | ✓ | ✓ | ✓ | x | ✓ |
 | Nutanix               | ✓ | ✓ | x | x | x | x |
 | Openstack             | ✓ | ✓ | ✓ | ✓ | x | ✓ |
-| VMware Cloud Director | ✓ | x | x | x | x | x |
+| VMware Cloud Director | ✓ | x | ✓ | x | x | x |
 | VSphere               | ✓ | ✓ | ✓ | ✓ | x | ✓ |
 
 There could be more in the future since change is constant. This page will constantly be updated each time there is a new supported operating system.

--- a/content/kubermatic/main/architecture/compatibility/os-support-matrix/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/os-support-matrix/_index.en.md
@@ -36,4 +36,4 @@ This table shows the combinations of operating systems and cloud providers that 
 
 There could be more in the future since change is constant. This page will constantly be updated each time there is a new supported operating system.
 
-[^1]: Hetzner has deprecated CentOS 7 and will stop supporting it in January 2024.
+[^1]: Hetzner stopped supporting CentOS 7 in January 2024.


### PR DESCRIPTION
Ref: https://github.com/kubermatic/kubermatic/pull/13162.

It seems we haven't updated our support matrix, but we support Flatcar in GCP and VCD now.

Also does a minor update to language about Hetzner's CentOS 7 support since the date was in the past.