### PR TITLE
Fully launch 2.25 documentation

### DIFF
--- a/data/products.yaml
+++ b/data/products.yaml
@@ -11,8 +11,8 @@ kubermatic:
   versions:
     - release: main
       name: main
-    #- release: v2.25
-    #  name: v2.25
+    - release: v2.25
+      name: v2.25
     - release: v2.24
       name: v2.24
     - release: v2.23


### PR DESCRIPTION
This will launch the 2.25 documentation.

/hold

until release is out.