### PR TITLE
KubeOne: remove duplicate word 'applied'

### DIFF
--- a/content/kubeone/main/architecture/_index.en.md
+++ b/content/kubeone/main/architecture/_index.en.md
@@ -19,7 +19,7 @@ the SSH access to the control plane nodes is required. Such tasks include
 installing and upgrading dependencies (such as container runtime and Kubernetes
 binaries), generating and distributing configuration files and certificates,
 running kubeadm, and more. The cluster components and addons are applied
-applied programmatically using client-go and controller-runtime libraries.
+programmatically using client-go and controller-runtime libraries.
 By default, KubeOne deploys the Canal CNI plugin, metrics-server, NodeLocalDNS,
 and Kubermatic machine-controller.
 

--- a/content/kubeone/v1.3/architecture/_index.en.md
+++ b/content/kubeone/v1.3/architecture/_index.en.md
@@ -18,7 +18,7 @@ the SSH access to the control plane nodes is required. Such tasks include
 installing and upgrading dependencies (such as container runtime and Kubernetes
 binaries), generating and distributing configuration files and certificates,
 running kubeadm, and more. The cluster components and addons are applied
-applied programmatically using client-go and controller-runtime libraries.
+programmatically using client-go and controller-runtime libraries.
 By default, KubeOne deploys the Canal CNI plugin, metrics-server, NodeLocalDNS,
 and Kubermatic machine-controller.
 

--- a/content/kubeone/v1.4/architecture/_index.en.md
+++ b/content/kubeone/v1.4/architecture/_index.en.md
@@ -19,7 +19,7 @@ the SSH access to the control plane nodes is required. Such tasks include
 installing and upgrading dependencies (such as container runtime and Kubernetes
 binaries), generating and distributing configuration files and certificates,
 running kubeadm, and more. The cluster components and addons are applied
-applied programmatically using client-go and controller-runtime libraries.
+programmatically using client-go and controller-runtime libraries.
 By default, KubeOne deploys the Canal CNI plugin, metrics-server, NodeLocalDNS,
 and Kubermatic machine-controller.
 

--- a/content/kubeone/v1.5/architecture/_index.en.md
+++ b/content/kubeone/v1.5/architecture/_index.en.md
@@ -19,7 +19,7 @@ the SSH access to the control plane nodes is required. Such tasks include
 installing and upgrading dependencies (such as container runtime and Kubernetes
 binaries), generating and distributing configuration files and certificates,
 running kubeadm, and more. The cluster components and addons are applied
-applied programmatically using client-go and controller-runtime libraries.
+programmatically using client-go and controller-runtime libraries.
 By default, KubeOne deploys the Canal CNI plugin, metrics-server, NodeLocalDNS,
 and Kubermatic machine-controller.
 

--- a/content/kubeone/v1.6/architecture/_index.en.md
+++ b/content/kubeone/v1.6/architecture/_index.en.md
@@ -19,7 +19,7 @@ the SSH access to the control plane nodes is required. Such tasks include
 installing and upgrading dependencies (such as container runtime and Kubernetes
 binaries), generating and distributing configuration files and certificates,
 running kubeadm, and more. The cluster components and addons are applied
-applied programmatically using client-go and controller-runtime libraries.
+programmatically using client-go and controller-runtime libraries.
 By default, KubeOne deploys the Canal CNI plugin, metrics-server, NodeLocalDNS,
 and Kubermatic machine-controller.
 

--- a/content/kubeone/v1.7/architecture/_index.en.md
+++ b/content/kubeone/v1.7/architecture/_index.en.md
@@ -19,7 +19,7 @@ the SSH access to the control plane nodes is required. Such tasks include
 installing and upgrading dependencies (such as container runtime and Kubernetes
 binaries), generating and distributing configuration files and certificates,
 running kubeadm, and more. The cluster components and addons are applied
-applied programmatically using client-go and controller-runtime libraries.
+programmatically using client-go and controller-runtime libraries.
 By default, KubeOne deploys the Canal CNI plugin, metrics-server, NodeLocalDNS,
 and Kubermatic machine-controller.
 


### PR DESCRIPTION
In the [Architecture](https://docs.kubermatic.com/kubeone/main/architecture/) section: 

> The cluster components and addons are **_applied_** applied programmatically using client-go and controller-runtime libraries.". 

The duplicate word has been removed.