### PR TITLE
KKP: Remove references for CoreOS

### DIFF
--- a/content/kubermatic/main/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/main/architecture/requirements/cluster-requirements/_index.en.md
@@ -14,7 +14,7 @@ The Master Cluster hosts the KKP components and might also act as a seed cluster
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
@@ -27,7 +27,7 @@ The User Cluster is a Kubernetes cluster created and managed by KKP. The exact r
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/main/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -106,8 +106,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 

--- a/content/kubermatic/v2.17/architecture/requirements/cluster_requirements/_index.en.md
+++ b/content/kubermatic/v2.17/architecture/requirements/cluster_requirements/_index.en.md
@@ -16,7 +16,7 @@ The Master Cluster hosts the KKP components and might also act as a seed cluster
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
@@ -29,7 +29,7 @@ The User Cluster is a Kubernetes cluster created and managed by KKP. The exact r
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.17/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/v2.17/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -107,8 +107,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 
@@ -186,7 +184,7 @@ Example specs for different providers:
     spec:
       alibaba:
         region: "eu1"
-    
+
   #==================================
   #============= Anexia ============
   #==================================
@@ -208,7 +206,7 @@ Datacenters are a part of the Seed resource and need to be managed by an Kuberma
 
 The EE offers 2 different ways to manage the datacenters. One way is using the dynamic datacenters feature through which
 admins can manage Datacenters on Seeds through API/UI. This is the preferred and recommended way. The other way is through the
-`datacenter.yaml` file which needs to be provided to the Kubermatic API server. 
+`datacenter.yaml` file which needs to be provided to the Kubermatic API server.
 
 ### Dynamic Datacenters
 
@@ -242,9 +240,9 @@ To delete the datacenter, just click on the trash icon in the admin panel:
 
 ### Management through static files - datacenter.yaml
 
-This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file. 
+This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file.
 
-In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect. 
+In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect.
 
 Example file:
 
@@ -330,6 +328,3 @@ datacenters:
         # Digitalocean region for the nodes
         region: ams2
 ```
-
-
-

--- a/content/kubermatic/v2.18/architecture/requirements/cluster_requirements/_index.en.md
+++ b/content/kubermatic/v2.18/architecture/requirements/cluster_requirements/_index.en.md
@@ -8,28 +8,32 @@ weight = 15
 ## Requirements
 
 ### Master Cluster
+
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in [Highly Available setup]({{< ref "../../../guides/installation/install_ha_kubernetes/">}}) with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
+
 * Six or more machines running one of:
   * Ubuntu 16.04+
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
 ### User Cluster
+
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
+
 * One or more machines running one of:
   * Ubuntu 16.04+
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.18/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/v2.18/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -108,8 +108,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 
@@ -187,7 +185,7 @@ Example specs for different providers:
     spec:
       alibaba:
         region: "eu1"
-    
+
   #==================================
   #============= Anexia ============
   #==================================
@@ -209,7 +207,7 @@ Datacenters are a part of the Seed resource and need to be managed by an Kuberma
 
 The EE offers 2 different ways to manage the datacenters. One way is using the dynamic datacenters feature through which
 admins can manage Datacenters on Seeds through API/UI. This is the preferred and recommended way. The other way is through the
-`datacenter.yaml` file which needs to be provided to the Kubermatic API server. 
+`datacenter.yaml` file which needs to be provided to the Kubermatic API server.
 
 ### Dynamic Datacenters
 
@@ -243,9 +241,9 @@ To delete the datacenter, just click on the trash icon in the admin panel:
 
 ### Management through static files - datacenter.yaml
 
-This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file. 
+This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file.
 
-In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect. 
+In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect.
 
 Example file:
 
@@ -331,6 +329,3 @@ datacenters:
         # Digitalocean region for the nodes
         region: ams2
 ```
-
-
-

--- a/content/kubermatic/v2.19/architecture/requirements/cluster_requirements/_index.en.md
+++ b/content/kubermatic/v2.19/architecture/requirements/cluster_requirements/_index.en.md
@@ -16,7 +16,7 @@ The Master Cluster hosts the KKP components and might also act as a seed cluster
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
@@ -29,7 +29,7 @@ The User Cluster is a Kubernetes cluster created and managed by KKP. The exact r
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.19/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -107,8 +107,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 
@@ -186,7 +184,7 @@ Example specs for different providers:
     spec:
       alibaba:
         region: "eu1"
-    
+
   #==================================
   #============= Anexia ============
   #==================================
@@ -208,7 +206,7 @@ Datacenters are a part of the Seed resource and need to be managed by an Kuberma
 
 The EE offers 2 different ways to manage the datacenters. One way is using the dynamic datacenters feature through which
 admins can manage Datacenters on Seeds through API/UI. This is the preferred and recommended way. The other way is through the
-`datacenter.yaml` file which needs to be provided to the Kubermatic API server. 
+`datacenter.yaml` file which needs to be provided to the Kubermatic API server.
 
 ### Dynamic Datacenters
 
@@ -242,9 +240,9 @@ To delete the datacenter, just click on the trash icon in the admin panel:
 
 ### Management through static files - datacenter.yaml
 
-This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file. 
+This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file.
 
-In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect. 
+In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect.
 
 Example file:
 
@@ -330,6 +328,3 @@ datacenters:
         # Digitalocean region for the nodes
         region: ams2
 ```
-
-
-

--- a/content/kubermatic/v2.20/architecture/requirements/cluster_requirements/_index.en.md
+++ b/content/kubermatic/v2.20/architecture/requirements/cluster_requirements/_index.en.md
@@ -16,7 +16,7 @@ The Master Cluster hosts the KKP components and might also act as a seed cluster
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
@@ -29,7 +29,7 @@ The User Cluster is a Kubernetes cluster created and managed by KKP. The exact r
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.20/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/administration/dynamic_data_centers/_index.en.md
@@ -107,8 +107,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 
@@ -186,7 +184,7 @@ Example specs for different providers:
     spec:
       alibaba:
         region: "eu1"
-    
+
   #==================================
   #============= Anexia ============
   #==================================
@@ -208,7 +206,7 @@ Datacenters are a part of the Seed resource and need to be managed by an Kuberma
 
 The EE offers 2 different ways to manage the datacenters. One way is using the dynamic datacenters feature through which
 admins can manage Datacenters on Seeds through API/UI. This is the preferred and recommended way. The other way is through the
-`datacenter.yaml` file which needs to be provided to the Kubermatic API server. 
+`datacenter.yaml` file which needs to be provided to the Kubermatic API server.
 
 ### Dynamic Datacenters
 
@@ -242,9 +240,9 @@ To delete the datacenter, just click on the trash icon in the admin panel:
 
 ### Management through static files - datacenter.yaml
 
-This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file. 
+This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file.
 
-In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect. 
+In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect.
 
 Example file:
 
@@ -330,6 +328,3 @@ datacenters:
         # Digitalocean region for the nodes
         region: ams2
 ```
-
-
-

--- a/content/kubermatic/v2.21/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/v2.21/architecture/requirements/cluster-requirements/_index.en.md
@@ -8,28 +8,32 @@ weight = 15
 ## Requirements
 
 ### Master Cluster
+
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in [Highly Available setup]({{< relref "../../../installation/install-ha-kubernetes/">}}) with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
+
 * Six or more machines running one of:
   * Ubuntu 16.04+
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
 ### User Cluster
+
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
+
 * One or more machines running one of:
   * Ubuntu 16.04+
   * Debian 9
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.21/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/v2.21/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -107,8 +107,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 
@@ -186,7 +184,7 @@ Example specs for different providers:
     spec:
       alibaba:
         region: "eu1"
-    
+
   #==================================
   #============= Anexia ============
   #==================================
@@ -208,7 +206,7 @@ Datacenters are a part of the Seed resource and need to be managed by an Kuberma
 
 The EE offers 2 different ways to manage the datacenters. One way is using the dynamic datacenters feature through which
 admins can manage Datacenters on Seeds through API/UI. This is the preferred and recommended way. The other way is through the
-`datacenter.yaml` file which needs to be provided to the Kubermatic API server. 
+`datacenter.yaml` file which needs to be provided to the Kubermatic API server.
 
 ### Dynamic Datacenters
 
@@ -242,9 +240,9 @@ To delete the datacenter, just click on the trash icon in the admin panel:
 
 ### Management through static files - datacenter.yaml
 
-This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file. 
+This option is activated by setting the `datacenters` flag on the Kubermatic API server and providing the path to the `datacenters.yaml` file.
 
-In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect. 
+In this option all the Seeds and datacenters used in KKP will be taken from this file, Seed objects in the cluster won't have any effect.
 
 Example file:
 
@@ -330,6 +328,3 @@ datacenters:
         # Digitalocean region for the nodes
         region: ams2
 ```
-
-
-

--- a/content/kubermatic/v2.22/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/v2.22/architecture/requirements/cluster-requirements/_index.en.md
@@ -6,28 +6,32 @@ weight = 15
 +++
 
 ## Master Cluster
+
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in a highly-available setup with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
+
 * Six or more machines running one of:
   * Ubuntu 20.04+
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
 ## User Cluster
+
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
+
 * One or more machines running one of:
   * Ubuntu 20.04+
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.22/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -106,8 +106,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 

--- a/content/kubermatic/v2.23/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/v2.23/architecture/requirements/cluster-requirements/_index.en.md
@@ -6,28 +6,32 @@ weight = 15
 +++
 
 ## Master Cluster
+
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in a highly-available setup with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
+
 * Six or more machines running one of:
   * Ubuntu 20.04+
   * Debian 10
-  * CentOS 7
+  * Flatcar
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
 ## User Cluster
+
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
+
 * One or more machines running one of:
-  * Ubuntu 20.04+
+  * Flatcar
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.23/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -106,8 +106,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 

--- a/content/kubermatic/v2.24/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/requirements/cluster-requirements/_index.en.md
@@ -6,28 +6,32 @@ weight = 15
 +++
 
 ## Master Cluster
+
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in a highly-available setup with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
+
 * Six or more machines running one of:
   * Ubuntu 20.04+
   * Debian 10
-  * CentOS 7
+  * Flatcar
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
 ## User Cluster
+
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
+
 * One or more machines running one of:
-  * Ubuntu 20.04+
+  * Flatcar
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.24/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/v2.24/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -106,8 +106,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 

--- a/content/kubermatic/v2.25/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/requirements/cluster-requirements/_index.en.md
@@ -6,28 +6,32 @@ weight = 15
 +++
 
 ## Master Cluster
+
 The Master Cluster hosts the KKP components and might also act as a seed cluster and host the master components of user clusters (see [Architecture]({{< ref "../../../architecture/">}})). Therefore, it should run in a highly-available setup with at least 3 master nodes and 3 worker nodes.
 
 **Minimal Requirements:**
+
 * Six or more machines running one of:
   * Ubuntu 20.04+
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 4 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 
 ## User Cluster
+
 The User Cluster is a Kubernetes cluster created and managed by KKP. The exact requirements may depend on the type of workloads that will be running in the user cluster.
 
 **Minimal Requirements:**
+
 * One or more machines running one of:
   * Ubuntu 20.04+
   * Debian 10
   * CentOS 7
   * RHEL 7
-  * Container Linux (tested with 1576.4.0)
+  * Flatcar
 * 2 GB or more of RAM per machine (any less will leave little room for your apps)
 * 2 CPUs or more
 * Full network connectivity between all machines in the cluster (public or private network is fine)

--- a/content/kubermatic/v2.25/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
+++ b/content/kubermatic/v2.25/tutorials-howtos/administration/dynamic-data-centers/_index.en.md
@@ -106,8 +106,6 @@ Example specs for different providers:
           ubuntu: "ami-07e101c2aebc37691"
           # Must be CentOS 7, defaults to https://aws.amazon.com/marketplace/pp/B00O7WM7QW
           centos: "ami-02eac2c0129f6376b"
-          # CoreOS Container Linux, defaults to https://coreos.com/os/docs/latest/booting-on-ec2.html
-          coreos: "ami-08e58b93705fb503f"
         # Region to use for nodes
         region: us-east-1
 


### PR DESCRIPTION
CoreOS was removed from the list of supported operating systems in [KKP 2.17](https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.17.md#:~:text=Remove%20CoreOS%20Support)