### PR TITLE
fix image URLs in KKP main branch docs

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/networking/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/networking/_index.en.md
@@ -14,16 +14,16 @@ The [expose strategy]({{< ref "../../../../tutorials-howtos/networking/expose-st
 This section explains how the connection between user clusters and the control plane is established, as well as the general networking concept in KKP.
 
 
-![KKP Network](@/images/main/concepts/architecture/network.png?classes=shadow,border "This diagram illustrated the necessary connections for KKP.")
+![KKP Network](@/images/concepts/architecture/network.png?classes=shadow,border "This diagram illustrated the necessary connections for KKP.")
 
 The following diagrams illustrate all available [expose strategy]({{< ref "../../../../tutorials-howtos/networking/expose-strategies" >}}) available in KKP.
 They define how user cluster connect to their control plane and how users connect to the cluster apiserver.
 
-![KKP NodePort](@/images/main/concepts/architecture/expose-np.png?classes=shadow,border "NodePort")
+![KKP NodePort](@/images/concepts/architecture/expose-np.png?classes=shadow,border "NodePort")
 
-![KKP Tunneling](@/images/main/concepts/architecture/expose-tunnel.png?classes=shadow,border "Tunneling")
+![KKP Tunneling](@/images/concepts/architecture/expose-tunnel.png?classes=shadow,border "Tunneling")
 
-![KKP LoadBalancer](@/images/main/concepts/architecture/expose-lb.png?classes=shadow,border "LoadBalancer")
+![KKP LoadBalancer](@/images/concepts/architecture/expose-lb.png?classes=shadow,border "LoadBalancer")
 
 Required accessible ports:
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
@@ -45,7 +45,7 @@ spec:
 The quota fields use the [ResourceQuantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity) to
 represent the values. One note is that CPU is denoted in single integer numbers.
 
-![Manage Quotas](@/images/main/architecture/concepts/resource-quotas/quota-menu.png?classes=shadow,border "Manage Quotas")
+![Manage Quotas](@/images/architecture/concepts/resource-quotas/quota-menu.png?classes=shadow,border "Manage Quotas")
 
 To simplify matters the UI uses GB as representation for Memory and Storage. The conversion from any value
 set in the ResourceQuota is done automatically by the API.
@@ -107,11 +107,11 @@ takes place after the MachineDeployment is created, and if quota is exceeded, th
 Users can observe the quotas being enforced (with a message stating why) on the User clusters Machine Deployment, in the form
 of Events.
 
-![Enforced Quota](@/images/main/architecture/concepts/resource-quotas/enforced.png?classes=shadow,border "Enforced Quota")
+![Enforced Quota](@/images/architecture/concepts/resource-quotas/enforced.png?classes=shadow,border "Enforced Quota")
 
 Furthermore, a project quota widget of the active project is visible in the dashboard, which shows what is the quota usage.
 
-![Quota Widget](@/images/main/architecture/concepts/resource-quotas/widget.png?classes=shadow,border "Quota Widget")
+![Quota Widget](@/images/architecture/concepts/resource-quotas/widget.png?classes=shadow,border "Quota Widget")
 
 ## Some Additional Information
 

--- a/content/kubermatic/main/architecture/iam-role-based-access-control/groups-support/_index.en.md
+++ b/content/kubermatic/main/architecture/iam-role-based-access-control/groups-support/_index.en.md
@@ -17,11 +17,11 @@ enterprise = true
 
 Group bindings can be configured from the "Groups" project panel.
 
-![Group Bindings Overview](@/images/main/architecture/group-rbac-view.png)
+![Group Bindings Overview](@/images/architecture/group-rbac-view.png)
 
 From this view, new group bindings can be created via the "Add Group" button.
 
-![Group Binding Wizard](@/images/main/architecture/group-rbac-add.png)
+![Group Binding Wizard](@/images/architecture/group-rbac-add.png)
 
 Be aware that group names are not further validated as KKP does not have access to a complete list of groups in the OIDC backend. This way, group permissions can be pre-provisioned even if no user with a specific group membership has signed into KKP yet.
 

--- a/content/kubermatic/main/architecture/monitoring-logging-alerting/_index.en.md
+++ b/content/kubermatic/main/architecture/monitoring-logging-alerting/_index.en.md
@@ -16,4 +16,4 @@ Kubermatic Monitoring, Logging & Alerting (MLA) consists of two stacks:
 
 [User Cluster MLA Stack]({{< ref "./user-cluster/">}}) monitors applications running in the user clusters as well as system components running in the user clusters. All KKP users can access monitoring data of the user clusters under projects they are members of.
 
-![KKP MLA Architecture](@/images/main/architecture/kkp-mla-architecture.png?classes=shadow,border "KKP MLA Architecture")
+![KKP MLA Architecture](@/images/architecture/kkp-mla-architecture.png?classes=shadow,border "KKP MLA Architecture")

--- a/content/kubermatic/main/architecture/monitoring-logging-alerting/master-seed/_index.en.md
+++ b/content/kubermatic/main/architecture/monitoring-logging-alerting/master-seed/_index.en.md
@@ -15,7 +15,7 @@ There is a single Prometheus service in each seed cluster's `monitoring` namespa
 
 Along the seed-level Prometheus, there is a single alertmanager running in the seed, which *all* Prometheus instances are using to relay their alerts (i.e. the Prometheus inside the customer clusters send their alerts to the seed cluster's alertmanager).
 
-![Monitoring architecture diagram](@/images/main/monitoring/architecture/architecture.png)
+![Monitoring architecture diagram](@/images/monitoring/architecture/architecture.png)
 
 ## Federation
 

--- a/content/kubermatic/main/architecture/monitoring-logging-alerting/user-cluster/_index.en.md
+++ b/content/kubermatic/main/architecture/monitoring-logging-alerting/user-cluster/_index.en.md
@@ -22,7 +22,7 @@ Unlike the [Master / Seed Cluster MLA stack]({{< ref "../master-seed/">}}), it i
 
 ## Architecture
 
-![Monitoring architecture diagram](@/images/main/monitoring/user-cluster/architecture.png)
+![Monitoring architecture diagram](@/images/monitoring/user-cluster/architecture.png)
 
 ### User Cluster Components
 When User Cluster MLA is enabled in a KKP user cluster, it automatically deploys two components into it - Prometheus and Loki Promtail. These components are configured to stream (remote write) the logs and metrics into backends running in the Seed Cluster (Cortex for metrics and Loki-Distributed for logs). The connection between the user cluster components and Seed cluster components is secured by HTTPS with mutual TLS certificate authentication.

--- a/content/kubermatic/main/architecture/supported-providers/edge/_index.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/edge/_index.en.md
@@ -52,4 +52,4 @@ to be executed on the target device you want to add as a worker node to your clu
 Currently, the edge provider only support Ubuntu 20.04 and 22.04 as an operating system. More support for other operating system will be added in the future.
 {{% /notice %}}
 
-![Edge Machine Deployment Window](@/images/main/architecture/supported-providers/edge/edge-machine-deployment-window.png?classes=shadow,border "Edge Machine Deployment Window")
+![Edge Machine Deployment Window](@/images/architecture/supported-providers/edge/edge-machine-deployment-window.png?classes=shadow,border "Edge Machine Deployment Window")

--- a/content/kubermatic/main/architecture/supported-providers/kubevirt/_index.en.md
+++ b/content/kubermatic/main/architecture/supported-providers/kubevirt/_index.en.md
@@ -7,7 +7,7 @@ weight = 5
 
 ## Architecture
 
-![KubeVirt Cloud Provider Architecture](@/images/main/architecture/supported-providers/kubevirt/architecture.png?classes=shadow,border "KubeVirt Cloud Provider Architecture")
+![KubeVirt Cloud Provider Architecture](@/images/architecture/supported-providers/kubevirt/architecture.png?classes=shadow,border "KubeVirt Cloud Provider Architecture")
 
 ## Installation And Configuration
 
@@ -141,7 +141,7 @@ Follow the official [Grafana documentation](https://grafana.com/docs/grafana/lat
 
 We provide a Virtual Machine templating functionality over [Instance Types and Preferences](https://kubevirt.io/user-guide/virtual_machines/instancetypes/).
 
-![Instance Types and Preferences](@/images/main/architecture/supported-providers/kubevirt/instance-type.png?classes=shadow,border "Instance Types and Preferences")
+![Instance Types and Preferences](@/images/architecture/supported-providers/kubevirt/instance-type.png?classes=shadow,border "Instance Types and Preferences")
 
 You can use our standard
 
@@ -187,7 +187,7 @@ this allows us to spread Virtual Machine equally across a cluster.
 It is possible to change the default behaviour and create your own topology combined with Node Affinity Presets.
 You can do it by expanding *ADVANCED SCHEDULING SETTINGS* on the initial nodes dashboard page.
 
-![Instance Types and Preferences](@/images/main/architecture/supported-providers/kubevirt/scheduling-form.png?classes=shadow,border "Advanced Scheduling Settings")
+![Instance Types and Preferences](@/images/architecture/supported-providers/kubevirt/scheduling-form.png?classes=shadow,border "Advanced Scheduling Settings")
 
 - `Node Affinity Preset Key` refers to the key of KubeVirt infra node labels.
 - `Node Affinity Preset Values` refers to the values of KubeVirt infra node labels.
@@ -346,7 +346,7 @@ After this step, it is required to follow the [Update LoadBalancer selectors](#u
 Right after the upgrade it is required to update Machine Deployment object (this will trigger Machines rotation).
 You can do it from the KKP Dashboard which is recommended approach as you will be guided with the possible options.
 
-![Machine Deployment Edit](@/images/main/architecture/supported-providers/kubevirt/mc-edit.png?classes=shadow,border "Machine Deployment Edit")
+![Machine Deployment Edit](@/images/architecture/supported-providers/kubevirt/mc-edit.png?classes=shadow,border "Machine Deployment Edit")
 
 The alternative is to directly change Machine Deployment objects over `kubectl apply`.
 Take a look into [the example](https://github.com/kubermatic/machine-controller/blob/v1.56.0/examples/kubevirt-machinedeployment.yaml) to see what has been changed.

--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
@@ -23,7 +23,7 @@ with Docker as container runtime.
 It is necessary to migrate **existing clusters and cluster templates** to containerd before proceeding. This can be done either via the Kubermatic Dashboard
 or with `kubectl`. On the Dashboard, just edit the cluster or cluster template, change the _Container Runtime_ field to `containerd` and save your changes.
 
-![Change Container Runtime](@/images/main/installation/upgrade-container-runtime.png?classes=shadow,border&height=200 "Change Container Runtime")
+![Change Container Runtime](@/images/installation/upgrade-container-runtime.png?classes=shadow,border&height=200 "Change Container Runtime")
 
 If using `kubectl`, update the `containerRuntime` field that is part of the [`Cluster` spec]({{< ref "../../../references/crds/#clusterspec" >}})
 and replace `docker` with `containerd`, e.g. by using `kubectl edit cluster <cluster name>` or by using `kubectl patch`:

--- a/content/kubermatic/main/tutorials-howtos/administration/admin-panel/backup-buckets/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/admin-panel/backup-buckets/_index.en.md
@@ -6,7 +6,7 @@ weight = 20
 
 Through the Backup Destinations settings you can enable and configure the new etcd backups for each Seed.
 
-![Backup Destinations](@/images/main/tutorials/backups/backup-destinations.png?classes=shadow,border "Backup Destinations Settings View")
+![Backup Destinations](@/images/tutorials/backups/backup-destinations.png?classes=shadow,border "Backup Destinations Settings View")
 
 
 ### Etcd Backup Settings
@@ -27,11 +27,11 @@ To add a new backup destination, just click on the `Add Destination` button on t
 When a destination is added, credentials also need to be added for the bucket. To do that, click on the `Edit Credentials`
 button and set the credentials. When credentials are properly set, the green checkmark appears and the destination can be used.
 
-![Add Backup Destination](@/images/main/tutorials/backups/add-backup-destination.png?classes=shadow,border "Backup Destination Settings Add")
+![Add Backup Destination](@/images/tutorials/backups/add-backup-destination.png?classes=shadow,border "Backup Destination Settings Add")
 
 To edit, just click on the `Edit Destination` pen icon on the right
 
-![Edit Backup Destination](@/images/main/tutorials/backups/edit-backup-destination.png?classes=shadow,border "Backup Destination Settings Edit")
+![Edit Backup Destination](@/images/tutorials/backups/edit-backup-destination.png?classes=shadow,border "Backup Destination Settings Edit")
 
 ### Credentials
 
@@ -40,7 +40,7 @@ button and set the credentials. When credentials are properly set, the green che
 
 For security reasons, the API/UI does not offer a way to get the current credentials.
 
-![Edit Credentials](@/images/main/tutorials/backups/edit-backup-dest-credentials.png?classes=shadow,border "Backup Destination Credentials Edit")
+![Edit Credentials](@/images/tutorials/backups/edit-backup-dest-credentials.png?classes=shadow,border "Backup Destination Credentials Edit")
 
 To see how to make backups and restore your cluster, check the [Etcd Backup and Restore Tutorial]({{< ref "../../../etcd-backups" >}}).
 
@@ -76,4 +76,4 @@ Default EtcdBackupConfig that is created:
 ...
 ```
 
-![Set Default Destination](@/images/main/tutorials/backups/set-backup-dest-as-default.png?classes=shadow,border "Set Backup Destination as Default")
+![Set Default Destination](@/images/tutorials/backups/set-backup-dest-as-default.png?classes=shadow,border "Set Backup Destination as Default")

--- a/content/kubermatic/main/tutorials-howtos/administration/admin-panel/seed-configurations/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/admin-panel/seed-configurations/_index.en.md
@@ -13,13 +13,13 @@ The Seed Configuration section is a readonly view page. This page does not provi
 
 ### Seed Configurations
 
-![Seed Configurations](@/images/main/tutorials/seed-configurations/seed-confgurations.png?classes=shadow,border "Seed Configurations List View")
+![Seed Configurations](@/images/tutorials/seed-configurations/seed-confgurations.png?classes=shadow,border "Seed Configurations List View")
 
 
 ### Seed Details
 
 The following page presents Seed's statistics along with tables of utilization broken down respectively per Providers and Datacenters.
 
-![Providers](@/images/main/tutorials/seed-configurations/seed-confgurations-details.png?classes=shadow,border "Available providers per seed")
+![Providers](@/images/tutorials/seed-configurations/seed-confgurations-details.png?classes=shadow,border "Available providers per seed")
 
-![Datacenters](@/images/main/tutorials/seed-configurations/seed-confgurations-provider-datacenters.png?classes=shadow,border "Associated clusters per datacenter")
+![Datacenters](@/images/tutorials/seed-configurations/seed-confgurations-provider-datacenters.png?classes=shadow,border "Associated clusters per datacenter")

--- a/content/kubermatic/main/tutorials-howtos/aws-assume-role/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/aws-assume-role/_index.en.md
@@ -11,7 +11,7 @@ Using KKP you are able to use the `AssumeRole` feature to easily deploy user clu
 
 ## How it Works
 
-![Running user clusters using an assumed IAM role](@/images/main/tutorials/aws-assume-role-sequence-diagram.png?width=1000&classes=shadow,border "Running user clusters using an assumed IAM role")
+![Running user clusters using an assumed IAM role](@/images/tutorials/aws-assume-role-sequence-diagram.png?width=1000&classes=shadow,border "Running user clusters using an assumed IAM role")
 
 ## Benefits
   * Privilege escalation
@@ -36,7 +36,7 @@ During cluster creation choose AWS as your provider and configure the cluster to
 After entering your AWS access credentials (access key ID and secret access key) choose "Enable Assume Role" (1), enter the ARN of the IAM role you would like to assume in field (2) (IAM role ARN should be in the format `arn:aws:iam::ID_OF_AWS_ACCOUNT_B:role/ROLE_NAME`) and if the IAM role has an optional `External ID` add it in field (3).
 After that you can proceed as usual.
 
-![Enabling AWS AssumeRole in the cluster creation wizard](@/images/main/tutorials/aws-assume-role-wizard.png?classes=shadow,border "Enabling AWS AssumeRole in the cluster creation wizard")
+![Enabling AWS AssumeRole in the cluster creation wizard](@/images/tutorials/aws-assume-role-wizard.png?classes=shadow,border "Enabling AWS AssumeRole in the cluster creation wizard")
 
 ## Notes
 Please note that KKP has no way to clean up clusters after a trust relationship has been removed.

--- a/content/kubermatic/main/tutorials-howtos/cluster-backup/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/cluster-backup/_index.en.md
@@ -22,7 +22,7 @@ KKP Velero integration provides project owners/editors with the ability to centr
 ### Using Integrated User Cluster Backup
 
 Cluster backup is disabled by default as an experimental feature. To use it, the KKP administrator needs to enable it the admin panel.
-![Enable Backup](@/images/main/tutorials/cluster-backup/enable-bakcup-kkp.png?classes=shadow,border "Enable Backup")
+![Enable Backup](@/images/tutorials/cluster-backup/enable-bakcup-kkp.png?classes=shadow,border "Enable Backup")
 
 Once UI dashboard options are available, the project owner must defined at least one Cluster Backup Storage Location.
 
@@ -35,7 +35,7 @@ The `ClusterBackupStorageLocation` resource is a simple wrapper for Velero's [Ba
 When Custer Backup is enabled for a user cluster, KKP will deploy a managed instance of Velero on the user cluster, and propagate the required Velero `BackupStorageLocation` to the user cluster, with a special prefix to avoid collisions with other user clusters that could be using the same storage.
 
 
-![Create ClusterBackupStorageLocation](@/images/main/tutorials/cluster-backup/create-cbsl.png?classes=shadow,border "Create ClusterBackupStorageLocation")
+![Create ClusterBackupStorageLocation](@/images/tutorials/cluster-backup/create-cbsl.png?classes=shadow,border "Create ClusterBackupStorageLocation")
 
 For simplicity, the KKP UI requires the minimal required values to enabled a working Velero Backup Storage Location. If further parameters are needed, they can be added by editing the `ClusterBackupStorageLocation` resources on the Seed cluster:
 
@@ -52,11 +52,11 @@ The KKP control plane nodes need to have access to s3 endpoint defined in the St
 #### Enabling Backup for User Clusters
 Cluster Backup can be used for existing clusters and newly created ones. When creating a new user cluster, you can enable the `Cluster Backup` option in the cluster creation wizard. Once enabled, you will be required to assign the Backup Storage Location that you have created previously.
 
-![Enable Backup for New Clusters](@/images/main/tutorials/cluster-backup/enable-backup-new-cluster.png?classes=shadow,border "Enable Backup for New Clusters")
+![Enable Backup for New Clusters](@/images/tutorials/cluster-backup/enable-backup-new-cluster.png?classes=shadow,border "Enable Backup for New Clusters")
 
 
 For existing clusters, you can edit the cluster to assign the required Cluster Backup Location:
-![Edit Existing Cluster](@/images/main/tutorials/cluster-backup/enable-backup-edit-cluster.png?classes=shadow,border "Edit Existing Cluster")
+![Edit Existing Cluster](@/images/tutorials/cluster-backup/enable-backup-edit-cluster.png?classes=shadow,border "Edit Existing Cluster")
 
 {{% notice note %}}
 Velero's Backup Storage Location Spec supports using s3 prefixes. When the storage location is propagated into the user cluster, an additional prefix of the Project ID and Cluster ID is added to avoid collision and provide isolation in case the storage location is used for multiple clusters.
@@ -75,7 +75,7 @@ Using the user cluster Kubernetes API, you can also create these resources using
 As with the `CBSL`, KKP UI allows the user to set the minimal required options to create a backup configuration. Since the backup process is started immediately after creation, it's not possible to edit it via the Kubernetes API. If you need to customize your backup further, you should use a Schedule.
 
 To configure a new one-time backup, go to the Backups list, select the cluster you would like to create the backup for from the drop-down list, and click `Create Cluster Backup`.
-![Create Backup](@/images/main/tutorials/cluster-backup/create-backup.png?classes=shadow,border "Create Backup")
+![Create Backup](@/images/tutorials/cluster-backup/create-backup.png?classes=shadow,border "Create Backup")
 
 
 You can select the Namespaces that you want to include in this backup configuration from the dropdown list. Note that this list of Namespaces is directly fetched from your cluster, so you need to create the Namespaces before configuring the backup.
@@ -91,7 +91,7 @@ Creating scheduled backups is almost identical to one-time backups. Configuratio
 
 For schedules, you also need to add a cron-style schedule to perform the backups.
 
-![Create Backup Schedule](@/images/main/tutorials/cluster-backup/create-schedule.png?classes=shadow,border "Create Backup Schedule")
+![Create Backup Schedule](@/images/tutorials/cluster-backup/create-schedule.png?classes=shadow,border "Create Backup Schedule")
 
 
 ##### Downloading Backups
@@ -105,13 +105,13 @@ To restore a specific backup, go to the Backups page, select your cluster and fi
 
 Velero restores backups by creating a `Restore` API resource on the clusters and then reconciles it.
 
-![Create Restore](@/images/main/tutorials/cluster-backup/create-restore.png?classes=shadow,border "Create Restore")
+![Create Restore](@/images/tutorials/cluster-backup/create-restore.png?classes=shadow,border "Create Restore")
 
 Simply, set a name for the restore request, and select the Namespaces that you would like to restore.
 
 You can later track the restore status from the Restore page.
 
-![Restore Status](@/images/main/tutorials/cluster-backup/restore-status.png?classes=shadow,border "Restore Status")
+![Restore Status](@/images/tutorials/cluster-backup/restore-status.png?classes=shadow,border "Restore Status")
 
 
 

--- a/content/kubermatic/main/tutorials-howtos/cluster-templates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/cluster-templates/_index.en.md
@@ -15,13 +15,13 @@ reusable cluster template object. The more details about cluster template you ca
 
 There are two ways to create cluster template. First, you can do this during the cluster creation in the last `Summary` step:
 
-![Create from cluster wizard](@/images/main/tutorials/cluster-template/create-from-cluster-wizard.png?classes=shadow,border "Cluster Template creation")
+![Create from cluster wizard](@/images/tutorials/cluster-template/create-from-cluster-wizard.png?classes=shadow,border "Cluster Template creation")
 
 Press button `Save Cluster Template` to create the template. Now you can specify the name and scope.
 
 The newly created cluster template is visible in `Cluster Templates` menu:
 
-![Create from cluster wizard](@/images/main/tutorials/cluster-template/cluster-template-menu.png?classes=shadow,border "Cluster Template view")
+![Create from cluster wizard](@/images/tutorials/cluster-template/cluster-template-menu.png?classes=shadow,border "Cluster Template view")
 
 You can also create a cluster template in this view. You will be redirected to the cluster creation wizard.
 
@@ -37,17 +37,17 @@ On the right side, you can find the action buttons:
 
 User can pick the desired template and specify number of cluster instances. The cluster template doesn't create any link to the clusters. They work independently.
 
-![Create from cluster template wizard](@/images/main/tutorials/cluster-template/create-cluster.png?classes=shadow,border "Create Clusters from Template")
+![Create from cluster template wizard](@/images/tutorials/cluster-template/create-cluster.png?classes=shadow,border "Create Clusters from Template")
 
 ## Edit Cluster Template
 
 From cluster template list, users can select to edit the cluster template, the wizard will walk you through each step from the cluster template creation wizard.
-![Edit cluster template](@/images/main/tutorials/cluster-template/edit-cluster-template.png?classes=shadow,border "Edit Cluster Template")
+![Edit cluster template](@/images/tutorials/cluster-template/edit-cluster-template.png?classes=shadow,border "Edit Cluster Template")
 
 Finally, user can choose to either update the existing cluster template or create a new cluster template that contains all the modifications.
 
-![Create from cluster template wizard](@/images/main/tutorials/cluster-template/edit-cluster-template-summary.png?classes=shadow,border "Save Cluster Template")
+![Create from cluster template wizard](@/images/tutorials/cluster-template/edit-cluster-template-summary.png?classes=shadow,border "Save Cluster Template")
 
 ## Delete Cluster Template
 
-![Delete from cluster template wizard](@/images/main/tutorials/cluster-template/delete-template.png?classes=shadow,border "Delete Cluster Template")
+![Delete from cluster template wizard](@/images/tutorials/cluster-template/delete-template.png?classes=shadow,border "Delete Cluster Template")

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/_index.en.md
@@ -32,7 +32,7 @@ KKP allows connecting any existing Kubernetes cluster as an external cluster to 
 
 - To add a new external cluster go to `External Clusters` page and Click the `Import External Cluster` button.
 
-![Import External Cluster](@/images/main/tutorials/external-clusters/add-external-cluster.png "Import External Cluster")
+![Import External Cluster](@/images/tutorials/external-clusters/add-external-cluster.png "Import External Cluster")
 
 - Select the Kubernetes cloud provider. You can add or create the following external clusters:
 
@@ -46,25 +46,25 @@ KKP allows connecting any existing Kubernetes cluster as an external cluster to 
 It is important that the kubeconfig used to connect the cluster is using standard authentication mechanisms like certificates or ServiceAccount tokens. OIDC or provider-specific plugins are not supported.
 {{% /notice %}}
 
-![Connect Cluster](@/images/main/tutorials/external-clusters/connect.png "Connect Cluster")
+![Connect Cluster](@/images/tutorials/external-clusters/connect.png "Connect Cluster")
 
 {{% notice info %}}
 If an existing kubeconfig uses custom authentication mechanisms, `kubermatic-installer convert-kubeconfig` can (optionally) be used to create a ServiceAccount on the external cluster and fetch its token into a new kubeconfig.
 {{% /notice %}}
 
-![Provide kubeconfig](@/images/main/tutorials/external-clusters/custom-cluster-credentials.png "Provide kubeconfig")
+![Provide kubeconfig](@/images/tutorials/external-clusters/custom-cluster-credentials.png "Provide kubeconfig")
 
 You can then see the details of the cluster.
 
-![Custom Cluster](@/images/main/tutorials/external-clusters/bringyourown.png "BringYourOwn Cluster")
+![Custom Cluster](@/images/tutorials/external-clusters/bringyourown.png "BringYourOwn Cluster")
 
 ## Create External Cluster
 
 KKP allows creating a Kubernetes cluster on AKS/GKE/EKS and import it as an External Cluster.
 
-![Create External Cluster](@/images/main/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
+![Create External Cluster](@/images/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
 
-![External Cluster List](@/images/main/tutorials/external-clusters/externalcluster-list.png "External Cluster List")
+![External Cluster List](@/images/tutorials/external-clusters/externalcluster-list.png "External Cluster List")
 
 ## Delete Cluster:
 
@@ -74,26 +74,26 @@ Delete operation is not allowed for imported clusters.
 
 Cluster can be  Deleted by clicking on the delete icon next to the cluster you want to delete or from the cluster details page, which will delete and disconnect the cluster from the provider.
 
-![Delete External Cluster](@/images/main/tutorials/external-clusters/delete-externalcluster.png "Delete External Cluster")
+![Delete External Cluster](@/images/tutorials/external-clusters/delete-externalcluster.png "Delete External Cluster")
 
-![Delete External Cluster on Details Page](@/images/main/tutorials/external-clusters/delete-disconnect-page.png "Delete External Cluster on Details Page")
+![Delete External Cluster on Details Page](@/images/tutorials/external-clusters/delete-disconnect-page.png "Delete External Cluster on Details Page")
 
 ## Cluster State
 
 You can view the current state of your cluster by hovering the cursor over the small circle on the left of the cluster name.
 
 Provisioning state depicts that the cluster is getting created:
-![External Cluster Provisioning State](@/images/main/tutorials/external-clusters/provisioning-status.png "External Cluster Provisioning State")
+![External Cluster Provisioning State](@/images/tutorials/external-clusters/provisioning-status.png "External Cluster Provisioning State")
 
 Reconciling state depicts that the cluster is getting upgraded:
-![External Cluster Reconciling State](@/images/main/tutorials/external-clusters/reconciling-status.png "External Cluster Reconciling State")
+![External Cluster Reconciling State](@/images/tutorials/external-clusters/reconciling-status.png "External Cluster Reconciling State")
 
 Running state depicts that the cluster is healthy:
-![External Cluster Provisioning State](@/images/main/tutorials/external-clusters/running-status.png "External Cluster Running State")
+![External Cluster Provisioning State](@/images/tutorials/external-clusters/running-status.png "External Cluster Running State")
 
 Deleting state depicts that the cluster is getting deleted:
 
-![External Cluster Delete State](@/images/main/tutorials/external-clusters/aks-deleting.png "External Cluster Delete State")
+![External Cluster Delete State](@/images/tutorials/external-clusters/aks-deleting.png "External Cluster Delete State")
 
 ## Disconnect Cluster
 
@@ -103,11 +103,11 @@ Disconnect operation does not delete the cluster from the cloud provider.
 
 You can `Disconnect` an external cluster by clicking on the disconnect icon next to the cluster you want to disconnect or from the cluster details page, which will delete internal cluster object in KKP.
 
-![Disconnect External Cluster](@/images/main/tutorials/external-clusters/disconnect-externalcluster.png "Disconnect External Cluster")
+![Disconnect External Cluster](@/images/tutorials/external-clusters/disconnect-externalcluster.png "Disconnect External Cluster")
 
-![Disconnect External Cluster on Details Page](@/images/main/tutorials/external-clusters/disconnect-externalcluster-details-page.png "Disconnect External Cluster on Details Page")
+![Disconnect External Cluster on Details Page](@/images/tutorials/external-clusters/disconnect-externalcluster-details-page.png "Disconnect External Cluster on Details Page")
 
-![Disconnect Dialog](@/images/main/tutorials/external-clusters/disconnect.png "Disconnect Dialog")
+![Disconnect Dialog](@/images/tutorials/external-clusters/disconnect.png "Disconnect Dialog")
 
 
 ## Delete Cluster
@@ -117,4 +117,4 @@ Delete Cluster displays information in case nodes are attached
 {{% /notice %}}
 
 
-![Delete External Cluster](@/images/main/tutorials/external-clusters/delete-external-cluster-dialog.png "Delete External Cluster")
+![Delete External Cluster](@/images/tutorials/external-clusters/delete-external-cluster-dialog.png "Delete External Cluster")

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/aks/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/aks/_index.en.md
@@ -14,11 +14,11 @@ You can add an existing Azure Kubernetes Service cluster and then manage it usin
 
 - Click `Import External Cluster` button.
 
-![Add External Cluster](@/images/main/tutorials/external-clusters/external-cluster-page.png "Add External Cluster")
+![Add External Cluster](@/images/tutorials/external-clusters/external-cluster-page.png "Add External Cluster")
 
 - Pick `Azure Kubernetes Cluster` provider.
 
-![Select Provider](@/images/main/tutorials/external-clusters/connect.png "Select Provider")
+![Select Provider](@/images/tutorials/external-clusters/connect.png "Select Provider")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
@@ -36,11 +36,11 @@ The credentials should provide access rights to read & write Azure Kubernetes Se
 Validation performed will only check if the credentials have `Read` access.
 {{% /notice %}}
 
-![AKS credentials](@/images/main/tutorials/external-clusters/aks-credentials.png "AKS credentials")
+![AKS credentials](@/images/tutorials/external-clusters/aks-credentials.png "AKS credentials")
 
 - You should see the list of all available clusters. Select the one and click the `Import Cluster` button. Clusters can be imported only once in a single project. The same cluster can be imported in multiple projects.
 
-![Select AKS cluster](@/images/main/tutorials/external-clusters/select-aks-cluster.png "Select AKS cluster")
+![Select AKS cluster](@/images/tutorials/external-clusters/select-aks-cluster.png "Select AKS cluster")
 
 ## Create AKS Preset
 Admin can create a preset on a KKP cluster using KKP `Admin Panel`.
@@ -48,7 +48,7 @@ This Preset can then be used to Create/Import an AKS cluster.
 
 - Click on `Admin Panel` from the menu.
 
-![Select Admin Panel](@/images/main/tutorials/external-clusters/select-adminpanel.png "Select Admin Panel")
+![Select Admin Panel](@/images/tutorials/external-clusters/select-adminpanel.png "Select Admin Panel")
 
 - Navigate to `Provider Presets` Page and Click on `+ Create Preset` button.
 
@@ -56,34 +56,34 @@ This Preset can then be used to Create/Import an AKS cluster.
 
 - Enter Preset Name.
 
-![Provide Preset Name](@/images/main/tutorials/external-clusters/create-akspreset.png "Provide Preset Name")
+![Provide Preset Name](@/images/tutorials/external-clusters/create-akspreset.png "Provide Preset Name")
 
 - Choose `Azure Kubernetes Service` from the list of providers.
 
-![Choose AKS Preset](@/images/main/tutorials/external-clusters/choose-akspreset.png "Choose AKS Preset")
+![Choose AKS Preset](@/images/tutorials/external-clusters/choose-akspreset.png "Choose AKS Preset")
 
 -  Enter AKS credentials and Click on `Create` button.
 
-!["Enter Credentials](@/images/main/tutorials/external-clusters/enter-aks-credentials-preset.png "Enter Credentials")
+!["Enter Credentials](@/images/tutorials/external-clusters/enter-aks-credentials-preset.png "Enter Credentials")
 
 - You can now use created AKS Preset to Create or Import AKS Cluster.
 
-![Select AKS Preset](@/images/main/tutorials/external-clusters/existing-aks-preset.png "Select AKS Preset")
+![Select AKS Preset](@/images/tutorials/external-clusters/existing-aks-preset.png "Select AKS Preset")
 
 ## Cluster Details Page
 
 After the cluster is added, the KKP controller retrieves the cluster kubeconfig to display all necessary information.
 A healthy cluster has `Running` state. Otherwise, the cluster can be in the `Error` state. Move the mouse cursor over the state indicator to get more details.
 
-![AKS cluster](@/images/main/tutorials/external-clusters/aks-details.png "AKS cluster")
+![AKS cluster](@/images/tutorials/external-clusters/aks-details.png "AKS cluster")
 
 You can also expand `Events` to get information from the controller.
 
-![Cluster Events](@/images/main/tutorials/external-clusters/aks-cluster-events.png "Cluster Events")
+![Cluster Events](@/images/tutorials/external-clusters/aks-cluster-events.png "Cluster Events")
 
 You can click on `Machine Deployments` to get the details:
 
-![AKS Machine Deployment](@/images/main/tutorials/external-clusters/aks-machine-deployments.png "AKS Machine Deployment")
+![AKS Machine Deployment](@/images/tutorials/external-clusters/aks-machine-deployments.png "AKS Machine Deployment")
 
 ## Update Cluster
 
@@ -92,9 +92,9 @@ You can click on `Machine Deployments` to get the details:
 When an upgrade for the cluster is available, a little dropdown arrow will be shown beside the `Control Plane Version` on the cluster’s page.
 To start the upgrade, choose the desired version from the list of available upgrade versions and click on `Change Version`.
 
-![Upgrade Available](@/images/main/tutorials/external-clusters/aks-upgrade-available.png "Upgrade Available")
+![Upgrade Available](@/images/tutorials/external-clusters/aks-upgrade-available.png "Upgrade Available")
 
-![Upgrade AKS](@/images/main/tutorials/external-clusters/upgrade-aks.png "Upgrade AKS")
+![Upgrade AKS](@/images/tutorials/external-clusters/upgrade-aks.png "Upgrade AKS")
 
 If the version upgrade is valid, the cluster state will change to `Reconciling`.
 
@@ -108,13 +108,13 @@ Only one operation can be performed at one point of time. If the replica count i
 
 - Click on the edit icon next to the machine deployment you want to edit.
 
-![Update AKS Machine Deployment](@/images/main/tutorials/external-clusters/edit-md.png "Update AKS Machine Deployment")
+![Update AKS Machine Deployment](@/images/tutorials/external-clusters/edit-md.png "Update AKS Machine Deployment")
 
 - Upgrade Kubernetes Version. Select the Kubernetes Version from the dropdown to upgrade the machine deployment.
 
 - Scale the replicas: In the popup dialog, you can increase or decrease the number of worker nodes that are managed by this machine deployment.
 
-![Update AKS Machine Deployment](@/images/main/tutorials/external-clusters/scale-aks-md.png "Update AKS Machine Deployment")
+![Update AKS Machine Deployment](@/images/tutorials/external-clusters/scale-aks-md.png "Update AKS Machine Deployment")
 
 ## Delete Cluster
 
@@ -124,7 +124,7 @@ Delete operation is not allowed for imported clusters
 
 Delete cluster operation allows to delete the cluster from the Provider. Click on the `Delete` button.
 
-![Delete Cluster](@/images/main/tutorials/external-clusters/aks-delete-button.png
+![Delete Cluster](@/images/tutorials/external-clusters/aks-delete-button.png
  "Delete Cluster")
 
 ## Delete the Node Pool
@@ -135,7 +135,7 @@ At least one systempool is required in an AKS cluster.
 
 Navigate to the cluster overview, scroll down to machine deployments and click on the delete icon next to the machine deployment you want to delete.
 
-![Update AKS Machine Deployment](@/images/main/tutorials/external-clusters/delete-md.png "Delete AKS Machine Deployment")
+![Update AKS Machine Deployment](@/images/tutorials/external-clusters/delete-md.png "Delete AKS Machine Deployment")
 
 ## Cluster State:
 
@@ -147,4 +147,4 @@ This represents the state of the last operation attempted on this node pool, suc
 If the cluster is stopped from the Azure side, you will be able to see the current state of the cluster as stopped.
 Cluster details will not be visible as the details are fetched using kubeconfig, and the kubeconfig is not available for the stopped cluster.
 
-![AKS Cluster Stopped](@/images/main/tutorials/external-clusters/aks-stopped.png "AKS Cluster Stopped")
+![AKS Cluster Stopped](@/images/tutorials/external-clusters/aks-stopped.png "AKS Cluster Stopped")

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/aks/create-aks/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/aks/create-aks/_index.en.md
@@ -10,15 +10,15 @@ Create a cluster following these steps:
 
 - Click on `Create External Cluster` button:
 
-![Create External Cluster](@/images/main/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
+![Create External Cluster](@/images/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
 
 - Choose "Azure Kubernetes Service" from the supported providers:
 
-![Select AKS Provider](@/images/main/tutorials/external-clusters/aks-selection.png "Select AKS Provider")
+![Select AKS Provider](@/images/tutorials/external-clusters/aks-selection.png "Select AKS Provider")
 
 - Provide the credentials
 
-![Select Preset](@/images/main/tutorials/external-clusters/select-preset.png "Select Preset")
+![Select Preset](@/images/tutorials/external-clusters/select-preset.png "Select Preset")
 
 - Configure the cluster:
 
@@ -26,7 +26,7 @@ Create a cluster following these steps:
 Supported kubernetes versions 1.23.0, 1.24.0, 1.25.0 currently available for new Azure AKS clusters.
 {{% /notice %}}
 
-![Configure Cluster](@/images/main/tutorials/external-clusters/aks-cluster-settings.png "Configure Cluster")
+![Configure Cluster](@/images/tutorials/external-clusters/aks-cluster-settings.png "Configure Cluster")
 
 - Click on `Create External Cluster` button
 
@@ -64,7 +64,7 @@ Node size
 
 ## Create Node Pool
 
-![Add Node Pool](@/images/main/tutorials/external-clusters/add-md.png "Add Node Pool")
+![Add Node Pool](@/images/tutorials/external-clusters/add-md.png "Add Node Pool")
 
 - Name: The name for this node pool. Node pool must contain only lowercase letters and numbers. For Linux node pools the name cannot be longer than 12 characters, and for Windows node pools the name cannot be longer than 6 characters.
 - VM Size: The size of the virtual machines that will form the nodes in this node pool.
@@ -74,4 +74,4 @@ Node size
 - AutoScaling: Autoscaling is recommended for standard configuration.
     Set the minimum and maximum node counts for this node pool. You cannot set a lower minimum than the current node count in the node pool.
 
-![Create Node Pool](@/images/main/tutorials/external-clusters/aks-md.png "Create Node Pool")
+![Create Node Pool](@/images/tutorials/external-clusters/aks-md.png "Create Node Pool")

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/eks/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/eks/_index.en.md
@@ -14,11 +14,11 @@ You can add an existing Kubernetes cluster and then manage it using KKP.
 
 - Click the `Import External Cluster` button
 
-![Add External Cluster](@/images/main/tutorials/external-clusters/external-cluster-page.png "Add External Cluster")
+![Add External Cluster](@/images/tutorials/external-clusters/external-cluster-page.png "Add External Cluster")
 
 - Pick `Elastic Kubernetes Engine` provider.
 
-![Select Provider](@/images/main/tutorials/external-clusters/connect.png "Select Provider")
+![Select Provider](@/images/tutorials/external-clusters/connect.png "Select Provider")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
@@ -35,11 +35,11 @@ Region is also kept as a part of a preset as it is a required value to create an
 Validation performed will only check if the credentials have `Read` access.
 {{% /notice %}}
 
-![EKS credentials](@/images/main/tutorials/external-clusters/eks-credentials.png "EKS credentials")
+![EKS credentials](@/images/tutorials/external-clusters/eks-credentials.png "EKS credentials")
 
 You should see the list of all available clusters in the region specified. Select the one and click the `Import Cluster` button. Clusters can be imported only once in a single project. The same cluster can be imported in other projects.
 
-![Select EKS cluster](@/images/main/tutorials/external-clusters/select-eks-cluster.png "Select EKS cluster")
+![Select EKS cluster](@/images/tutorials/external-clusters/select-eks-cluster.png "Select EKS cluster")
 
 ## Create EKS Preset
 Admin can create a preset on a KKP cluster using KKP `Admin Panel`.
@@ -47,7 +47,7 @@ This Preset can then be used to Create/Import an EKS cluster.
 
 - Click on `Admin Panel` from the menu.
 
-![Select Admin Panel](@/images/main/tutorials/external-clusters/select-adminpanel.png "Select Admin Panel")
+![Select Admin Panel](@/images/tutorials/external-clusters/select-adminpanel.png "Select Admin Panel")
 
 - Navigate to `Provider Presets` Page and Click on `+ Create Preset` button.
 
@@ -55,34 +55,34 @@ This Preset can then be used to Create/Import an EKS cluster.
 
 - Enter Preset Name.
 
-![Provide Preset Name](@/images/main/tutorials/external-clusters/create-ekspreset.png "Provide Preset Name")
+![Provide Preset Name](@/images/tutorials/external-clusters/create-ekspreset.png "Provide Preset Name")
 
 - Choose `Elastic Kubernetes Service` from the list of providers.
 
-![Choose EKS Preset](@/images/main/tutorials/external-clusters/choose-akspreset.png "Choose EKS Preset")
+![Choose EKS Preset](@/images/tutorials/external-clusters/choose-akspreset.png "Choose EKS Preset")
 
 -  Enter EKS credentials and Click on `Create` button.
 
-![Enter Credentials](@/images/main/tutorials/external-clusters/enter-eks-credentials-preset.png "Enter Credentials")
+![Enter Credentials](@/images/tutorials/external-clusters/enter-eks-credentials-preset.png "Enter Credentials")
 
 - You can now use created EKS Preset to Create or Import EKS Cluster.
 
-![Select EKS Preset](@/images/main/tutorials/external-clusters/existing-eks-preset.png "Select EKS Preset")
+![Select EKS Preset](@/images/tutorials/external-clusters/existing-eks-preset.png "Select EKS Preset")
 
 ## Cluster Details Page
 
 After the cluster is added, the KKP controller retrieves the cluster kubeconfig to display all necessary information.
 A healthy cluster has `Running` state. Move the mouse cursor over the state indicator to get more details.
 
-![EKS cluster](@/images/main/tutorials/external-clusters/eks-details.png "EKS cluster")
+![EKS cluster](@/images/tutorials/external-clusters/eks-details.png "EKS cluster")
 
 You can also expand `Events` to get information from the controller.
 
-![Cluster Events](@/images/main/tutorials/external-clusters/eks-cluster-events.png "Cluster Events")
+![Cluster Events](@/images/tutorials/external-clusters/eks-cluster-events.png "Cluster Events")
 
 You can also click on `Machine Deployments` to get the details:
 
-![EKS Machine Deployment](@/images/main/tutorials/external-clusters/eks-machine-deployments.png "EKS Machine Deployment")
+![EKS Machine Deployment](@/images/tutorials/external-clusters/eks-machine-deployments.png "EKS Machine Deployment")
 
 ## Update Cluster
 
@@ -91,9 +91,9 @@ You can also click on `Machine Deployments` to get the details:
 To upgrade, click on the little dropdown arrow beside the `Control Plane Version` on the cluster’s page and select the version from the dropdown. For more details about EKS available Kubernetes versions
 [Amazon EKS Kubernetes versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html "Amazon EKS Kubernetes versions")
 
-![Upgrade Available](@/images/main/tutorials/external-clusters/eks-upgrade-available.png "Upgrade Available")
+![Upgrade Available](@/images/tutorials/external-clusters/eks-upgrade-available.png "Upgrade Available")
 
-![Upgrade EKS](@/images/main/tutorials/external-clusters/upgrade-eks.png "Upgrade EKS")
+![Upgrade EKS](@/images/tutorials/external-clusters/upgrade-eks.png "Upgrade EKS")
 
 If the upgrade version provided is valid, the cluster state will change to `Reconciling`
 
@@ -107,13 +107,13 @@ Only one operation can be performed at one point of time. If the replica count i
 
 - Click on the edit icon next to the machine deployment you want to edit.
 
-![Update EKS Machine Deployment](@/images/main/tutorials/external-clusters/edit-md.png "Update EKS Machine Deployment")
+![Update EKS Machine Deployment](@/images/tutorials/external-clusters/edit-md.png "Update EKS Machine Deployment")
 
 - Upgrade Kubernetes Version. Select the Kubernetes Version from the dropdown to upgrade the md.
 
 - Scale the replicas: In the popup dialog, you can increase or decrease the number of worker nodes that are managed by this machine deployment. Either specify the number of desired nodes or use the `+` or `-` to increase or decrease node count.
 
-![Update EKS Machine Deployment](@/images/main/tutorials/external-clusters/edit-eks-md.png "Update EKS Machine Deployment")
+![Update EKS Machine Deployment](@/images/tutorials/external-clusters/edit-eks-md.png "Update EKS Machine Deployment")
 
 ## Delete Cluster
 
@@ -123,14 +123,14 @@ Delete operation is not allowed for imported clusters.
 
 Delete cluster operation allows to delete the cluster from the Provider. Click on the `Delete` button.
 
-![Delete Cluster](@/images/main/tutorials/external-clusters/eks-disconnect-button.png
+![Delete Cluster](@/images/tutorials/external-clusters/eks-disconnect-button.png
  "Delete Cluster")
 
 ## Delete the Node Group
 
 Navigate to the cluster overview, scroll down to machine deployments and click on the delete icon next to the machine deployment you want to delete.
 
-![Update EKS Machine Deployment](@/images/main/tutorials/external-clusters/delete-md.png "Delete EKS Machine Deployment")
+![Update EKS Machine Deployment](@/images/tutorials/external-clusters/delete-md.png "Delete EKS Machine Deployment")
 
 ### Authenticating with EKS
 

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/eks/create-eks/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/eks/create-eks/_index.en.md
@@ -16,15 +16,15 @@ Create a cluster following these steps:
 
 - Click on `Create External Cluster` button:
 
-![Create External Cluster](@/images/main/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
+![Create External Cluster](@/images/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
 
 - Choose "Elastic Kubernetes Service" from the supported providers:
 
-![Select AKS Provider](@/images/main/tutorials/external-clusters/eks-selection.png "Select EKS Provider")
+![Select AKS Provider](@/images/tutorials/external-clusters/eks-selection.png "Select EKS Provider")
 
 - Provide the credentials:
 
-![Select Preset](@/images/main/tutorials/external-clusters/select-eks-preset.png "Select Preset")
+![Select Preset](@/images/tutorials/external-clusters/select-eks-preset.png "Select Preset")
 
 - Configure the cluster:
 
@@ -32,7 +32,7 @@ Create a cluster following these steps:
 Supported kubernetes versions 1.21.0, 1.22.0, 1.23.0, 1.24.0 currently available for new Amazon EKS clusters.
 {{% /notice %}}
 
-![Configure Cluster](@/images/main/tutorials/external-clusters/eks-settings.png "Configure Cluster")
+![Configure Cluster](@/images/tutorials/external-clusters/eks-settings.png "Configure Cluster")
 
 - Click on `Create External Cluster` button
 
@@ -78,6 +78,6 @@ Node group scaling configuration:
 - Max Count: Set the maximum number of nodes that the group can scale out to.
 - Min Count: Set the minimum number of nodes that the group can scale in to.
 
-![Add Node Group](@/images/main/tutorials/external-clusters/add-md.png "Add Node Group")
+![Add Node Group](@/images/tutorials/external-clusters/add-md.png "Add Node Group")
 
-![Create Node Group](@/images/main/tutorials/external-clusters/create-eks-md.png "Create Node Group")
+![Create Node Group](@/images/tutorials/external-clusters/create-eks-md.png "Create Node Group")

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/gke/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/gke/_index.en.md
@@ -12,20 +12,20 @@ You can add an existing Kubernetes cluster and then manage it using KKP.
 
 - Navigate to `External Clusters` page.
 
-![Add External Cluster](@/images/main/tutorials/external-clusters/external-cluster-page.png "Add External Cluster")
+![Add External Cluster](@/images/tutorials/external-clusters/external-cluster-page.png "Add External Cluster")
 
 - Click the `Import External Cluster` button and Pick `Google Kubernetes Engine` provider.
 
-![Add External Cluster](@/images/main/tutorials/external-clusters/connect.png "Select Provider")
+![Add External Cluster](@/images/tutorials/external-clusters/connect.png "Select Provider")
 
 - Select preset with valid credentials or enter GKE Service Account to connect to the provider.
 
-![GKE credentials](@/images/main/tutorials/external-clusters/gke-credentials.png "GKE credentials")
+![GKE credentials](@/images/tutorials/external-clusters/gke-credentials.png "GKE credentials")
 
 You should see the list of all available clusters. Select the one and click the `Import Cluster` button.
 Clusters can be imported only once in a single project. The same cluster can be imported in multiple projects.
 
-![Select GKE cluster](@/images/main/tutorials/external-clusters/select-gke-cluster.png "Select GKE cluster")
+![Select GKE cluster](@/images/tutorials/external-clusters/select-gke-cluster.png "Select GKE cluster")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
@@ -46,7 +46,7 @@ This Preset can then be used to Create/Import an GKE cluster.
 
 - Click on `Admin Panel` from the menu.
 
-![Select Admin Panel](@/images/main/tutorials/external-clusters/select-adminpanel.png "Select Admin Panel")
+![Select Admin Panel](@/images/tutorials/external-clusters/select-adminpanel.png "Select Admin Panel")
 
 - Navigate to `Provider Presets` Page and Click on `+ Create Preset` button.
 
@@ -54,34 +54,34 @@ This Preset can then be used to Create/Import an GKE cluster.
 
 - Enter Preset Name.
 
-![Provide Preset Name](@/images/main/tutorials/external-clusters/create-gkepreset.png "Provide Preset Name")
+![Provide Preset Name](@/images/tutorials/external-clusters/create-gkepreset.png "Provide Preset Name")
 
 - Choose `Google Kubernetes Engine` from the list of providers.
 
-![Choose EKS Preset](@/images/main/tutorials/external-clusters/choose-akspreset.png "Choose GKE Preset")
+![Choose EKS Preset](@/images/tutorials/external-clusters/choose-akspreset.png "Choose GKE Preset")
 
 -  Enter GKE credentials and Click on `Create` button.
 
-![Enter Credentials](@/images/main/tutorials/external-clusters/enter-gke-credentials-preset.png "Enter Credentials")
+![Enter Credentials](@/images/tutorials/external-clusters/enter-gke-credentials-preset.png "Enter Credentials")
 
 - You can now use created GKE Preset to Create or Import GKE Cluster.
 
-![Select GKE Preset](@/images/main/tutorials/external-clusters/existing-gke-preset.png "Select GKE Preset")
+![Select GKE Preset](@/images/tutorials/external-clusters/existing-gke-preset.png "Select GKE Preset")
 
 ## Cluster Details Page
 
 After the cluster is added, the KKP controller retrieves the cluster kubeconfig to display all necessary information. A healthy cluster has `Running` state. Otherwise, the cluster can be in the `Error` state. Move the mouse cursor over the
 state indicator to get more details. You can also expand `Events` to get information from the controller.
 
-![GKE cluster](@/images/main/tutorials/external-clusters/gke-details.png "GKE cluster")
+![GKE cluster](@/images/tutorials/external-clusters/gke-details.png "GKE cluster")
 
 You can also expand `Events` to get information from the controller.
 
-![GKE Events](@/images/main/tutorials/external-clusters/gke-cluster-events.png "GKE Events")
+![GKE Events](@/images/tutorials/external-clusters/gke-cluster-events.png "GKE Events")
 
 You can also click on `Machine Deployments` to get the details:
 
-![GKE Machine Deployment](@/images/main/tutorials/external-clusters/gke-machine-deployments.png "GKE Machine Deployment")
+![GKE Machine Deployment](@/images/tutorials/external-clusters/gke-machine-deployments.png "GKE Machine Deployment")
 
 ## Update Cluster
 
@@ -90,7 +90,7 @@ You can also click on `Machine Deployments` to get the details:
 When an upgrade for the cluster is available, a little dropdown arrow will be shown beside the Master Version on the cluster’s page.
 To start the upgrade, just click on the link and choose the desired version:
 
-![Upgrade GKE](@/images/main/tutorials/external-clusters/upgrade-gke.png "Upgrade GKE")
+![Upgrade GKE](@/images/tutorials/external-clusters/upgrade-gke.png "Upgrade GKE")
 
 If the version upgrade is valid, the cluster state will change to `Reconciling`.
 
@@ -103,15 +103,15 @@ Only one operation can be performed at one point of time. If the replica count i
 - Navigate to the cluster overview, scroll down to machine deployments
 - Click on the edit icon next to the machine deployment you want to edit.
 
-![Edit GKE Machine Deployment](@/images/main/tutorials/external-clusters/edit-gke-md.png "Edit GKE Machine Deployment")
+![Edit GKE Machine Deployment](@/images/tutorials/external-clusters/edit-gke-md.png "Edit GKE Machine Deployment")
 
 - Upgrade Kubernetes Version. Select the Kubernetes Version from the dropdown to upgrade the md.
 
-![Update GKE Machine Deployment](@/images/main/tutorials/external-clusters/upgrade-gke-md.png "Update GKE Machine Deployment")
+![Update GKE Machine Deployment](@/images/tutorials/external-clusters/upgrade-gke-md.png "Update GKE Machine Deployment")
 
 - Scale the replicas: In the popup dialog, you can increase or decrease the number of worker nodes that are managed by this machine deployment. Either specify the number of desired nodes or use the + or - to increase or decrease node count.
 
-![Scale GKE Machine Deployment](@/images/main/tutorials/external-clusters/scale-gke-md.png "Scale GKE Machine Deployment")
+![Scale GKE Machine Deployment](@/images/tutorials/external-clusters/scale-gke-md.png "Scale GKE Machine Deployment")
 
 ## Delete Cluster
 
@@ -121,20 +121,20 @@ Delete operation is not allowed for imported clusters
 
 Delete cluster operation allows to delete the cluster from the Provider. Click on the `Delete` button.
 
-![Delete Cluster](@/images/main/tutorials/external-clusters/gke-delete-button.png
+![Delete Cluster](@/images/tutorials/external-clusters/gke-delete-button.png
  "Delete Cluster")
 
 ## Delete the Node Pool
 
 Navigate to the cluster overview, scroll down to machine deployments and click on the delete icon next to the machine deployment you want to delete.
 
-![Update GKE Machine Deployment](@/images/main/tutorials/external-clusters/delete-md.png "Delete GKE Machine Deployment")
+![Update GKE Machine Deployment](@/images/tutorials/external-clusters/delete-md.png "Delete GKE Machine Deployment")
 
 ### Authenticating with GKE
 
 The KKP platform allows getting kubeconfig file for the GKE cluster.
 
-![Get GKE kubeconfig](@/images/main/tutorials/external-clusters/gke-kubeconfig.png "Get cluster kubeconfig")
+![Get GKE kubeconfig](@/images/tutorials/external-clusters/gke-kubeconfig.png "Get cluster kubeconfig")
 
 
 The end-user must be aware that the kubeconfig expires after some short period of time. To mitigate this disadvantage you

--- a/content/kubermatic/main/tutorials-howtos/external-clusters/gke/create-gke/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/external-clusters/gke/create-gke/_index.en.md
@@ -12,19 +12,19 @@ Create a cluster following these steps:
 
 - Click on `Create External Cluster` button:
 
-![Create External Cluster](@/images/main/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
+![Create External Cluster](@/images/tutorials/external-clusters/create-external-cluster.png "Create External Cluster")
 
 - Choose "Google Kubernetes Engine" from the supported providers:
 
-![Select Provider](@/images/main/tutorials/external-clusters/gke-select-provider.png "Select Provider")
+![Select Provider](@/images/tutorials/external-clusters/gke-select-provider.png "Select Provider")
 
 - Provide the credentials:
 
-![Select Preset](@/images/main/tutorials/external-clusters/select-gke-preset.png "Select Preset")
+![Select Preset](@/images/tutorials/external-clusters/select-gke-preset.png "Select Preset")
 
 - Configure the cluster:
 
-![Configure Cluster](@/images/main/tutorials/external-clusters/gke-settings.png "Configure Cluster")
+![Configure Cluster](@/images/tutorials/external-clusters/gke-settings.png "Configure Cluster")
 
 - Click on `Create External Cluster` button
 
@@ -45,7 +45,7 @@ Create a cluster following these steps:
 
 ### Create Node Pool
 
-![Add Node Pool](@/images/main/tutorials/external-clusters/add-md.png "Add Node Pool")
+![Add Node Pool](@/images/tutorials/external-clusters/add-md.png "Add Node Pool")
 
 - Name: Enter a unique name for this machine deployment.
 - Kubernetes Version: Control Plane Version of Cluster is prefilled.
@@ -54,4 +54,4 @@ Create a cluster following these steps:
 - AutoScaling: Autoscaling is recommended for standard configuration.
     Set the minimum and maximum node counts for this node pool. You cannot set a lower minimum than the current node count in the node pool.
 
-![Create Node Pool](@/images/main/tutorials/external-clusters/gke-md.png "Create Node Pool")
+![Create Node Pool](@/images/tutorials/external-clusters/gke-md.png "Create Node Pool")

--- a/content/kubermatic/main/tutorials-howtos/kkp-autoscaler/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-autoscaler/_index.en.md
@@ -29,7 +29,7 @@ Create a KKP User cluster by selecting your project on the dashboard and click o
 
 When the User cluster is ready, check the pods in the `kube-system` namespace to know if any autoscaler is running.
 
-![KKP Dashboard](@/images/main/tutorials/cluster-autoscaler/kkp-autoscaler-dashboard.png?classes=shadow,border "KKP Dashboard")
+![KKP Dashboard](@/images/tutorials/cluster-autoscaler/kkp-autoscaler-dashboard.png?classes=shadow,border "KKP Dashboard")
 
 ```bash
 $ kubectl get pods -n kube-system
@@ -49,23 +49,23 @@ As shown above, the autoscaler is not part of the running Kubernetes components 
 
 Add the Autoscaler to the User cluster under the addon section on the dashboard by clicking on the Addons and then `Install Addon.`
 
-![Add Addon](@/images/main/tutorials/cluster-autoscaler/add-autoscaler-addon.png?classes=shadow,border "Add Addon")
+![Add Addon](@/images/tutorials/cluster-autoscaler/add-autoscaler-addon.png?classes=shadow,border "Add Addon")
 
 
 Select Cluster Autoscaler:
 
 
-![Select Autoscaler](@/images/main/tutorials/cluster-autoscaler/select-autoscaler.png?classes=shadow,border "Select Autoscaler")
+![Select Autoscaler](@/images/tutorials/cluster-autoscaler/select-autoscaler.png?classes=shadow,border "Select Autoscaler")
 
 
 Select install:
 
 
-![Select Install](@/images/main/tutorials/cluster-autoscaler/install-autoscaler.png?classes=shadow,border "Select Install")
+![Select Install](@/images/tutorials/cluster-autoscaler/install-autoscaler.png?classes=shadow,border "Select Install")
 
 
 
-![Installation Confirmation](@/images/main/tutorials/cluster-autoscaler/autoscaler-confirmation.png?classes=shadow,border "Installation Confirmation")
+![Installation Confirmation](@/images/tutorials/cluster-autoscaler/autoscaler-confirmation.png?classes=shadow,border "Installation Confirmation")
 
 
 **Step 4**
@@ -94,11 +94,11 @@ The Cluster Autoscaler only considers MachineDeployment with valid annotations. 
 
 Annotations can be preconfigured at the time of cluster creation. Just put appropriate values in the Initial Nodes form.
 
-![Set autoscaling annotations while creating cluster](@/images/main/tutorials/cluster-autoscaler/create-autoscaler-annotations.png?classes=shadow,border "Set autoscaling annotations while creating cluster")
+![Set autoscaling annotations while creating cluster](@/images/tutorials/cluster-autoscaler/create-autoscaler-annotations.png?classes=shadow,border "Set autoscaling annotations while creating cluster")
 
 If you already have an existing Machine Deployment, open an edit form and scroll down to `Advanced Settings` > `Node Autoscaling`.
 
-![Set autoscaling annotations while editing MD](@/images/main/tutorials/cluster-autoscaler/edit-autoscaler-annotations.png?classes=shadow,border "Set autoscaling annotations while editing Machine Deployment")
+![Set autoscaling annotations while editing MD](@/images/tutorials/cluster-autoscaler/edit-autoscaler-annotations.png?classes=shadow,border "Set autoscaling annotations while editing Machine Deployment")
 
 ### Manual setup
 
@@ -177,14 +177,14 @@ As shown above, the MachineDeployment has been annotated with a minimum of 1 and
 
 To edit KKP Autoscaler, click on the three dots in front of the Cluster Autoscaler in the Addons section of the Cluster dashboard and select edit.
 
-![Edit Autoscaler](@/images/main/tutorials/cluster-autoscaler/edit-autoscaler.png?classes=shadow,border "Edit Autoscaler")
+![Edit Autoscaler](@/images/tutorials/cluster-autoscaler/edit-autoscaler.png?classes=shadow,border "Edit Autoscaler")
 
 
 ## Delete KKP Autoscaler
 
 You can delete autoscaler from where you edit it above and select delete.
 
-![Delete Autoscaler](@/images/main/tutorials/cluster-autoscaler/delete-autoscaler.png?classes=shadow,border "Delete Autoscaler")
+![Delete Autoscaler](@/images/tutorials/cluster-autoscaler/delete-autoscaler.png?classes=shadow,border "Delete Autoscaler")
 
 
  Once it has been deleted, you can check the cluster to ensure that the autoscaler has been deleted using the command `kubectl get pods -n kube-system`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/_index.en.md
@@ -36,20 +36,20 @@ KKP allows connecting any existing KubeOne cluster of supported provider to view
 
 - To import a KubeOne cluster go to `KubeOne Clusters` page and Click the `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Select the KubeOne cloud provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - See [AWS]({{< ref "./aws" >}}) / [Google Cloud Provider]({{< ref "./gcp" >}})/[Azure]({{< ref "./azure" >}})/[DigitalOcean]({{< ref "./digitalocean" >}})/[Hetzner]({{< ref "./hetzner" >}})/[OpenStack]({{< ref "./openstack" >}})/[vSphere]({{< ref "./vsphere" >}})
  specific documentation for detailed cluster import steps.
 
 After the cluster has been imported, we can see the details of the cluster in the dashboard.
 
-![Cluster Details](@/images/main/tutorials/kubeone-clusters/cluster-details.png "Imported AWS Cluster")
+![Cluster Details](@/images/tutorials/kubeone-clusters/cluster-details.png "Imported AWS Cluster")
 
-![KubeOne Cluster List](@/images/main/tutorials/kubeone-clusters/cluster-list.png "KubeOne Cluster List")
+![KubeOne Cluster List](@/images/tutorials/kubeone-clusters/cluster-list.png "KubeOne Cluster List")
 
 ## Cluster Details Page
 
@@ -69,7 +69,7 @@ Please refer to the [KubeOne Compatibility section]({{< relref "../../../../kube
 When an upgrade for the cluster is available, a little dropdown arrow will be shown beside the `Control Plane Version` on the cluster’s page.
 To start the upgrade, choose the desired version from the list of available upgrade versions and click on `Change Version`.
 
-![Upgrade Cluster](@/images/main/tutorials/kubeone-clusters/upgrade-cluster.png "Upgrade Cluster")
+![Upgrade Cluster](@/images/tutorials/kubeone-clusters/upgrade-cluster.png "Upgrade Cluster")
 
 If the version upgrade is valid, the cluster state will change to `Reconciling`.
 
@@ -81,11 +81,11 @@ Kubelet version on the worker nodes managed by Machine Deployments can be update
 
 - Click on the edit icon next to the machine deployment we want to edit.
 
-![Update Machine Deployment Version](@/images/main/tutorials/kubeone-clusters/update-md-list.png "Update Machine Deployment Version")
+![Update Machine Deployment Version](@/images/tutorials/kubeone-clusters/update-md-list.png "Update Machine Deployment Version")
 
 - Upgrade Kubelet Version. Select the Kubelet Version from the dropdown to upgrade the machine deployment.
 
-![Select Version](@/images/main/tutorials/kubeone-clusters/update-md-dialog.png "Select Version")
+![Select Version](@/images/tutorials/kubeone-clusters/update-md-dialog.png "Select Version")
 
 ## Disconnect Cluster
 
@@ -95,11 +95,11 @@ Disconnect operation does not delete the cluster from the cloud provider.
 
 We can `Disconnect` a KubeOne cluster by clicking on the disconnect icon next to the cluster we want to disconnect or from the cluster details page.
 
-![Disconnect KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/disconnect-cluster-list.png "Disconnect KubeOne Cluster")
+![Disconnect KubeOne Cluster](@/images/tutorials/kubeone-clusters/disconnect-cluster-list.png "Disconnect KubeOne Cluster")
 
-![Disconnect KubeOne Cluster on Details Page](@/images/main/tutorials/kubeone-clusters/disconnect-cluster-details.png "Disconnect KubeOne Cluster on Details Page")
+![Disconnect KubeOne Cluster on Details Page](@/images/tutorials/kubeone-clusters/disconnect-cluster-details.png "Disconnect KubeOne Cluster on Details Page")
 
-![Disconnect Dialog](@/images/main/tutorials/kubeone-clusters/disconnect-cluster-dialog.png "Disconnect Dialog")
+![Disconnect Dialog](@/images/tutorials/kubeone-clusters/disconnect-cluster-dialog.png "Disconnect Dialog")
 
 ## Troubleshoot
 To Troubleshoot a failing imported cluster we can `Pause` cluster by editing the external cluster CR.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/aws/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/aws/_index.en.md
@@ -14,21 +14,21 @@ You can add an existing AWS KubeOne cluster and then manage it using KKP.
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Pick `AWS` provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - Provide cluster Manifest config and enter SSH private key to access the KubeOne cluster.
 
-![Cluster Settings](@/images/main/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
 
     - Manually enter the credentials `Access Key ID`, `Secret Access Key`.
 
-![AWS credentials](@/images/main/tutorials/kubeone-clusters/aws-credentials-step.png "AWS credentials")
+![AWS credentials](@/images/tutorials/kubeone-clusters/aws-credentials-step.png "AWS credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/azure/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/azure/_index.en.md
@@ -14,21 +14,21 @@ You can add an existing Azure KubeOne cluster and then manage it using KKP.
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Pick `Azure` provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - Provide cluster Manifest config and enter private key to access the KubeOne cluster.
 
-![Cluster Settings](@/images/main/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
 
     - Manually enter the credentials `Client ID`, `Client Secret`, `Subscription ID`, `Tenant ID`.
 
-![Azure credentials](@/images/main/tutorials/kubeone-clusters/azure-credentials-step.png "Azure credentials")
+![Azure credentials](@/images/tutorials/kubeone-clusters/azure-credentials-step.png "Azure credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/digitalocean/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/digitalocean/_index.en.md
@@ -14,15 +14,15 @@ You can add an existing DigitalOcean KubeOne cluster and then manage it using KK
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Pick `DigitalOcean` provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - Provide cluster Manifest config yaml, SSH private key and SSH key Passphrase (if any) used to create the cluster you are importing, to access the KubeOne cluster using KKP.
 
-![Cluster Settings](@/images/main/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
@@ -30,6 +30,6 @@ You can add an existing DigitalOcean KubeOne cluster and then manage it using KK
     - Manually enter the credentials `Token` used to create the KubeOne cluster you are importing.
 
 
-![DigitalOcean credentials](@/images/main/tutorials/kubeone-clusters/digitalocean-credentials-step.png "DigitalOcean credentials")
+![DigitalOcean credentials](@/images/tutorials/kubeone-clusters/digitalocean-credentials-step.png "DigitalOcean credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/gcp/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/gcp/_index.en.md
@@ -14,21 +14,21 @@ You can add an existing Google KubeOne cluster and then manage it using KKP.
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Pick `Google` provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - Provide cluster Manifest config and enter private key to access the KubeOne cluster.
 
-![Cluster Settings](@/images/main/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
 
     - Manually enter the credentials `Service Account`.
 
-![GCP credentials](@/images/main/tutorials/kubeone-clusters/gcp-credentials-step.png "GCP credentials")
+![GCP credentials](@/images/tutorials/kubeone-clusters/gcp-credentials-step.png "GCP credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/hetzner/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/hetzner/_index.en.md
@@ -14,15 +14,15 @@ You can add an existing Hetzner KubeOne cluster and then manage it using KKP.
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Pick `Hetzner` provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - Provide cluster Manifest config yaml, SSH private key and SSH key Passphrase (if any) used to create the cluster you are importing, to access the KubeOne cluster using KKP.
 
-![Cluster Settings](@/images/main/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
 
 - Provide Credentials in either of the below mentioned ways:
     - Select a pre-created preset which stores the provider specific credentials.
@@ -30,6 +30,6 @@ You can add an existing Hetzner KubeOne cluster and then manage it using KKP.
     - Manually enter the credentials `Token` used to create the KubeOne cluster you are importing.
 
 
-![Hetzner credentials](@/images/main/tutorials/kubeone-clusters/hetzner-credentials-step.png "Hetzner credentials")
+![Hetzner credentials](@/images/tutorials/kubeone-clusters/hetzner-credentials-step.png "Hetzner credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/openstack/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/openstack/_index.en.md
@@ -14,19 +14,19 @@ You can add an existing OpenStack KubeOne cluster and then manage it using KKP.
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeoned-clusters/clusterd-listd-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeoned-clusters/clusterd-listd-empty.png "Import KubeOne Cluster")
 
 - Pick `OpenStack` provider.
 
-![Select Provider](@/images/main/tutorials/kubeoned-clusters/importd-kubeoned-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeoned-clusters/importd-kubeoned-cluster.png "Select Provider")
 
 - Provide cluster Manifest config yaml, SSH private key and SSH key Passphrase (if any) used to create the cluster you are importing, to access the KubeOne cluster using KKP.
 
-![Cluster Settings](@/images/main/tutorials/kubeoned-clusters/clusterd-settingsd-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeoned-clusters/clusterd-settingsd-step.png "Cluster Settings")
 
 - Enter the credentials `AuthURL`, `Username`, `Password`, `Domain`, `Project Name`, `Project ID` and `Region` used to create the KubeOne cluster you are importing.
 
 
-![OpenStack credentials](@/images/main/tutorials/kubeoned-clusters/openstackd-credentialsd-step.png "OpenStack credentials")
+![OpenStack credentials](@/images/tutorials/kubeoned-clusters/openstackd-credentialsd-step.png "OpenStack credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/vsphere/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-kubeone-integration/vsphere/_index.en.md
@@ -14,19 +14,19 @@ You can add an existing vSphere KubeOne cluster and then manage it using KKP.
 
 - Click `Import KubeOne Cluster` button.
 
-![Import KubeOne Cluster](@/images/main/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
+![Import KubeOne Cluster](@/images/tutorials/kubeone-clusters/cluster-list-empty.png "Import KubeOne Cluster")
 
 - Pick `vSphere` provider.
 
-![Select Provider](@/images/main/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
+![Select Provider](@/images/tutorials/kubeone-clusters/import-kubeone-cluster.png "Select Provider")
 
 - Provide cluster Manifest config yaml, SSH private key and SSH key Passphrase (if any) used to create the cluster you are importing, to access the KubeOne cluster using KKP.
 
-![Cluster Settings](@/images/main/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
+![Cluster Settings](@/images/tutorials/kubeone-clusters/cluster-settings-step.png "Cluster Settings")
 
 - Enter the credentials `Username`, `Password`, and `ServerURL` used to create the KubeOne cluster you are importing.
 
 
-![vSphere credentials](@/images/main/tutorials/kubeone-clusters/vsphere-credentials-step.png "vSphere credentials")
+![vSphere credentials](@/images/tutorials/kubeone-clusters/vsphere-credentials-step.png "vSphere credentials")
 
 - Review provided settings and click `Import KubeOne Cluster`.

--- a/content/kubermatic/main/tutorials-howtos/kubelb/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kubelb/_index.en.md
@@ -69,4 +69,4 @@ spec:
 
 This can be enabled using the KKP dashboard as well.
 
-![Enable KubeLB during cluster creation](@/images/main/tutorials/kubelb/kubelb-dashboard.png?classes=shadow,border "Enable KubeLB during cluster creation")
+![Enable KubeLB during cluster creation](@/images/tutorials/kubelb/kubelb-dashboard.png?classes=shadow,border "Enable KubeLB during cluster creation")

--- a/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/metering/_index.en.md
@@ -43,7 +43,7 @@ work properly the s3 endpoint needs to be available from the browser.
 Using the dashboard, configuring the Metering tool becomes a breeze.
 Open the [Admin Panel][admin-panel] and choose the **Metering** tab on the left side.
 
-![Navigation to Metering configuration and reports](@/images/main/tutorials/metering-admin-panel-location.png?classes=shadow,border "Navigation to Metering configuration and reports")
+![Navigation to Metering configuration and reports](@/images/tutorials/metering-admin-panel-location.png?classes=shadow,border "Navigation to Metering configuration and reports")
 
 First you need to configure the credentials for your S3 bucket.
 To do so click on *Edit credentials*, fill in the credential fields and confirm with the button below.
@@ -56,7 +56,7 @@ To do so click on *Edit credentials*, fill in the credential fields and confirm 
 - **S3 bucket**
   - Name of your S3 bucket
 
-!["Edit Credentials" form](@/images/main/tutorials/metering-credentials.png?classes=shadow,border "'Edit Credentials' form")
+!["Edit Credentials" form](@/images/tutorials/metering-credentials.png?classes=shadow,border "'Edit Credentials' form")
 
 The next step is to enable metering.
 Click on **Configure Metering**, switch on **Enable Metering** and change the configuration options
@@ -94,7 +94,7 @@ A schedule consist of four different values to set:
 - `Report Types`
   - Types of reports to generate. By default, all types of reports are generated.
 
-![Metering Configuration](@/images/main/tutorials/metering-report-configuration.png?classes=shadow,border "Metering Configuration")
+![Metering Configuration](@/images/tutorials/metering-report-configuration.png?classes=shadow,border "Metering Configuration")
 
 ### Configuration via Seed Object
 
@@ -168,7 +168,7 @@ While the reports will be stored in your S3 bucket, they can also be accessed fr
 The metering overview provides a list of all reports. Click on the download button on the right side
 to save a specific report file.
 
-![Metering Overview](@/images/main/tutorials/metering-overview.png?classes=shadow,border "Metering Overview")
+![Metering Overview](@/images/tutorials/metering-overview.png?classes=shadow,border "Metering Overview")
 
 ### Cluster Report
 

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/_index.en.md
@@ -15,4 +15,4 @@ Kubermatic Monitoring, Logging & Alerting (MLA) consists of two stacks:
 
 [User Cluster MLA Stack]({{< ref "./user-cluster/">}}) monitors applications running in the user clusters as well as system components running in the user clusters. All KKP users can access monitoring data of the user clusters under projects they are members of.
 
-![KKP MLA Architecture](@/images/main/architecture/kkp-mla-architecture.png?classes=shadow,border "KKP MLA Architecture")
+![KKP MLA Architecture](@/images/architecture/kkp-mla-architecture.png?classes=shadow,border "KKP MLA Architecture")

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -160,7 +160,7 @@ spec:
 
 There are several options in the KKP “Admin Panel” which are related to user cluster MLA, as shown on the picture below:
 
-![MLA Admin Panel](@/images/main/monitoring/user-cluster/admin-panel.png)
+![MLA Admin Panel](@/images/monitoring/user-cluster/admin-panel.png)
 
 **User Cluster Logging:**
 
@@ -376,13 +376,13 @@ This chapter describes some potential problems that you may face in a KKP instal
 - Make sure you are switched to the proper Grafana Organization (see the “Switch between Grafana Organizations” section of this documentation)
 - Make sure that user cluster Monitoring / Logging is enabled for the user cluster (In KKP UI, you should see green checkboxes on the Cluster Page):
 
-![MLA UI - Cluster View](@/images/main/monitoring/user-cluster/ui-cluster-view.png)
+![MLA UI - Cluster View](@/images/monitoring/user-cluster/ui-cluster-view.png)
 
 **Metrics / Logs are not available in Grafana UI for some user cluster:**
 
 - Make sure that User Cluster Monitoring / Logging is enabled for the user cluster (In KKP UI, you should see green checkboxes on the Cluster Page):
 
-![MLA UI - Cluster View](@/images/main/monitoring/user-cluster/ui-cluster-view.png)
+![MLA UI - Cluster View](@/images/monitoring/user-cluster/ui-cluster-view.png)
 
 - Check that Monitoring / Logging Agent was deployed an is running in the user cluster:
 

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/setting-up-alertmanager-with-slack-notifications/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/setting-up-alertmanager-with-slack-notifications/_index.en.md
@@ -14,22 +14,22 @@ workspace, please create one Slack workspace [here](https://slack.com/create).
 You will need a Slack Webhook URL in order to receive alerting notifications. Please go to **Slack** ->
 **Administration** -> **Manage apps** as shown below:
 
-![Slack Workspace](@/images/main/monitoring/user-cluster/slack-dashboard.png?classes=shadow,border, "Slack Workspace")
+![Slack Workspace](@/images/monitoring/user-cluster/slack-dashboard.png?classes=shadow,border, "Slack Workspace")
 
 In the **Manage apps** directory, search for **Incoming Webhooks** and add it to your Slack workspace as shown below:
 
-![Slack Manage Apps](@/images/main/monitoring/user-cluster/slack-incoming-webhook.png?classes=shadow,border, "Slack Manage Apps")
+![Slack Manage Apps](@/images/monitoring/user-cluster/slack-incoming-webhook.png?classes=shadow,border, "Slack Manage Apps")
 
 After you click the **Add to Slack** button as shown above, you will be directed to the configuration page.
 Please select the channel that you would like to receive notifications from Alertmanager, in this example, we will use
 a channel called "#test-alerts":
 
-![Slack Config Channel](@/images/main/monitoring/user-cluster/slack-config-channel.png?classes=shadow,border, "Slack Channel Config")
+![Slack Config Channel](@/images/monitoring/user-cluster/slack-config-channel.png?classes=shadow,border, "Slack Channel Config")
 
 Then click the **Add Incoming WebHooks integration** button, and the Slack Webhook URL will be generated and displayed
 in the **Setup Instructions** page as shown below:
 
-![Slack Webhook URL](@/images/main/monitoring/user-cluster/slack-webhook-url.png?classes=shadow,border, "Slack Setup Instructions")
+![Slack Webhook URL](@/images/monitoring/user-cluster/slack-webhook-url.png?classes=shadow,border, "Slack Setup Instructions")
 
 Make sure to copy that, and it will be used in the next step where we will configure Alertmanager.
 
@@ -63,12 +63,12 @@ alertmanager_config: |
 Don’t forget to add the Slack Webhook URL that you have generated in the previous setup to `slack_api_url`,
 change the slack channel under `slack_configs` to the channel that you are going to use and save it by clicking **Edit** button:
 
-![Slack Alertmanager Config](@/images/main/monitoring/user-cluster/slack-alertmanager-config.png?classes=shadow,border, "Alertmanager Configuration")
+![Slack Alertmanager Config](@/images/monitoring/user-cluster/slack-alertmanager-config.png?classes=shadow,border, "Alertmanager Configuration")
 
 Wait until the configuration takes effect. It can be verified in Alertmanager UI: Click **Open Alertmanager UI** in the
 **Monitoring, Logging & Alerting** tab, in the UI, go to **Status** page and check if the config is applied in the **Config** section as shown in below screenshot:
 
-![Alertmanager Status](@/images/main/monitoring/user-cluster/alertmanager-status.png?classes=shadow,border, "Alertmanager Status")
+![Alertmanager Status](@/images/monitoring/user-cluster/alertmanager-status.png?classes=shadow,border, "Alertmanager Status")
 
 If the configuration is applied to Alertmanager, it is ready to send notifications to Slack. In the next step, we will
 create some alerting rules to generate alerts from metrics and logs.
@@ -91,7 +91,7 @@ rules:
     severity: 'critical'
 ```
 
-![Metrics Rule Group](@/images/main/monitoring/user-cluster/create-metrics-alert-rule.png?classes=shadow,border, "Creating Rule Group with type Metrics")
+![Metrics Rule Group](@/images/monitoring/user-cluster/create-metrics-alert-rule.png?classes=shadow,border, "Creating Rule Group with type Metrics")
 
 Add another one with type `Logs` to generate alerts for logs:
 
@@ -108,11 +108,11 @@ rules:
     summary: "log stream is high"
 ```
 
-![Logs Rule Group](@/images/main/monitoring/user-cluster/create-logs-alert-rule.png?classes=shadow,border, "Creating Rule Group with type Logs")
+![Logs Rule Group](@/images/monitoring/user-cluster/create-logs-alert-rule.png?classes=shadow,border, "Creating Rule Group with type Logs")
 
 After those Rule Groups are created, you will be able to to receive alert notifications in your Slack channel like the following:
 
-![Slack Alerts](@/images/main/monitoring/user-cluster/slack-alerts.png?classes=shadow,border, "Slack Alert Notifications")
+![Slack Alerts](@/images/monitoring/user-cluster/slack-alerts.png?classes=shadow,border, "Slack Alert Notifications")
 
 That’s it! If you want to configure Alertmanager with more alerts receivers, please check [Prometheus Alertmanager Configuration](https://prometheus.io/docs/alerting/latest/configuration/),
 and if you want to create more useful alerting rules, please check [KKP User Cluster MLA Alerting & Recording Rules]({{< relref "../user-guide/#recording-rules--alerting-rules" >}}), [Prometheus Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting-rules/)

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/user-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/user-guide/_index.en.md
@@ -12,7 +12,7 @@ The administrator guide is available at the [User Cluster MLA Admin Guide]({{< r
 
 Once the User Cluster MLA feature is enabled in KKP, user can enable monitoring and logging for a user cluster via the KKP UI as shown below:
 
-![MLA UI - Cluster Create](@/images/main/monitoring/user-cluster/ui-cluster-create.png)
+![MLA UI - Cluster Create](@/images/monitoring/user-cluster/ui-cluster-create.png)
 
 Users can enable monitoring and logging independently, and also can disable or enable them after the cluster is created.
 
@@ -27,9 +27,9 @@ the exposed metrics will be scraped by user cluster Monitoring Agent and become 
 
 Given that the addons have been already [enabled in the KKP installation]({{< relref "../admin-guide/#addons-configuration" >}}), they can be enabled via the KKP UI on the cluster page, as shown below:
 
-![KKP UI - Addons](@/images/main/monitoring/user-cluster/ui-addons.png)
+![KKP UI - Addons](@/images/monitoring/user-cluster/ui-addons.png)
 
-![KKP UI - Addons](@/images/main/monitoring/user-cluster/ui-addons-select.png)
+![KKP UI - Addons](@/images/monitoring/user-cluster/ui-addons-select.png)
 
 ## Exposing Application Metrics
 
@@ -95,9 +95,9 @@ Once monitoring and/or logging are enabled for a user cluster, users can access 
 
 Every KKP Project is mapped to a Grafana Organization with name of `<project-name>- <project-id>` respectively, and if users want to access metrics and logs of different user clusters which belong to different KKP Projects, they can navigate between different Grafana Organizations as shown below (in the bottom left corner of Grafana UI, navigate to your profile icon - > Current Org. -> Switch):
 
-![Grafana UI - Organizations](@/images/main/monitoring/user-cluster/ui-grafana-orgs.png)
+![Grafana UI - Organizations](@/images/monitoring/user-cluster/ui-grafana-orgs.png)
 
-![Grafana UI - Organizations](@/images/main/monitoring/user-cluster/ui-grafana-orgs2.png)
+![Grafana UI - Organizations](@/images/monitoring/user-cluster/ui-grafana-orgs2.png)
 
 User’s permission in Grafana Organization is tied to the role in the KKP Project. The table below demonstrates the mapping between KKP role and Grafana Organization role:
 
@@ -116,13 +116,13 @@ For every user cluster with MLA enabled, corresponding Grafana Datasources will 
 - A Datasource with the name `Loki <cluster-name>` is created for accessing logs data if User Cluster Logging is enabled.
 - A Datasource with the name `Prometheus <cluster-name>` is created for accessing metrics data if User Cluster Monitoring is enabled.
 
-![Grafana UI - Datasources](@/images/main/monitoring/user-cluster/ui-grafana-datasources.png)
+![Grafana UI - Datasources](@/images/monitoring/user-cluster/ui-grafana-datasources.png)
 
 ### Grafana Dashboards
 
 There are some pre-installed Grafana Dashboards which can be found in Grafana UI under Dashboards -> Manage:
 
-![Grafana UI - Dashboards](@/images/main/monitoring/user-cluster/ui-grafana-dashboards.png)
+![Grafana UI - Dashboards](@/images/monitoring/user-cluster/ui-grafana-dashboards.png)
 
 KKP administrators can configure the set of Dashboards deployed for each user cluster - see the Manage Grafana Dashboard section of the Admin guide.
 
@@ -132,7 +132,7 @@ Users can also add their own custom Dashboards for more data visualization via G
 
 KKP provides API and UI to allow users to configure Alertmanager on a per user cluster basis. The “Monitoring, Logging & Alerting” tab will be visible if monitoring or logging is enabled for the user cluster:
 
-![KKP UI - Alertmanager](@/images/main/monitoring/user-cluster/ui-alertmanager.png)
+![KKP UI - Alertmanager](@/images/monitoring/user-cluster/ui-alertmanager.png)
 
 There will be a default Alertmanager configuration which is created by KKP, and users can click “Open Alertmanager UI” to navigate to the Alertmanager UI.
 
@@ -142,11 +142,11 @@ Users can configure Alertmanager configuration with customized receivers and tem
 
 KKP User Cluster MLA supports Prometheus-compatible rules for metrics and logs. The table on the “Monitoring, Logging & Alerting” tab can be used to manage both recording rules and alerting rules:
 
-![KKP UI - Alerting Rules](@/images/main/monitoring/user-cluster/ui-alert-rules.png)
+![KKP UI - Alerting Rules](@/images/monitoring/user-cluster/ui-alert-rules.png)
 
 It supports rules for both metrics and logs. For adding a new rule group, click on the “+ Add Rule Group” button, select the rule type and fill the “Data” input with rule group in YAML format:
 
-![KKP UI - Alerting Rules Data](@/images/main/monitoring/user-cluster/ui-alert-rules-data.png)
+![KKP UI - Alerting Rules Data](@/images/monitoring/user-cluster/ui-alert-rules-data.png)
 
 For more information about Prometheus rules, please check [Prometheus Recording Rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) and [Prometheus Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
 

--- a/content/kubermatic/main/tutorials-howtos/networking/apiserver-policies/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/apiserver-policies/_index.en.md
@@ -69,8 +69,8 @@ spec:
 
 This can be also configured from the KKP UI, either during cluster creation, under the "Network Configuration" > "Advanced Network Configuration":
 
-![Allowed IP Ranges - Cluster Creation](@/images/main/tutorials/networking/network-config-allowed-ip-ranges.png?height=400px&classes=shadow,border "Allowed IP Ranges - Cluster Creation")
+![Allowed IP Ranges - Cluster Creation](@/images/tutorials/networking/network-config-allowed-ip-ranges.png?height=400px&classes=shadow,border "Allowed IP Ranges - Cluster Creation")
 
 or in an existing cluster via the "Edit Cluster" dialog:
 
-![Allowed IP Ranges - Edit Cluster](@/images/main/tutorials/networking/cluster-details-allowed-ip-ranges.png?height=400px&classes=shadow,border "Allowed IP Ranges - Edit Cluster")
+![Allowed IP Ranges - Edit Cluster](@/images/tutorials/networking/cluster-details-allowed-ip-ranges.png?height=400px&classes=shadow,border "Allowed IP Ranges - Edit Cluster")

--- a/content/kubermatic/main/tutorials-howtos/networking/cni-cluster-network/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/cni-cluster-network/_index.en.md
@@ -11,7 +11,7 @@ at the cluster creation time and cannot be changed in an already existing cluste
 
 Cluster networking can be configured in the "Network Configuration" part of the cluster creation wizard, as shown below:
 
-![Cluster Settings - Network Configuration](@/images/main/tutorials/networking/ui-cluster-networking.png?classes=shadow,border "Cluster Settings - Network Configuration")
+![Cluster Settings - Network Configuration](@/images/tutorials/networking/ui-cluster-networking.png?classes=shadow,border "Cluster Settings - Network Configuration")
 
 ## CNI Type and Version
 
@@ -34,7 +34,7 @@ The following table lists the versions of individual CNIs supported by KKP:
 
 The desired CNI type and version can be selected at the cluster creation time - on the Cluster Settings page, as shown below:
 
-![Cluster Settings - Network Configuration](@/images/main/tutorials/networking/ui-cluster-cni.png?classes=shadow,border "Cluster Settings - Network Configuration")
+![Cluster Settings - Network Configuration](@/images/tutorials/networking/ui-cluster-cni.png?classes=shadow,border "Cluster Settings - Network Configuration")
 
 Available CNI versions depend on the KKP version. Note that CNI type cannot be changed after cluster creation, but [manual CNI migration]({{< relref "../cni-migration/" >}}) is possible when necessary.
 
@@ -80,7 +80,7 @@ Apart from internally relying on KKP's [Applications]({{< relref "../../applicat
 #### Editing the CNI Configuration During Cluster Creation
 When creating a new user cluster via KKP UI, it is possible to specify Helm values used to deploy the CNI via the "Edit CNI Values" button at the bottom of the "Advanced Network Configuration" section on the step 2 of the cluster creation wizard:
 
-![Edit CNI Values](@/images/main/tutorials/networking/edit-cni-app-values.png?classes=shadow,border "Edit CNI Values")
+![Edit CNI Values](@/images/tutorials/networking/edit-cni-app-values.png?classes=shadow,border "Edit CNI Values")
 
 This can be used e.g. to turn specific CNI features on or off, or modify arbitrary CNI configuration. If no initial values are provided, the default values configured for the CNI `ApplicationDefinition` will be used (see [Changing the Default CNI Configuration](#changing-the-default-cni-configuration)).
 Please note that the final Helm values applied in the user cluster will be automatically extended/overridden by the KKP controllers with the configuration necessary to provision the cluster, such as pod CIDR etc.
@@ -92,7 +92,7 @@ In an existing cluster, the CNI configuration can be edited in two ways: via KKP
 
 For editing CNI configuration via KKP UI, navigate to the "Applications" tab on the cluster details page, switch the "Show System Applications" toggle, and click on the "Edit Application" button of the CNI. After that a new dialog window with currently applied CNI Helm values will be open and allow their modification.
 
-![Edit CNI Application](@/images/main/tutorials/networking/edit-cni-app.png?classes=shadow,border "Edit CNI Application")
+![Edit CNI Application](@/images/tutorials/networking/edit-cni-app.png?classes=shadow,border "Edit CNI Application")
 
 The other option is to edit the CNI `ApplicationInstallation` in the user cluster directly, e.g. like this for the Cilium CNI:
 ```bash
@@ -135,9 +135,9 @@ In the rare case of downgrading the Cilium CNI from the `1.13.0` to a lower vers
 
 If the KKP installation supports a newer version of the CNI installed in a user cluster, it is possible to upgrade to it. This will be shown in the KKP UI and the available versions will be listed in the upgrade dialog shown after clicking on the "CNI Plugin Version" box:
 
-![Cluster Details](@/images/main/tutorials/networking/ui-cni-upgrade-available.png?classes=shadow,border "Cluster Details")
+![Cluster Details](@/images/tutorials/networking/ui-cni-upgrade-available.png?classes=shadow,border "Cluster Details")
 
-![Cluster Details - CNI Plugin Version Dialog](@/images/main/tutorials/networking/ui-cni-upgrade-dialog.png?classes=shadow,border "Cluster Details - CNI Plugin Version Dialog")
+![Cluster Details - CNI Plugin Version Dialog](@/images/tutorials/networking/ui-cni-upgrade-dialog.png?classes=shadow,border "Cluster Details - CNI Plugin Version Dialog")
 
 Once a newer version is selected, the CNI upgrade in the user cluster can be triggered by clicking on the "Change CNI Version" button. Please note that this action may cause network connectivity drops in the cluster, so it should be performed during a maintenance window.
 
@@ -165,7 +165,7 @@ This feature is described in detail on an individual page: [Dual-Stack Networkin
 After Clicking on the "Advanced Networking Configuration" button in the cluster creation wizard, several more network
 configuration options are shown to the user:
 
-![Cluster Settings - Advanced Network Configuration](@/images/main/tutorials/networking/ui-cluster-networking-advanced.png?classes=shadow,border "Cluster Settings - Network Configuration")
+![Cluster Settings - Advanced Network Configuration](@/images/tutorials/networking/ui-cluster-networking-advanced.png?classes=shadow,border "Cluster Settings - Network Configuration")
 
 ### Proxy Mode
 Configures kube-proxy mode for k8s services. Can be set to `ipvs`, `iptables` or `ebpf` (`ebpf` is available only if Cilium CNI is selected and [Konnectivity](#konnectivity) is enabled).
@@ -199,7 +199,7 @@ Please follow these guidelines to migrate clusters to the Konnectivity.
 
 Konnectivity can be enabled on per-user-cluster basis. When creating a new user cluster, the `Konnectivity` checkbox will become available in the Advanced Network Configuration part of the cluster in the KKP UI (and will be enabled by default):
 
-![Cluster Settings - Network Configuration](@/images/main/tutorials/networking/ui-cluster-konnectivity.png?classes=shadow,border "Cluster Settings - Network Configuration")
+![Cluster Settings - Network Configuration](@/images/tutorials/networking/ui-cluster-konnectivity.png?classes=shadow,border "Cluster Settings - Network Configuration")
 
 When this option is checked (which it is by default), Konnectivity will be used for control plane to worker nodes communication in the cluster. Otherwise, the old OpenVPN solution will be used.
 
@@ -213,7 +213,7 @@ This action will cause a restart of most of the control plane components and res
 
 {{% /notice %}}
 
-![Cluster Details - Edit Cluster Dialog](@/images/main/tutorials/networking/ui-cluster-dialog-konnectivity.png?classes=shadow,border "Cluster Details - Edit Cluster Dialog")
+![Cluster Details - Edit Cluster Dialog](@/images/tutorials/networking/ui-cluster-dialog-konnectivity.png?classes=shadow,border "Cluster Details - Edit Cluster Dialog")
 
 After switching to Konnectivity, give the control plane components in Seed enough time to redeploy (may take several minutes). Once this redeployment is done, you should see two `konnectivity-agent` replicas running in the user cluster instead of the `openvpn-client` pod. Apart from it, you should also see new `metrics-server` pods running in the user cluster:
 

--- a/content/kubermatic/main/tutorials-howtos/networking/dual-stack/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/dual-stack/_index.en.md
@@ -68,13 +68,13 @@ If dual-stack networking is available for the given provider and datacenter, an 
 `IPv4` and `IPv4 and IPv6 (Dual Stack)` becomes automatically available on the cluster details page in the cluster
 creation wizard:
 
-![Cluster Settings - Network Configuration - IPv4 vs. Dual-Stack](@/images/main/tutorials/networking/ui-cluster-ip-family.png?classes=shadow,border "Cluster Settings - Network Configuration - IPv4 vs. Dual-Stack")
+![Cluster Settings - Network Configuration - IPv4 vs. Dual-Stack](@/images/tutorials/networking/ui-cluster-ip-family.png?classes=shadow,border "Cluster Settings - Network Configuration - IPv4 vs. Dual-Stack")
 
 After clicking on the `ADVANCED NETWORKING CONFIGURATION` button, more detailed networking configuration can be provided.
 In case of a dual-stack cluster, the pods & services CIDRs, the node CIDR mask size and the allowed IP range for nodePorts
 can be configured separately for each address family:
 
-![Cluster Settings - Network Configuration - Advanced Dual-Stack Configuration](@/images/main/tutorials/networking/ui-cluster-advanced-nw-config.png?classes=shadow,border "Cluster Settings - Network Configuration - Advanced Dual-Stack Configuration")
+![Cluster Settings - Network Configuration - Advanced Dual-Stack Configuration](@/images/tutorials/networking/ui-cluster-advanced-nw-config.png?classes=shadow,border "Cluster Settings - Network Configuration - Advanced Dual-Stack Configuration")
 
 The rest of the cluster creation process remains the same as for single-stack user clusters.
 

--- a/content/kubermatic/main/tutorials-howtos/networking/expose-strategies/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/expose-strategies/_index.en.md
@@ -20,7 +20,7 @@ NodePort is the default expose strategy in KKP. With this strategy a k8s service
 exposed component (e.g. Kubernetes API Server) of each user cluster. This implies, that each apiserver will be
 exposed on a randomly assigned TCP port from the nodePort range configured for the seed cluster.
 
-![KKP NodePort](@/images/main/concepts/architecture/expose-np.png?classes=shadow,border)
+![KKP NodePort](@/images/concepts/architecture/expose-np.png?classes=shadow,border)
 
 
 Each cluster normally consumes 2 NodePorts (one for the apiserver + one for the worker-nodes to control-plane "tunnel"),
@@ -38,7 +38,7 @@ In the LoadBalancer expose strategy, a dedicated service of type LoadBalancer wi
 This strategy requires services of type LoadBalancer to be available on the Seed cluster and usually results into higher cost of cloud resources.
 However, this expose strategy supports more user clusters per Seed, and provides better ingress traffic isolation per user cluster.
 
-![KKP LoadBalancer](@/images/main/concepts/architecture/expose-lb.png?classes=shadow,border)
+![KKP LoadBalancer](@/images/concepts/architecture/expose-lb.png?classes=shadow,border)
 
 
 The port number on which the apiserver is exposed via the LoadBalancer service is still randomly allocated from the
@@ -48,7 +48,7 @@ NodePort range configured in the Seed cluster.
 The Tunneling expose strategy addresses both the scaling issues of the NodePort strategy and cost issues of the LoadBalancer strategy.
 With this strategy, the traffic is routed to the based on a combination of SNI and HTTP/2 tunnels by the nodeport-proxy.
 
-![KKP Tunneling](@/images/main/concepts/architecture/expose-tunnel.png?classes=shadow,border)
+![KKP Tunneling](@/images/concepts/architecture/expose-tunnel.png?classes=shadow,border)
 
 
 Another benefit of this expose strategy is that control plane components of each user cluster are always exposed

--- a/content/kubermatic/main/tutorials-howtos/operating-system-manager/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/operating-system-manager/_index.en.md
@@ -48,7 +48,7 @@ For each cluster there are at least two OSC objects:
 
 OSCs are processed by controllers to eventually generate **secrets inside each user cluster**. These secrets are then consumed by worker nodes.
 
-![Architecture](@/images/main/tutorials/operating-system-manager/architecture.png?classes=shadow,border "Architecture")
+![Architecture](@/images/tutorials/operating-system-manager/architecture.png?classes=shadow,border "Architecture")
 
 ### Air-gapped Environment
 

--- a/content/kubermatic/main/tutorials-howtos/operating-system-manager/usage/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/operating-system-manager/usage/_index.en.md
@@ -14,7 +14,7 @@ OSM can be configured using the dashboard or CLI.
 
 Create a new cluster from the dashboard and toggle **Operating System Manager** feature on.
 
-![Enable OSM during cluster creation](@/images/main/tutorials/operating-system-manager/osm-dashboard.png?classes=shadow,border "Enable OSM during cluster creation")
+![Enable OSM during cluster creation](@/images/tutorials/operating-system-manager/osm-dashboard.png?classes=shadow,border "Enable OSM during cluster creation")
 
 {{% notice note %}}
 OSM cannot be disabled after cluster creation.
@@ -22,7 +22,7 @@ OSM cannot be disabled after cluster creation.
 
 ### Selecting OperatingSystemProfile
 
-![Select OperatingSystemProfile](@/images/main/tutorials/operating-system-manager/osm-select.png?classes=shadow,border "Select OperatingSystemProfile")
+![Select OperatingSystemProfile](@/images/tutorials/operating-system-manager/osm-select.png?classes=shadow,border "Select OperatingSystemProfile")
 
 ## Via CLI
 

--- a/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/_index.en.md
@@ -11,11 +11,11 @@ weight = 1
 
 Clusters are assigned to projects, so in order to create a cluster, you must create a project first. In the Kubermatic Kubernetes Platform (KKP) dashboard, choose `Add Project`:
 
-![Project List](@/images/main/tutorials/projects-overview.png?classes=shadow,border "Project List")
+![Project List](@/images/tutorials/projects-overview.png?classes=shadow,border "Project List")
 
 Assign your new project a name:
 
-![Add Project Dialog](@/images/main/tutorials/project-add.png?classes=shadow,border "Add Project Dialog")
+![Add Project Dialog](@/images/tutorials/project-add.png?classes=shadow,border "Add Project Dialog")
 
 You can assign key-label pairs to your projects. These will be inherited by the clusters and cluster nodes in this project. You can assign multiple key-label pairs to a project.
 
@@ -26,18 +26,18 @@ After you click `Save`, the project will be created. If you click on it now, you
 
 To delete a project, move the cursor over the line with the project name and click the trash bucket icon.
 
-![Delete Project](@/images/main/tutorials/project-delete.png?classes=shadow,border "Delete Project")
+![Delete Project](@/images/tutorials/project-delete.png?classes=shadow,border "Delete Project")
 
 
 ### Add an SSH Key
 
 If you want to ssh into the project VMs, you need to provide your SSH public key. SSH keys are tied to a project. During cluster creation you can choose which SSH keys should be added to nodes. To add an SSH key, navigate to `SSH Keys` in the Dashboard and click on `Add SSH Key`:
 
-![SSH Key List](@/images/main/tutorials/sshkeys-overview.png?classes=shadow,border "SSH Key List")
+![SSH Key List](@/images/tutorials/sshkeys-overview.png?classes=shadow,border "SSH Key List")
 
 This will create a pop up. Enter a unique name and paste the complete content of the SSH key into the respective field:
 
-![Add SSH Key Dialog](@/images/main/tutorials/sshkeys-add-dialog.png?classes=shadow,border "Add SSH Key Dialog")
+![Add SSH Key Dialog](@/images/tutorials/sshkeys-add-dialog.png?classes=shadow,border "Add SSH Key Dialog")
 
 After you click on `Add SSH key`, your key will be created and you can now add it to clusters in the same project.
 
@@ -48,11 +48,11 @@ After you click on `Add SSH key`, your key will be created and you can now add i
 
 To create a new cluster, open the Kubermatic Kubernetes Platform (KKP) dashboard, choose a project, select the menu entry `Clusters` and click the button `Create Cluster` on the top right.
 
-![Cluster List](@/images/main/tutorials/cluster-list.png?classes=shadow,border "Cluster List")
+![Cluster List](@/images/tutorials/cluster-list.png?classes=shadow,border "Cluster List")
 
 Choose the cloud provider and the datacenter:
 
-![Menu to choose Cloud Provider](@/images/main/tutorials/wizard-step-1.png?classes=shadow,border "Menu to choose Cloud Provider")
+![Menu to choose Cloud Provider](@/images/tutorials/wizard-step-1.png?classes=shadow,border "Menu to choose Cloud Provider")
 
 Enter a name for your cluster and optionally adapt other settings, such as:
 
@@ -66,43 +66,43 @@ When done, click Next to continue to the next step.
 **Note:**
 Disabling the User SSH Key Agent at this point can not be reverted after the cluster creation, which means that ssh key management after creation for this cluster will have to be done manually. More info in [`User SSH Key Agent`]({{< ref "../../tutorials-howtos/administration/user-settings/user-ssh-key-agent" >}})
 
-![General Cluster Settings](@/images/main/tutorials/wizard-step-2.png?classes=shadow,border "General Cluster Settings")
+![General Cluster Settings](@/images/tutorials/wizard-step-2.png?classes=shadow,border "General Cluster Settings")
 
 
 In the next step of the installer, enter the credentials for the chosen provider. A good option is to use [Presets]({{< ref "../administration/presets/" >}}) instead putting in credentials for every cluster creation:
 
-![Provider Credentials](@/images/main/tutorials/wizard-step-3.png?classes=shadow,border "Provider Credentials")
+![Provider Credentials](@/images/tutorials/wizard-step-3.png?classes=shadow,border "Provider Credentials")
 
 In the Initial nodes section of the wizard you can setup the size, settings and amount of nodes your cluster will start with. Also you can assign labels to your nodes. You can also set [node taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) which is a property that allows your node to repel certain pods.
 
-![Node Settings](@/images/main/tutorials/wizard-step-4.png?classes=shadow,border "Node Settings")
-![Node Settings](@/images/main/tutorials/wizard-step-4.1.png?classes=shadow,border "Node Settings")
+![Node Settings](@/images/tutorials/wizard-step-4.png?classes=shadow,border "Node Settings")
+![Node Settings](@/images/tutorials/wizard-step-4.1.png?classes=shadow,border "Node Settings")
 
 In the cluster creation wizard, you can select applications to install into your cluster. KKP will automatically install your selection after the infrastructure is provisioned and the cluster is ready. Learn more about [Adding Applications to a cluster via wizard]({{< ref "../applications/add-applications-to-cluster/" >}}).
 
-![Add Applications to a cluster Settings](@/images/main/tutorials/wizard-step-5.png?classes=shadow,border "Add Applications")
+![Add Applications to a cluster Settings](@/images/tutorials/wizard-step-5.png?classes=shadow,border "Add Applications")
 
 Lastly, a cluster summary screen will be presented so that you can check out if everything looks ok.
 
-![Cluster Details as a Summary](@/images/main/tutorials/wizard-step-6.png?classes=shadow,border "Cluster Details as a Summary")
+![Cluster Details as a Summary](@/images/tutorials/wizard-step-6.png?classes=shadow,border "Cluster Details as a Summary")
 
 You will then be forwarded to the cluster page where you can view the cluster creation process:
 
-![Cluster Details in Creation State](@/images/main/tutorials/cluster-details-after-creation.png?classes=shadow,border "Cluster Details in Creation State")
+![Cluster Details in Creation State](@/images/tutorials/cluster-details-after-creation.png?classes=shadow,border "Cluster Details in Creation State")
 
 After all of the control plane components are ready, your cluster will create the configured number of worker nodes. Fully created nodes will be marked with a green dot, pending ones with a yellow circle. Clicking on the download icon lets you download the kubeconfig to be able to use `kubectl` with your cluster.
 
-![Cluster Created](@/images/main/tutorials/cluster-details-overview.png?classes=shadow,border "Cluster Created")
+![Cluster Created](@/images/tutorials/cluster-details-overview.png?classes=shadow,border "Cluster Created")
 
 ### Upgrade Cluster
 
 When an upgrade for the cluster is available, a little dropdown arrow will be shown besides the Master Version on the cluster's page:
 
-![Cluster with available Upgrade](@/images/main/tutorials/upgrade-version.png?classes=shadow,border "Cluster with available Upgrade")
+![Cluster with available Upgrade](@/images/tutorials/upgrade-version.png?classes=shadow,border "Cluster with available Upgrade")
 
 To start the upgrade, just click on the link and choose the desired version:
 
-![Dialog to choose Upgrade Version](@/images/main/tutorials/change-version.png?classes=shadow,border "Dialog to choose Upgrade Version")
+![Dialog to choose Upgrade Version](@/images/tutorials/change-version.png?classes=shadow,border "Dialog to choose Upgrade Version")
 
 After the update is initiated, the main components will be upgraded in the background. Check the checkbox for `Upgrade Machine Deployments` if you wish to upgrade the existing worker nodes as well.
 
@@ -110,19 +110,19 @@ After the update is initiated, the main components will be upgraded in the backg
 
 Clusters can be edited by pressing the ellipsis button on the right and then select `Edit Cluster`:
 
-![Select Edit Cluster](@/images/main/tutorials/cluster-edit-menu.png?classes=shadow,border "Select Edit Cluster")
+![Select Edit Cluster](@/images/tutorials/cluster-edit-menu.png?classes=shadow,border "Select Edit Cluster")
 
-![Edit Cluster Dialog](@/images/main/tutorials/edit-cluster-dialog.png?classes=shadow,border "Edit Cluster Dialog")
+![Edit Cluster Dialog](@/images/tutorials/edit-cluster-dialog.png?classes=shadow,border "Edit Cluster Dialog")
 
 ### Delete Cluster
 
 To delete a cluster, navigate to `Clusters` and choose the cluster that you would like to delete. On the top left is a button `Delete`:
 
-![Cluster Deletion Button in the top right corner](@/images/main/tutorials/delete-cluster-button.png?classes=shadow,border "Cluster Deletion Button in the top right corner")
+![Cluster Deletion Button in the top right corner](@/images/tutorials/delete-cluster-button.png?classes=shadow,border "Cluster Deletion Button in the top right corner")
 
 To confirm the deletion, type the name of the cluster into the text box:
 
-![Confirmation dialog for Cluster Deletion](@/images/main/tutorials/delete-cluster.png?classes=shadow,border "Confirmation dialog for Cluster Deletion")
+![Confirmation dialog for Cluster Deletion](@/images/tutorials/delete-cluster.png?classes=shadow,border "Confirmation dialog for Cluster Deletion")
 
 The cluster will switch into deletion state afterwards, and will be removed from the list when the deletion succeeds.
 
@@ -131,7 +131,7 @@ The cluster will switch into deletion state afterwards, and will be removed from
 
 To add a new machine deployment navigate to your cluster view and click on the `Add Machine Deployment` button:
 
-![Cluster overview with highlighted add button](@/images/main/tutorials/add-machine-deployment.png?classes=shadow,border "Cluster overview with highlighted add button")
+![Cluster overview with highlighted add button](@/images/tutorials/add-machine-deployment.png?classes=shadow,border "Cluster overview with highlighted add button")
 
 In the popup you can then choose the number of nodes (replicas), kubelet version, etc for your newly created machine deployment. All nodes created in this machine deployment will have the chosen settings.
 
@@ -139,8 +139,8 @@ In the popup you can then choose the number of nodes (replicas), kubelet version
 
 To add or delete a worker node you can easily edit the machine deployment in your cluster. Navigate to the cluster overview, scroll down to `Machine Deployments` and click on the edit icon next to the machine deployment you want to edit:
 
-![Machine deployment overview with highlighted edit button](@/images/main/tutorials/machine-deployment-edit.png?classes=shadow,border "Machine deployment overview with highlighted edit button")
+![Machine deployment overview with highlighted edit button](@/images/tutorials/machine-deployment-edit.png?classes=shadow,border "Machine deployment overview with highlighted edit button")
 
 In the popup dialog you can now in- or decrease the number of worker nodes which are managed by this machine deployment, as well as their operating system, used image etc.:
 
-![Machine deployment overview with opened edit modal](@/images/main/tutorials/machine-deployment-edit-dialog.png?classes=shadow,border "Machine deployment overview with opened edit modal")
+![Machine deployment overview with opened edit modal](@/images/tutorials/machine-deployment-edit-dialog.png?classes=shadow,border "Machine deployment overview with opened edit modal")

--- a/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/using-kubectl/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/using-kubectl/_index.en.md
@@ -10,15 +10,15 @@ See the [Official kubectl Install Instructions](https://kubernetes.io/docs/tasks
 
 To download the kubeconfig, navigate to `Clusters` and select the correct cluster. On the top right you can find a download button circled with red box:
 
-![Download config button in the top right corner](@/images/main/tutorials/cluster-details-btn.png?classes=shadow,border "Download config button in the top right corner")
+![Download config button in the top right corner](@/images/tutorials/cluster-details-btn.png?classes=shadow,border "Download config button in the top right corner")
 
 You can revoke access for already downloaded kubeconfigs by revoking the token on the cluster detail page. To do so, click on the three-dot settings icon on the right to see the option `Revoke Token`:
 
-![Select Revoke Token](@/images/main/tutorials/revoke-token-cluster.png?classes=shadow,border "Select Revoke Token")
+![Select Revoke Token](@/images/tutorials/revoke-token-cluster.png?classes=shadow,border "Select Revoke Token")
 
 Users in the groups `Owner` and `Editor` have an admin token in their kubeconfig. Users in the group `Viewer` have a viewer token. Revoking the token for a user group means the kubeconfig becomes unusable for users in this group and they need to download it again. Using `kubectl` with the invalid kubeconfig will result in an error message. You can see which group every project member belongs to on the `Members` page.
 
-![Revoke the token](@/images/main/tutorials/revoke-token-dialog.png?classes=shadow,border "Revoke the token")
+![Revoke the token](@/images/tutorials/revoke-token-dialog.png?classes=shadow,border "Revoke the token")
 
 
 Once you have installed the kubectl and downloaded the kubeconfig, change into the download directory and export it to your environment:


### PR DESCRIPTION
This supersedes #1710.

When @ URLs are used, the release name (main or v21.2.3.12) must not be part of the URL in the Markdown file. Because image URLs are by default relative to the version they are in.