### PR TITLE
Velero migration instructions

### DIFF
--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
@@ -142,7 +142,7 @@ velero:
 
 #### Kopia replaces restic
 
-The default file backup solution in Velero is now Kopia, replacing the previous implementation using restic. From a Velero user perspective this can be seen as an implementation detail and commands like `velero backup create` will continue to work as before. However, Kopia's data is stored in a new repository inside the backup storage location (for example if you used restic before and now switch to Kopia and use and S3 bucket for storage, you would end up with 3 directories in the bucket: `backups`, `restic` and `kopia`).
+The default file backup solution in Velero is now [Kopia](https://kopia.io/), replacing the previous implementation using [restic](https://restic.net/). From a Velero user perspective this can be seen as an implementation detail and commands like `velero backup create` will continue to work as before. However, Kopia's data is stored in a new repository inside the backup storage location (for example if you used restic before and now switch to Kopia and use and S3 bucket for storage, you would end up with 3 directories in the bucket: `backups`, `restic` and `kopia`).
 
 When migrating to Kopia, new backups will be made using it, but existing backups made using restic can still be restored. Once no old restic backups are required anymore, the `restic` directory in the backup storage can be deleted.
 

--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
@@ -31,27 +31,142 @@ KKP 2.26 ships a lot of major version upgrades for the Helm charts, most notably
 
 Some of these updates require manual intervention or at least checking whether a given KKP system is affected by upstream changes. Please read the following sections carefully before beginning the upgrade.
 
-#### Velero 1.13
+### Velero 1.14
 
-Velero was updated from 1.10 to 1.13, which includes a number of significant improvements internally.
+Velero was updated from 1.10 to 1.14, which includes a number of significant improvements internally. In the same breath, KKP also replaced the custom Helm chart with the [official upstream Helm chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero) for Velero.
 
-* The default file-level backup tool was changed from Restic to Kopia. To keep backwards-compatibility, the KKP `velero` chart now explicitly configures Restic, but we expect that switching to Kopia will be mandatory in the future. Please use the `restic.uploaderType` variable in the `values.yaml` to switch to Kopia when desired.
+Due to labelling changes, and in-place upgrade of Velero is not possible. It's recommended to delete the previous Helm release and install the chart fresh. Existing backups will not be affected by the switch, but Velero configuration created by Helm will be deleted and re-created (like `BackupStorageLocations`).
 
-#### cert-manager 1.14
+#### Configuration Changes
+
+The switch to the upstream Helm chart requires adjusting the `values.yaml` used to install Velero. Most existing settings have a 1:1 representation in the new chart:
+
+* `velero.podAnnotations` is now `velero.annotations`
+* `velero.serverFlags` is now `velero.configuration.*` (each CLI flag is its own field in the YAML file, e.g. `serverFlags:["--log-format=json"]` would become `configuration.logFormat: "json"`)
+* `velero.uploaderType` is now `velero.configuration.uploaderType`; note that the default has changed from restic to Kopia, see the next section below for more information.
+* `velero.credentials` is now `velero.credentials.*`
+* `velero.schedulesPath` is not available anymore, since putting additional files into a Helm chart before installing it is a rather unusual process. Instead, specify the desired schedules directly inside the `values.yaml` in `velero.schedules`
+* `velero.backupStorageLocations` is now `velero.configuration.backupStorageLocation`
+* `velero.volumeSnapshotLocations` is now `velero.configuration.volumeSnapshotLocation`
+* `velero.defaultVolumeSnapshotLocations` is now `velero.configuration.defaultBackupStorageLocation`
+
+{{< tabs name="Velero Helm Chart Upgrades" >}}
+{{% tab name="old Velero Chart" %}}
+```yaml
+velero:
+  podAnnotations:
+    iam.amazonaws.com/role: arn:aws:iam::1234:role/velero
+
+  backupStorageLocations:
+    aws:
+      provider: aws
+      objectStorage:
+        bucket: myclusterbackups
+      config:
+        region: eu-west-1
+
+  # optionally define some of your volumeSnapshotLocations as the default;
+  # each element in the list must be a string of the form "provider:location"
+  defaultVolumeSnapshotLocations:
+    - aws:aws
+
+  # see https://velero.io/docs/v1.10/api-types/volumesnapshotlocation/
+  volumeSnapshotLocations:
+    aws:
+      provider: aws
+      config:
+        region: eu-west-1
+
+  uploaderType: restic
+
+  serverFlags:
+    - --log-format=json
+
+  credentials:
+    aws:
+      accessKey: itsme
+      secretKey: andthisismypassword
+
+  schedulesPath: schedules/*
+```
+{{% /tab %}}
+
+{{% tab name="new Velero Chart" %}}
+```yaml
+velero:
+  annotations:
+    iam.amazonaws.com/role: arn:aws:iam::1234:role/velero
+
+  # schedules are no longer loaded from external files, but must be included inline
+  schedules:
+    hourly-cluster:
+      schedule: 0 * * * *
+      template:
+        includeClusterResources: true
+        includedNamespaces:
+          - '*'
+        snapshotVolumes: false
+        ttl: 168h # 7 days
+
+  configuration:
+    uploaderType: restic
+    logFormat: json
+
+    backupStorageLocation:
+      - name: aws
+        provider: aws
+        objectStorage:
+          bucket: myclusterbackups
+        config:
+          region: eu-west-1
+
+    volumeSnapshotLocation:
+      - name: aws
+        provider: aws
+        config:
+          region: eu-west-1
+
+    defaultBackupStorageLocation: aws
+
+  credentials:
+    useSecret: true
+    name: aws-credentials
+    secretContents:
+      cloud: |
+        [default]
+        aws_access_key_id=itsme
+        aws_secret_access_key=andthisismypassword
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Kopia replaces restic
+
+The default file backup solution in Velero is now Kopia, replacing the previous implementation using restic. From a Velero user perspective this can be seen as an implementation detail and commands like `velero backup create` will continue to work as before. However, Kopia's data is stored in a new repository inside the backup storage location (for example if you used restic before and now switch to Kopia and use and S3 bucket for storage, you would end up with 3 directories in the bucket: `backups`, `restic` and `kopia`).
+
+When migrating to Kopia, new backups will be made using it, but existing backups made using restic can still be restored. Once no old restic backups are required anymore, the `restic` directory in the backup storage can be deleted.
+
+KKP's wrapper `velero` Helm chart is not configuring the backup tool, so it defaults to Kopia. If you wish to continue using restic, set `velero.uploaderType` to `restic` in your Helm `values.yaml` file. Note that restic support will eventually be removed from Velero, so a switch will be necessary at some point.
+
+{{% notice note %}}
+If you decide to switch to Kopia and do not need the restic repository anymore, consider rotating the repository password by updating the `velero-repo-credentials` Secret in the `velero` namespace. This should only be done before a new repository is created by Velero and changing it will also make all previously created repositories unavailable.
+{{% /notice %}}
+
+### cert-manager 1.14
 
 The configuration syntax for cert-manager has changed slightly.
 
 * Breaking: If you have `.featureGates` value set in `values.yaml`, the features defined there will no longer be passed to cert-manager webhook, only to cert-manager controller. Use the `webhook.featureGates` field instead to define features to be enabled on webhook.
 * Potentially breaking: Webhook validation of CertificateRequest resources is stricter now: all `KeyUsages` and `ExtendedKeyUsages` must be defined directly in the CertificateRequest resource, the encoded CSR can never contain more usages that defined there.
 
-#### oauth2-proxy (IAP) 7.6
+### oauth2-proxy (IAP) 7.6
 
 This upgrade includes one breaking change:
 
 * A change to how auth routes are evaluated using the flags `skip-auth-route`/`skip-auth-regex`: the new behaviour uses the regex you specify to evaluate the full path including query parameters. For more details please read the [detailed PR description](https://github.com/oauth2-proxy/oauth2-proxy/issues/2271).
 * The environment variable `OAUTH2_PROXY_GOOGLE_GROUP` has been deprecated in favor of `OAUTH2_PROXY_GOOGLE_GROUPS`. Next major release will remove this option.
 
-#### Loki & Promtail 2.9 (Seed MLA)
+### Loki & Promtail 2.9 (Seed MLA)
 
 The Loki upgrade from 2.5 to 2.9 might be the most significant bump in this KKP release. Due to the amount of changes, it's necessary to delete the existing `loki` StatefulSet and letting Helm recreate it. Deleting the StatefulSet will not touch the PVCs and the new StatefulSet's pods will reuse the existing PVCs after the upgrade.
 
@@ -69,15 +184,15 @@ Before upgrading, review your `values.yaml` for Loki, as a number of syntax chan
 * `loki.singleBinary.persistence.enableStatefulSetAutoDeletePVC` is set to `false` to ensure that when the StatefulSet is deleted, the PVCs will not also be deleted. This allows for easier upgrades in the
 future, but if you scale down Loki, you would have to manually deleted the leftover PVCs.
 
-#### Alertmanager 0.27 (Seed MLA)
+### Alertmanager 0.27 (Seed MLA)
 
 This version removes the `v1` API which was deprecated since 2019. If you have custom integrations with Alertmanager, ensure none of them use the now removed API.
 
-#### blackbox-exporter 0.25 (Seed MLA)
+### blackbox-exporter 0.25 (Seed MLA)
 
 This version changes the `proxy_connect_header` configuration structure to match Prometheus (see [PR](https://github.com/prometheus/blackbox_exporter/pull/1008)); update your `values.yaml` accordingly if you configured this option.
 
-#### helm-exporter 1.2.16 (Seed MLA)
+### helm-exporter 1.2.16 (Seed MLA)
 
 KKP 2.26 removes the custom Helm chart and instead now reuses the official [upstream chart](https://shanestarcher.com/helm-charts/). Before upgrading you must delete the existing Helm release in your cluster:
 
@@ -87,7 +202,7 @@ $ helm --namespace monitoring delete helm-exporter
 
 Afterwards you can install the new release from the chart.
 
-#### kube-state-metrics 2.12 (Seed MLA)
+### kube-state-metrics 2.12 (Seed MLA)
 
 As is typical for kube-state-metrics, the upgrade simple, but the devil is in the details. There were many minor changes since v2.8, please review [the changelog](https://github.com/kubernetes/kube-state-metrics/releases) carefully if you built upon metrics provided by kube-state-metrics:
 
@@ -95,7 +210,7 @@ As is typical for kube-state-metrics, the upgrade simple, but the devil is in th
 * Label names were regulated to adhere with OTel-Prometheus standards, so existing label names that do not follow the same may be replaced by the ones that do. Please refer to [the PR](https://github.com/kubernetes/kube-state-metrics/pull/2004) for more details.
 * Label and annotation metrics aren't exposed by default anymore to reduce the memory usage of the default configuration of kube-state-metrics. Before this change, they used to only include the name and namespace of the objects which is not relevant to users not opting in these metrics.
 
-#### node-exporter 1.7 (Seed MLA)
+### node-exporter 1.7 (Seed MLA)
 
 This new version comes with a few minor backwards-incompatible changes:
 
@@ -104,7 +219,7 @@ This new version comes with a few minor backwards-incompatible changes:
 * ntp collector was deprecated
 * supervisord collector was deprecated
 
-#### Prometheus 2.51 (Seed MLA)
+### Prometheus 2.51 (Seed MLA)
 
 Prometheus had many improvements and some changes to the remote-write functionality that might affect you:
 
@@ -115,7 +230,7 @@ Prometheus had many improvements and some changes to the remote-write functional
 * Scraping:
   * Do experimental timestamp alignment even if tolerance is bigger than 1% of scrape interval
 
-#### nginx-ingress-controller 1.10
+### nginx-ingress-controller 1.10
 
 nginx v1.10 brings quite a few potentially breaking changes:
 
@@ -125,13 +240,13 @@ nginx v1.10 brings quite a few potentially breaking changes:
 * dropped support for GeoIP (legacy), only GeoIP2 is supported
 * The automatically generated `NetworkPolicy` from nginx 1.9.3 is now disabled by default, refer to https://github.com/kubernetes/ingress-nginx/pull/10238 for more information.
 
-#### Dex 2.40
+### Dex 2.40
 
 The validation of username and password in the LDAP connector is much more strict now. Dex uses the [EscapeFilter](https://pkg.go.dev/gopkg.in/ldap.v1#EscapeFilter) function to check for special characters in credentials and prevent injections by denying such requests. Please ensure this is not an issue before upgrading.
 
 Additionally, the custom `oauth` Helm chart in KKP has been deprecated and will be replaced with a new Helm chart, `dex`, which is based on the [official upstream chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex). Administrators are advised to begin migrating to the new chart as soon as possible.
 
-##### Migration Procedure
+#### Migration Procedure
 
 Most importantly, with this change the Kubernetes namespace where Dex is installed is also changed. Previously we installed Dex into the `oauth` namespace, but the new chart is meant to be installed into the `dex` namespace. This is the default the KKP installer will choose; if you install KKP manually you could place Dex into any namespace.
 

--- a/content/kubermatic/v2.26/architecture/supported-providers/kubevirt/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/supported-providers/kubevirt/_index.en.md
@@ -105,7 +105,7 @@ We allow to configure:
 * `infraStorageClasses` - Storage classes that are initialized on user clusters that end users can work with.
   * Pass names of KubeVirt storage classes that can be used from user clusters.
 
-Refer to this [document](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/zz_generated.seed.ce.yaml#L115)
+Refer to this [document](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/zz_generated.seed.ce.yaml#L115)
 for more details and configuration example.
 
 {{% notice warning %}}
@@ -220,7 +220,7 @@ We implemented a mechanism that will allow you to safely drain a bare-metal node
 After running a drain command the VMs running on the node along with their workload will be evicted to different nodes.
 
 {{% notice note %}}
-More details on the eviction implementation can be found [here](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/proposals/kubevirt-workload-eviction.md).
+More details on the eviction implementation can be found [here](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/proposals/kubevirt-workload-eviction.md).
 {{% /notice %}}
 
 {{% notice warning %}}

--- a/content/kubermatic/v2.26/how-to-contribute/_index.en.md
+++ b/content/kubermatic/v2.26/how-to-contribute/_index.en.md
@@ -6,7 +6,7 @@ weight = 61
 
 ## Contributing to KKP
 
-KKP is an open-source project to centrally manage the global automation of thousands of Kubernetes clusters across multi-cloud, on-prem and edge with unparalleled density and resilience. Therefore, contributors in different areas but not limited to project automation, code review, tooling, documentation, testing etc., for the holistic improvement of the KKP project is highly welcomed. Kubermatic projects are [Apache 2.0 licensed](https://github.com/kubermatic/kubermatic/blob/release/v22.26/LICENSE) and accept contributions via GitHub pull requests from interested contributors. This document outlines some of the conventions on development workflow, contributor's notes, contributing steps, contact points and other resources to make your contribution to the projects felicitous.
+KKP is an open-source project to centrally manage the global automation of thousands of Kubernetes clusters across multi-cloud, on-prem and edge with unparalleled density and resilience. Therefore, contributors in different areas but not limited to project automation, code review, tooling, documentation, testing etc., for the holistic improvement of the KKP project is highly welcomed. Kubermatic projects are [Apache 2.0 licensed](https://github.com/kubermatic/kubermatic/blob/release/v2.26/LICENSE) and accept contributions via GitHub pull requests from interested contributors. This document outlines some of the conventions on development workflow, contributor's notes, contributing steps, contact points and other resources to make your contribution to the projects felicitous.
 
 ## Contributor's Notes
 
@@ -14,7 +14,7 @@ There are few things to note when contributing to the KKP project, which are hig
 
 *   KKP project is hosted on GitHub; thus, GitHub knowledge is one of the essential pre-requisites
 *   The KKP documentation is written in markdown (.md) and located in the [docs repository](https://github.com/kubermatic/docs/tree/main/content/kubermatic)
-*   See [CONTRIBUTING.md](https://github.com/kubermatic/kubermatic/blob/release/v22.26/CONTRIBUTING.md) for instructions on the developer certificate of origin that we require
+*   See [CONTRIBUTING.md](https://github.com/kubermatic/kubermatic/blob/release/v2.26/CONTRIBUTING.md) for instructions on the developer certificate of origin that we require
 *   Familiarization with Hugo for building static site locally is suggested for documentation contribution
 *   Kubernetes knowledge is also recommended
 *   The KKP documentation is currently available only in English
@@ -22,10 +22,10 @@ There are few things to note when contributing to the KKP project, which are hig
 
 ## Steps in Contributing to KKP
 
-*   Please familiarise yourself with our [Code of Conduct](https://github.com/kubermatic/kubermatic/blob/release/v22.26/CODE_OF_CONDUCT.md)
+*   Please familiarise yourself with our [Code of Conduct](https://github.com/kubermatic/kubermatic/blob/release/v2.26/CODE_OF_CONDUCT.md)
 *   Check the [opened issues](https://github.com/kubermatic/kubermatic/issues) on our GitHub repo peradventure there might be anyone that will be of interest
 *   Fork the repository on GitHub
-*   Read the [README](https://github.com/kubermatic/kubermatic/blob/release/v22.26/README.md) for build and test instructions
+*   Read the [README](https://github.com/kubermatic/kubermatic/blob/release/v2.26/README.md) for build and test instructions
 
 ## Contribution Workflow
 

--- a/content/kubermatic/v2.26/installation/install-kkp-ce/add-seed-cluster/_index.en.md
+++ b/content/kubermatic/v2.26/installation/install-kkp-ce/add-seed-cluster/_index.en.md
@@ -153,7 +153,7 @@ when creating your `Seed` resource.
 
 To configure the storage class to use and the size of backing storage, edit the `minio` section in your `values.yaml` file.
 For more information about the Minio options, take a look at
-[the minio chart's `values.yaml`](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/minio/values.yaml).
+[the minio chart's `values.yaml`](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/minio/values.yaml).
 
 ```yaml
 minio:

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.20-to-2.21/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.20-to-2.21/_index.en.md
@@ -8,13 +8,13 @@ weight = 20
 Upgrading to KKP 2.21 is only supported from version 2.20. Do not attempt to upgrade from versions prior to that and apply the upgrade step by step over minor versions instead (e.g. from [2.19 to 2.20]({{< ref "../upgrade-from-2.19-to-2.20/" >}}) and then to 2.21). It is also strongly advised to be on the latest 2.20.x patch release before upgrading to 2.21.
 {{% /notice %}}
 
-This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.21. For the full list of changes in this release, please check out the [KKP changelog for v2.21](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.21.md). Please read the full document before proceeding with the upgrade.
+This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.21. For the full list of changes in this release, please check out the [KKP changelog for v2.21](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.21.md). Please read the full document before proceeding with the upgrade.
 
 ## Pre-Upgrade Considerations
 
 - Support for Kubernetes 1.20 and Kubernetes 1.21 has been removed in KKP. User clusters on Kubernetes 1.20 need to be upgraded prior to a KKP upgrade. It is recommended to update existing user clusters to 1.22 before proceeding with the upgrade, but user clusters with 1.21 will also be automatically updated to 1.22 as part of the upgrade.
 - The expected secret name for S3 credentials has been updated to `kubermatic-s3-credentials`. If the `s3-credentials` secret was manually created instead of using the `minio` Helm chart, the existing `s3-credentials` secret should be duplicated to `kubermatic-s3-credentials`.
-- Check the full list of [breaking changes](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.21.md#breaking-changes), specifically for changes to Helm chart values shipped as part of KKP. Adjust your local `values.yaml` and any CRDs manually deployed for the required changes (do not apply them yet, the Helm charts will be updated during the upgrade procedure).
+- Check the full list of [breaking changes](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.21.md#breaking-changes), specifically for changes to Helm chart values shipped as part of KKP. Adjust your local `values.yaml` and any CRDs manually deployed for the required changes (do not apply them yet, the Helm charts will be updated during the upgrade procedure).
 
 ## Upgrade Procedure
 
@@ -120,4 +120,4 @@ After finishing the upgrade, check out some of the new features that were added 
 - [Resource Quotas]({{< ref "../../../architecture/concept/kkp-concepts/resource-quotas/" >}}) (available in Enterprise Edition)
 - [KKP role assignments for OIDC groups]({{< ref "../../../architecture/iam-role-based-access-control/groups-support/" >}}) (available in Enterprise Edition)
 
-Check out the [changelog](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.21.md) for a full list of changes.
+Check out the [changelog](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.21.md) for a full list of changes.

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.21-to-2.22/_index.en.md
@@ -8,7 +8,7 @@ weight = 10
 Upgrading to KKP 2.22 is only supported from version 2.21. Do not attempt to upgrade from versions prior to that and apply the upgrade step by step over minor versions instead (e.g. from [2.20 to 2.21]({{< ref "../upgrade-from-2.20-to-2.21/" >}}) and then to 2.22). It is also strongly advised to be on the latest 2.21.x patch release before upgrading to 2.22.
 {{% /notice %}}
 
-This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.22. For the full list of changes in this release, please check out the [KKP changelog for v2.22](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.22.md). Please read the full document before proceeding with the upgrade.
+This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.22. For the full list of changes in this release, please check out the [KKP changelog for v2.22](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.22.md). Please read the full document before proceeding with the upgrade.
 
 ## Pre-Upgrade Considerations
 
@@ -227,4 +227,4 @@ After finishing the upgrade, check out some of the new features that were added 
 - Support for Kubernetes 1.25 and 1.26 has been added and can be used to create or upgrade user clusters.
 - Various improvements to the look and feel of the Kubermatic Dashboard of your KKP instance.
 
-Check out the [changelog](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.22.md) for a full list of changes.
+Check out the [changelog](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.22.md) for a full list of changes.

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.22-to-2.23/_index.en.md
@@ -8,7 +8,7 @@ weight = 10
 Upgrading to KKP 2.23 is only supported from version 2.22. Do not attempt to upgrade from versions prior to that and apply the upgrade step by step over minor versions instead (e.g. from [2.21 to 2.22]({{< ref "../upgrade-from-2.21-to-2.22/" >}}) and then to 2.23). It is also strongly advised to be on the latest 2.22.x patch release before upgrading to 2.23.
 {{% /notice %}}
 
-This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.23. For the full list of changes in this release, please check out the [KKP changelog for v2.23](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.23.md). Please read the full document before proceeding with the upgrade.
+This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.23. For the full list of changes in this release, please check out the [KKP changelog for v2.23](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.23.md). Please read the full document before proceeding with the upgrade.
 
 ## Pre-Upgrade Considerations
 

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.23-to-2.24/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.23-to-2.24/_index.en.md
@@ -8,7 +8,7 @@ weight = 10
 Upgrading to KKP 2.24 is only supported from version 2.23. Do not attempt to upgrade from versions prior to that and apply the upgrade step by step over minor versions instead (e.g. from [2.22 to 2.23]({{< ref "../upgrade-from-2.22-to-2.23/" >}}) and then to 2.24). It is also strongly advised to be on the latest 2.23.x patch release before upgrading to 2.24.
 {{% /notice %}}
 
-This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.24. For the full list of changes in this release, please check out the [KKP changelog for v2.24](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.24.md). Please read the full document before proceeding with the upgrade.
+This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.24. For the full list of changes in this release, please check out the [KKP changelog for v2.24](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.24.md). Please read the full document before proceeding with the upgrade.
 
 ## Pre-Upgrade Considerations
 

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.24-to-2.25/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.24-to-2.25/_index.en.md
@@ -8,7 +8,7 @@ weight = 10
 Upgrading to KKP 2.25 is only supported from version 2.24. Do not attempt to upgrade from versions prior to that and apply the upgrade step by step over minor versions instead (e.g. from [2.23 to 2.24]({{< ref "../upgrade-from-2.23-to-2.24/" >}}) and then to 2.25). It is also strongly advised to be on the latest 2.24.x patch release before upgrading to 2.25.
 {{% /notice %}}
 
-This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.25. For the full list of changes in this release, please check out the [KKP changelog for v2.25](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.25.md). Please read the full document before proceeding with the upgrade.
+This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.25. For the full list of changes in this release, please check out the [KKP changelog for v2.25](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.25.md). Please read the full document before proceeding with the upgrade.
 
 ## Pre-Upgrade Considerations
 
@@ -171,7 +171,7 @@ Of particular interest to the upgrade process is if the `ResourcesReconciled` co
 
 ### Deprecations and Removals
 
-Some functionality of KKP has been deprecated or removed with KKP 2.25. You should review the full [changelog](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.25.md) and adjust any automation or scripts that might be using deprecated fields or features. Below is a list of changes that might affect you:
+Some functionality of KKP has been deprecated or removed with KKP 2.25. You should review the full [changelog](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.25.md) and adjust any automation or scripts that might be using deprecated fields or features. Below is a list of changes that might affect you:
 
 - The field `ovdcNetwork` in `cluster` and `preset` CRDs is considered deprecated for VMware Cloud Director and `ovdcNetworks` should be used instead ([#12996](https://github.com/kubermatic/kubermatic/pull/12996))
 - Some of high cardinality metrics were dropped from the User Cluster MLA prometheus. If your KKP installation was using some of those metrics for the custom Grafana dashboards for the user clusters, your dashboards might stop showing some of the charts ([#12756](https://github.com/kubermatic/kubermatic/pull/12756))

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
@@ -8,7 +8,7 @@ weight = 10
 Upgrading to KKP 2.26 is only supported from version 2.25. Do not attempt to upgrade from versions prior to that and apply the upgrade step by step over minor versions instead (e.g. from [2.24 to 2.25]({{< ref "../upgrade-from-2.24-to-2.25/" >}}) and then to 2.26). It is also strongly advised to be on the latest 2.25.x patch release before upgrading to 2.26.
 {{% /notice %}}
 
-This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.26. For the full list of changes in this release, please check out the [KKP changelog for v2.26](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.26.md). Please read the full document before proceeding with the upgrade.
+This guide will walk you through upgrading Kubermatic Kubernetes Platform (KKP) to version 2.26. For the full list of changes in this release, please check out the [KKP changelog for v2.26](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.26.md). Please read the full document before proceeding with the upgrade.
 
 ## Pre-Upgrade Considerations
 
@@ -31,27 +31,142 @@ KKP 2.26 ships a lot of major version upgrades for the Helm charts, most notably
 
 Some of these updates require manual intervention or at least checking whether a given KKP system is affected by upstream changes. Please read the following sections carefully before beginning the upgrade.
 
-#### Velero 1.13
+### Velero 1.14
 
-Velero was updated from 1.10 to 1.13, which includes a number of significant improvements internally.
+Velero was updated from 1.10 to 1.14, which includes a number of significant improvements internally. In the same breath, KKP also replaced the custom Helm chart with the [official upstream Helm chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero) for Velero.
 
-* The default file-level backup tool was changed from Restic to Kopia. To keep backwards-compatibility, the KKP `velero` chart now explicitly configures Restic, but we expect that switching to Kopia will be mandatory in the future. Please use the `restic.uploaderType` variable in the `values.yaml` to switch to Kopia when desired.
+Due to labelling changes, and in-place upgrade of Velero is not possible. It's recommended to delete the previous Helm release and install the chart fresh. Existing backups will not be affected by the switch, but Velero configuration created by Helm will be deleted and re-created (like `BackupStorageLocations`).
 
-#### cert-manager 1.14
+#### Configuration Changes
+
+The switch to the upstream Helm chart requires adjusting the `values.yaml` used to install Velero. Most existing settings have a 1:1 representation in the new chart:
+
+* `velero.podAnnotations` is now `velero.annotations`
+* `velero.serverFlags` is now `velero.configuration.*` (each CLI flag is its own field in the YAML file, e.g. `serverFlags:["--log-format=json"]` would become `configuration.logFormat: "json"`)
+* `velero.uploaderType` is now `velero.configuration.uploaderType`; note that the default has changed from restic to Kopia, see the next section below for more information.
+* `velero.credentials` is now `velero.credentials.*`
+* `velero.schedulesPath` is not available anymore, since putting additional files into a Helm chart before installing it is a rather unusual process. Instead, specify the desired schedules directly inside the `values.yaml` in `velero.schedules`
+* `velero.backupStorageLocations` is now `velero.configuration.backupStorageLocation`
+* `velero.volumeSnapshotLocations` is now `velero.configuration.volumeSnapshotLocation`
+* `velero.defaultVolumeSnapshotLocations` is now `velero.configuration.defaultBackupStorageLocation`
+
+{{< tabs name="Velero Helm Chart Upgrades" >}}
+{{% tab name="old Velero Chart" %}}
+```yaml
+velero:
+  podAnnotations:
+    iam.amazonaws.com/role: arn:aws:iam::1234:role/velero
+
+  backupStorageLocations:
+    aws:
+      provider: aws
+      objectStorage:
+        bucket: myclusterbackups
+      config:
+        region: eu-west-1
+
+  # optionally define some of your volumeSnapshotLocations as the default;
+  # each element in the list must be a string of the form "provider:location"
+  defaultVolumeSnapshotLocations:
+    - aws:aws
+
+  # see https://velero.io/docs/v1.10/api-types/volumesnapshotlocation/
+  volumeSnapshotLocations:
+    aws:
+      provider: aws
+      config:
+        region: eu-west-1
+
+  uploaderType: restic
+
+  serverFlags:
+    - --log-format=json
+
+  credentials:
+    aws:
+      accessKey: itsme
+      secretKey: andthisismypassword
+
+  schedulesPath: schedules/*
+```
+{{% /tab %}}
+
+{{% tab name="new Velero Chart" %}}
+```yaml
+velero:
+  annotations:
+    iam.amazonaws.com/role: arn:aws:iam::1234:role/velero
+
+  # schedules are no longer loaded from external files, but must be included inline
+  schedules:
+    hourly-cluster:
+      schedule: 0 * * * *
+      template:
+        includeClusterResources: true
+        includedNamespaces:
+          - '*'
+        snapshotVolumes: false
+        ttl: 168h # 7 days
+
+  configuration:
+    uploaderType: restic
+    logFormat: json
+
+    backupStorageLocation:
+      - name: aws
+        provider: aws
+        objectStorage:
+          bucket: myclusterbackups
+        config:
+          region: eu-west-1
+
+    volumeSnapshotLocation:
+      - name: aws
+        provider: aws
+        config:
+          region: eu-west-1
+
+    defaultBackupStorageLocation: aws
+
+  credentials:
+    useSecret: true
+    name: aws-credentials
+    secretContents:
+      cloud: |
+        [default]
+        aws_access_key_id=itsme
+        aws_secret_access_key=andthisismypassword
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Kopia replaces restic
+
+The default file backup solution in Velero is now [Kopia](https://kopia.io/), replacing the previous implementation using [restic](https://restic.net/). From a Velero user perspective this can be seen as an implementation detail and commands like `velero backup create` will continue to work as before. However, Kopia's data is stored in a new repository inside the backup storage location (for example if you used restic before and now switch to Kopia and use and S3 bucket for storage, you would end up with 3 directories in the bucket: `backups`, `restic` and `kopia`).
+
+When migrating to Kopia, new backups will be made using it, but existing backups made using restic can still be restored. Once no old restic backups are required anymore, the `restic` directory in the backup storage can be deleted.
+
+KKP's wrapper `velero` Helm chart is not configuring the backup tool, so it defaults to Kopia. If you wish to continue using restic, set `velero.uploaderType` to `restic` in your Helm `values.yaml` file. Note that restic support will eventually be removed from Velero, so a switch will be necessary at some point.
+
+{{% notice note %}}
+If you decide to switch to Kopia and do not need the restic repository anymore, consider rotating the repository password by updating the `velero-repo-credentials` Secret in the `velero` namespace. This should only be done before a new repository is created by Velero and changing it will also make all previously created repositories unavailable.
+{{% /notice %}}
+
+### cert-manager 1.14
 
 The configuration syntax for cert-manager has changed slightly.
 
 * Breaking: If you have `.featureGates` value set in `values.yaml`, the features defined there will no longer be passed to cert-manager webhook, only to cert-manager controller. Use the `webhook.featureGates` field instead to define features to be enabled on webhook.
 * Potentially breaking: Webhook validation of CertificateRequest resources is stricter now: all `KeyUsages` and `ExtendedKeyUsages` must be defined directly in the CertificateRequest resource, the encoded CSR can never contain more usages that defined there.
 
-#### oauth2-proxy (IAP) 7.6
+### oauth2-proxy (IAP) 7.6
 
 This upgrade includes one breaking change:
 
 * A change to how auth routes are evaluated using the flags `skip-auth-route`/`skip-auth-regex`: the new behaviour uses the regex you specify to evaluate the full path including query parameters. For more details please read the [detailed PR description](https://github.com/oauth2-proxy/oauth2-proxy/issues/2271).
 * The environment variable `OAUTH2_PROXY_GOOGLE_GROUP` has been deprecated in favor of `OAUTH2_PROXY_GOOGLE_GROUPS`. Next major release will remove this option.
 
-#### Loki & Promtail 2.9 (Seed MLA)
+### Loki & Promtail 2.9 (Seed MLA)
 
 The Loki upgrade from 2.5 to 2.9 might be the most significant bump in this KKP release. Due to the amount of changes, it's necessary to delete the existing `loki` StatefulSet and letting Helm recreate it. Deleting the StatefulSet will not touch the PVCs and the new StatefulSet's pods will reuse the existing PVCs after the upgrade.
 
@@ -69,15 +184,15 @@ Before upgrading, review your `values.yaml` for Loki, as a number of syntax chan
 * `loki.singleBinary.persistence.enableStatefulSetAutoDeletePVC` is set to `false` to ensure that when the StatefulSet is deleted, the PVCs will not also be deleted. This allows for easier upgrades in the
 future, but if you scale down Loki, you would have to manually deleted the leftover PVCs.
 
-#### Alertmanager 0.27 (Seed MLA)
+### Alertmanager 0.27 (Seed MLA)
 
 This version removes the `v1` API which was deprecated since 2019. If you have custom integrations with Alertmanager, ensure none of them use the now removed API.
 
-#### blackbox-exporter 0.25 (Seed MLA)
+### blackbox-exporter 0.25 (Seed MLA)
 
 This version changes the `proxy_connect_header` configuration structure to match Prometheus (see [PR](https://github.com/prometheus/blackbox_exporter/pull/1008)); update your `values.yaml` accordingly if you configured this option.
 
-#### helm-exporter 1.2.16 (Seed MLA)
+### helm-exporter 1.2.16 (Seed MLA)
 
 KKP 2.26 removes the custom Helm chart and instead now reuses the official [upstream chart](https://shanestarcher.com/helm-charts/). Before upgrading you must delete the existing Helm release in your cluster:
 
@@ -87,7 +202,7 @@ $ helm --namespace monitoring delete helm-exporter
 
 Afterwards you can install the new release from the chart.
 
-#### kube-state-metrics 2.12 (Seed MLA)
+### kube-state-metrics 2.12 (Seed MLA)
 
 As is typical for kube-state-metrics, the upgrade simple, but the devil is in the details. There were many minor changes since v2.8, please review [the changelog](https://github.com/kubernetes/kube-state-metrics/releases) carefully if you built upon metrics provided by kube-state-metrics:
 
@@ -95,7 +210,7 @@ As is typical for kube-state-metrics, the upgrade simple, but the devil is in th
 * Label names were regulated to adhere with OTel-Prometheus standards, so existing label names that do not follow the same may be replaced by the ones that do. Please refer to [the PR](https://github.com/kubernetes/kube-state-metrics/pull/2004) for more details.
 * Label and annotation metrics aren't exposed by default anymore to reduce the memory usage of the default configuration of kube-state-metrics. Before this change, they used to only include the name and namespace of the objects which is not relevant to users not opting in these metrics.
 
-#### node-exporter 1.7 (Seed MLA)
+### node-exporter 1.7 (Seed MLA)
 
 This new version comes with a few minor backwards-incompatible changes:
 
@@ -104,7 +219,7 @@ This new version comes with a few minor backwards-incompatible changes:
 * ntp collector was deprecated
 * supervisord collector was deprecated
 
-#### Prometheus 2.51 (Seed MLA)
+### Prometheus 2.51 (Seed MLA)
 
 Prometheus had many improvements and some changes to the remote-write functionality that might affect you:
 
@@ -115,7 +230,7 @@ Prometheus had many improvements and some changes to the remote-write functional
 * Scraping:
   * Do experimental timestamp alignment even if tolerance is bigger than 1% of scrape interval
 
-#### nginx-ingress-controller 1.10
+### nginx-ingress-controller 1.10
 
 nginx v1.10 brings quite a few potentially breaking changes:
 
@@ -125,13 +240,13 @@ nginx v1.10 brings quite a few potentially breaking changes:
 * dropped support for GeoIP (legacy), only GeoIP2 is supported
 * The automatically generated `NetworkPolicy` from nginx 1.9.3 is now disabled by default, refer to https://github.com/kubernetes/ingress-nginx/pull/10238 for more information.
 
-#### Dex 2.40
+### Dex 2.40
 
 The validation of username and password in the LDAP connector is much more strict now. Dex uses the [EscapeFilter](https://pkg.go.dev/gopkg.in/ldap.v1#EscapeFilter) function to check for special characters in credentials and prevent injections by denying such requests. Please ensure this is not an issue before upgrading.
 
 Additionally, the custom `oauth` Helm chart in KKP has been deprecated and will be replaced with a new Helm chart, `dex`, which is based on the [official upstream chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex). Administrators are advised to begin migrating to the new chart as soon as possible.
 
-##### Migration Procedure
+#### Migration Procedure
 
 Most importantly, with this change the Kubernetes namespace where Dex is installed is also changed. Previously we installed Dex into the `oauth` namespace, but the new chart is meant to be installed into the `dex` namespace. This is the default the KKP installer will choose; if you install KKP manually you could place Dex into any namespace.
 
@@ -311,7 +426,7 @@ Of particular interest to the upgrade process is if the `ResourcesReconciled` co
 
 ### Deprecations and Removals
 
-Some functionality of KKP has been deprecated or removed with KKP 2.26. You should review the full [changelog](https://github.com/kubermatic/kubermatic/blob/release/v22.26/docs/changelogs/CHANGELOG-2.26.md) and adjust any automation or scripts that might be using deprecated fields or features. Below is a list of changes that might affect you:
+Some functionality of KKP has been deprecated or removed with KKP 2.26. You should review the full [changelog](https://github.com/kubermatic/kubermatic/blob/release/v2.26/docs/changelogs/CHANGELOG-2.26.md) and adjust any automation or scripts that might be using deprecated fields or features. Below is a list of changes that might affect you:
 
 - TBD
 

--- a/content/kubermatic/v2.26/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/v2.26/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -252,13 +252,13 @@ By default, the MLA stack is configured to hold the logs and metrics in the obje
 
 **For the metrics:**
 
-- In the [cortex Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/cortex/values.yaml#L208), set `cortex.config.limits.max_query_lookback` to the desired value (default: `168h` = 7 days).
-- In the [minio-lifecycle-mgr Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/minio-lifecycle-mgr/values.yaml#L18), set `lifecycleMgr.buckets[name=cortex].expirationDays` to the value used in the cortex Helm chart + 1 day (default: `8d`).
+- In the [cortex Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/cortex/values.yaml#L208), set `cortex.config.limits.max_query_lookback` to the desired value (default: `168h` = 7 days).
+- In the [minio-lifecycle-mgr Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/minio-lifecycle-mgr/values.yaml#L18), set `lifecycleMgr.buckets[name=cortex].expirationDays` to the value used in the cortex Helm chart + 1 day (default: `8d`).
 
 **For the logs:**
 
-- In the [loki Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/loki-distributed/values.yaml#L52), set `loki-distributed.loki.config.chunk_store_config.max_look_back_period` to the desired value (default: `168h` = 7 days).
-- In the [minio-lifecycle-mgr Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/minio-lifecycle-mgr/values.yaml#L20), set `lifecycleMgr.buckets[name=loki].expirationDays` to the value used in the loki Helm chart + 1 day (default: `8d`).
+- In the [loki Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/loki-distributed/values.yaml#L52), set `loki-distributed.loki.config.chunk_store_config.max_look_back_period` to the desired value (default: `168h` = 7 days).
+- In the [minio-lifecycle-mgr Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/minio-lifecycle-mgr/values.yaml#L20), set `lifecycleMgr.buckets[name=loki].expirationDays` to the value used in the loki Helm chart + 1 day (default: `8d`).
 
 ### Cortex Performance Tips
 
@@ -288,11 +288,11 @@ There are three Helm charts which are related to MinIO in MLA repository:
 - [minio-lifecycle-mgr](https://github.com/kubermatic/kubermatic/tree/release/v2.26/charts/mla/minio-lifecycle-mgr) is used to manage the lifecycle of the stored data, and to take care of data retention.
 
 If you want to disable the MinIO installation and use your existing MinIO instance or other S3 services, you need to:
-- Disable the Secret creation for MinIO in mla-secrets Helm chart. In the [mla-secrets Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/mla-secrets/values.yaml#L18), set `mlaSecrets.minio.enabled` to `false`.
+- Disable the Secret creation for MinIO in mla-secrets Helm chart. In the [mla-secrets Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/mla-secrets/values.yaml#L18), set `mlaSecrets.minio.enabled` to `false`.
 - Modify the S3 storage settings in `values.yaml` of other MLA components to use the existing MinIO instance or other S3 services:
-  - In [cortex Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/cortex/values.yaml), change the `cortex.config.ruler.storage.s3`, `cortex.config.alertmanager.storage.s3`, and `cortex.config.blocks_storage.s3` to point to your MinIO instance. Modify the `cortex.ruler.env`, `cortex.storage_gateway.env`, `cortex.ingester.env`, `cortex.querier.env` and `cortex.alertmanager.env` to get credentials from your Secret.
-  - In [loki Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/loki-distributed/values.yaml), change the `loki-distributed.storage_config.aws` and `loki-distributed.ruler.storage.s3` in the `loki-distributed.loki.config` to point to your MinIO instance or S3 service. Modify `extraEnvFrom` of `loki-distributed.tableManager`, `loki-distributed.ingester`, `loki-distributed.querier`, `loki-distributed.ruler` and `loki-distributed.compactor` to get credentials from your Secret.
-  - If you still want to use MinIO lifecycle manager to manage data retention for MLA data in your MinIO instance, in [minio-lefecycle-mgr Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/minio-lifecycle-mgr/values.yaml), set `lifecycleMgr.minio.endpoint` and `lifecycleMgr.minio.secretName` to your MinIO endpoint and Secret.
+  - In [cortex Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/cortex/values.yaml), change the `cortex.config.ruler.storage.s3`, `cortex.config.alertmanager.storage.s3`, and `cortex.config.blocks_storage.s3` to point to your MinIO instance. Modify the `cortex.ruler.env`, `cortex.storage_gateway.env`, `cortex.ingester.env`, `cortex.querier.env` and `cortex.alertmanager.env` to get credentials from your Secret.
+  - In [loki Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/loki-distributed/values.yaml), change the `loki-distributed.storage_config.aws` and `loki-distributed.ruler.storage.s3` in the `loki-distributed.loki.config` to point to your MinIO instance or S3 service. Modify `extraEnvFrom` of `loki-distributed.tableManager`, `loki-distributed.ingester`, `loki-distributed.querier`, `loki-distributed.ruler` and `loki-distributed.compactor` to get credentials from your Secret.
+  - If you still want to use MinIO lifecycle manager to manage data retention for MLA data in your MinIO instance, in [minio-lefecycle-mgr Helm chart values.yaml](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/minio-lifecycle-mgr/values.yaml), set `lifecycleMgr.minio.endpoint` and `lifecycleMgr.minio.secretName` to your MinIO endpoint and Secret.
 - Use `--mla-skip-minio` or `--mla-skip-minio-lifecycle-mgr` flag when you execute `kubermatic-installer deploy usercluster-mla`. If you want to disable MinIO but still use MinIO lifecycle manager to take care of data retention, you can use `--mla-skip-minio` flag. Otherwise, you can use both flags to disable both MinIO and lifecycle manager. Please note that if you are redeploying the stack on existing cluster, you will have to manually uninstall MinIO and/or lifecycle manager. To do that, you can use commands: `helm uninstall --namespace mla minio` and `helm uninstall --namespace mla minio-lifecycle-mgr` accordingly.
 
 
@@ -316,7 +316,7 @@ data:
   example-dashboard.json: <your-dashboard-json-data>
 ```
 
-- Add dashboards to the User Cluster MLA Grafana Helm chart values. You can add dashboards into the `grafana.dashboards` section of the [values.yaml file](https://github.com/kubermatic/kubermatic/blob/release/v22.26/charts/mla/grafana/values.yaml#L41).
+- Add dashboards to the User Cluster MLA Grafana Helm chart values. You can add dashboards into the `grafana.dashboards` section of the [values.yaml file](https://github.com/kubermatic/kubermatic/blob/release/v2.26/charts/mla/grafana/values.yaml#L41).
 
 After the new dashboards are applied to the Seed Cluster, they will become available across all Grafana Organizations, and they can be found in the Grafana UI under Dashboards -> Manage.
 

--- a/content/kubermatic/v2.26/tutorials-howtos/networking/ipam/_index.en.md
+++ b/content/kubermatic/v2.26/tutorials-howtos/networking/ipam/_index.en.md
@@ -202,4 +202,4 @@ custom resource (from the `metallb.io/v1beta1` API) will have the following name
 
 Both address pools (single-stack and dual-stack) can co-exist in the same cluster.
 
-For the reference, the Addon manifests can be found in the [addons/metallb/](https://github.com/kubermatic/kubermatic/blob/release/v22.26/addons/metallb/) folder of the KKP source code.
+For the reference, the Addon manifests can be found in the [addons/metallb/](https://github.com/kubermatic/kubermatic/blob/release/v2.26/addons/metallb/) folder of the KKP source code.


### PR DESCRIPTION
This describes the changes and process for customers to migrate from our homegrown Velero Helm chart to the official one. This is the sister PR to https://github.com/kubermatic/kubermatic/pull/13488.

I moved some sections from `<h4>` to `<h3>` to improve the site's usability, otherwise `<h4>` and `<h5>` would not be visually distinguishable.