### PR TITLE
Update the Kubernetes compatibility matrix for supported KubeOne versions

### DIFF
--- a/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/main/architecture/compatibility/supported-versions/_index.en.md
@@ -14,16 +14,16 @@ support policy in the [Version Skew Policy document][upstream-supported-versions
 In the following table you can find the supported Kubernetes versions for the
 current KubeOne version.
 
-| KubeOne \ Kubernetes | 1.30 | 1.29 | 1.28 | 1.27[^1] | 1.26[^2] | 1.25[^2] |
-| -------------------- | ---- | ---- | ---- | -------- | -------- | -------- |
-| v1.8.1               | ✓    | ✓    | ✓    | ✓        | -        | -        |
-| v1.8                 | -    | ✓    | ✓    | ✓        | -        | -        |
-| v1.7                 | -    | -    | -    | ✓        | ✓        | ✓        |
+| KubeOne \ Kubernetes | 1.31 | 1.30 | 1.29 | 1.28[^1] | 1.27[^2] |
+| -------------------- | ---- | ---- | ---- | -------- | -------- |
+| v1.9                 | ✓    | ✓    | ✓    | ✓        | ✓        |
+| v1.8.1               | -    | ✓    | ✓    | ✓        | ✓        |
+| v1.8                 | -    | -    | ✓    | ✓        | ✓        |
 
-[^1]: Kubernetes 1.27 will be reaching End-of-Life (EOL) on 2024-06-28.
+[^1]: Kubernetes 1.28 will be reaching End-of-Life (EOL) on 2024-10-28.
 We strongly recommend upgrading to a newer Kubernetes release as soon as possible.
 
-[^2]: Kubernetes 1.26 and 1.25 have reached End-of-Life (EOL) and are not supported
+[^2]: Kubernetes 1.27 has reached End-of-Life (EOL) and is not supported
 any longer. We strongly recommend upgrading to a newer supported Kubernetes release
 as soon as possible.
 

--- a/content/kubeone/v1.7/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/v1.7/architecture/compatibility/supported-versions/_index.en.md
@@ -20,14 +20,17 @@ Kubernetes 1.21 or older must be upgraded with an older KubeOne release
 according to the table below.
 {{% /notice %}}
 
-| KubeOne version | 1.28  | 1.27  | 1.26  | 1.25[^1] | 1.24[^1] |
-| --------------- | ----- | ----- | ----- | -------- | -------- |
-| v1.7            | -     | ✓     | ✓     | ✓        | -        |
-| v1.6            | -     | -     | ✓     | ✓        | ✓        |
+| KubeOne version | 1.28[^1]  | 1.27[^2]  | 1.26[^2]  | 1.25[^2] | 1.24[^2] |
+| --------------- | --------- | --------- | --------- | -------- | -------- |
+| v1.7            | -         | ✓         | ✓         | ✓        | -        |
+| v1.6            | -         | -         | ✓         | ✓        | ✓        |
 
-[^1]: Kubernetes 1.25 and 1.24 have reached End-of-Life (EOL) on 2023-10-28 and
-2023-07-28, respectively, We strongly recommend upgrading to a supported
-Kubernetes release as soon as possible.
+[^1]: Kubernetes 1.28 will be reaching End-of-Life (EOL) on 2024-10-28.
+We strongly recommend upgrading to a newer Kubernetes release as soon as possible.
+
+[^2]: Kubernetes 1.27, 1.26, 1.25, and 1.24 have reached End-of-Life (EOL) and
+are not supported any longer. We strongly recommend upgrading to a newer
+supported Kubernetes release as soon as possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
 than the latest Kubernetes release. For example, with 1.27 being the latest

--- a/content/kubeone/v1.8/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubeone/v1.8/architecture/compatibility/supported-versions/_index.en.md
@@ -14,16 +14,16 @@ support policy in the [Version Skew Policy document][upstream-supported-versions
 In the following table you can find the supported Kubernetes versions for the
 current KubeOne version.
 
-| KubeOne \ Kubernetes | 1.30 | 1.29 | 1.28 | 1.27[^1] | 1.26[^2] | 1.25[^2] |
-| -------------------- | ---- | ---- | ---- | -------- | -------- | -------- |
-| v1.8.1               | ✓    | ✓    | ✓    | ✓        | -        | -        |
-| v1.8                 | -    | ✓    | ✓    | ✓        | -        | -        |
-| v1.7                 | -    | -    | -    | ✓        | ✓        | ✓        |
+| KubeOne \ Kubernetes | 1.30 | 1.29 | 1.28[^1] | 1.27[^2] | 1.26[^2] | 1.25[^2] |
+| -------------------- | ---- | ---- | -------- | -------- | -------- | -------- |
+| v1.8.1               | ✓    | ✓    | ✓        | ✓        | -        | -        |
+| v1.8                 | -    | ✓    | ✓        | ✓        | -        | -        |
+| v1.7                 | -    | -    | -        | ✓        | ✓        | ✓        |
 
-[^1]: Kubernetes 1.27 will be reaching End-of-Life (EOL) on 2024-06-28.
+[^1]: Kubernetes 1.28 will be reaching End-of-Life (EOL) on 2024-10-28.
 We strongly recommend upgrading to a newer Kubernetes release as soon as possible.
 
-[^2]: Kubernetes 1.26 and 1.25 have reached End-of-Life (EOL) and are not supported
+[^2]: Kubernetes 1.27, 1.26, and 1.25 have reached End-of-Life (EOL) and are not supported
 any longer. We strongly recommend upgrading to a newer supported Kubernetes release
 as soon as possible.
 


### PR DESCRIPTION
- Add Kubernetes v1.31 as a supported version for KubeOne 1.9.0
- Update the Kubernetes compatibility matrix for supported KubeOne versions
  - Update information about the EOL releases

/assign @xrstf 