### PR TITLE
correct description for automatic node updates

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure to configure Kubernetes version updates contains:
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.14/advanced/versions_updates/_index.en.md
+++ b/content/kubermatic/v2.14/advanced/versions_updates/_index.en.md
@@ -80,7 +80,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.15/advanced/versions_updates/_index.en.md
+++ b/content/kubermatic/v2.15/advanced/versions_updates/_index.en.md
@@ -80,7 +80,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.16/advanced/versions_updates/_index.en.md
+++ b/content/kubermatic/v2.16/advanced/versions_updates/_index.en.md
@@ -35,7 +35,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.17/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
+++ b/content/kubermatic/v2.17/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.18/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
+++ b/content/kubermatic/v2.18/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
@@ -36,7 +36,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.19/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
+++ b/content/kubermatic/v2.19/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.20/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
+++ b/content/kubermatic/v2.20/tutorials_howtos/upgrading/version_and_upgrade_configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure for Kubernetes and OpenShift versions is identical. Each contains
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.21/tutorials-howtos/upgrading/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/v2.21/tutorials-howtos/upgrading/version-and-upgrade-configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure to configure Kubernetes version updates contains:
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.22/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure to configure Kubernetes version updates contains:
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.23/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure to configure Kubernetes version updates contains:
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.24/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/v2.24/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure to configure Kubernetes version updates contains:
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 

--- a/content/kubermatic/v2.25/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
+++ b/content/kubermatic/v2.25/tutorials-howtos/administration/version-and-upgrade-configuration/_index.en.md
@@ -35,7 +35,7 @@ The structure to configure Kubernetes version updates contains:
     updated to.
   * `automatic` (bool) controls whether an update is performed immediately after applying the
     configuration. This is useful for force updates in case of security patch releases.
-  * `automaticNodeUpgrade` (bool) controls whether worker nodes are updated as well. If this
+  * `automaticNodeUpdate` (bool) controls whether worker nodes are updated as well. If this
     is left to its default (false), only the controlplane will be updated. When set to true,
     it implies `automatic`.
 


### PR DESCRIPTION
This PR corrects the description to configure automatic node updates in the `KubermaticConfiguration` for all documented KKP versions. Looking at the initial implementation in https://github.com/kubermatic/kubermatic/pull/4258, it seems that the field was always named `automaticNodeUpdate`.