### PR TITLE
AWS permission fix for kubeone, based on #1555

### DIFF
--- a/content/kubeone/main/architecture/requirements/machine-controller/aws/_index.en.md
+++ b/content/kubeone/main/architecture/requirements/machine-controller/aws/_index.en.md
@@ -21,7 +21,8 @@ Permissions listed here are permission required by the Kubermatic machine-contro
             "Effect": "Allow",
             "Action": [
                 "iam:GetInstanceProfile",
-                "iam:ListInstanceProfiles"
+                "iam:ListInstanceProfiles",
+                "iam:TagInstanceProfile"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/*"
         },
@@ -32,10 +33,12 @@ Permissions listed here are permission required by the Kubermatic machine-contro
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
                 "iam:GetRole",
+                "iam:GetRolePolicy",
                 "iam:ListAttachedRolePolicies",
                 "iam:ListRolePolicies",
                 "iam:PassRole",
-                "iam:PutRolePolicy"
+                "iam:PutRolePolicy",
+                "iam:TagRole"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_CLUSTER_NAME-*"
         },
@@ -54,10 +57,14 @@ Permissions listed here are permission required by the Kubermatic machine-contro
             "Effect": "Allow",
             "Action": [
                 "ec2:*",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateRule",
                 "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
                 "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:DeleteListener",
                 "elasticloadbalancing:DeleteRule",
@@ -66,6 +73,7 @@ Permissions listed here are permission required by the Kubermatic machine-contro
                 "elasticloadbalancing:DeregisterTargets",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTags",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",

--- a/content/kubeone/v1.7/architecture/requirements/machine-controller/aws/aws.en.md
+++ b/content/kubeone/v1.7/architecture/requirements/machine-controller/aws/aws.en.md
@@ -21,7 +21,8 @@ Permissions listed here are permission required by the Kubermatic machine-contro
             "Effect": "Allow",
             "Action": [
                 "iam:GetInstanceProfile",
-                "iam:ListInstanceProfiles"
+                "iam:ListInstanceProfiles",
+                "iam:TagInstanceProfile"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/*"
         },
@@ -32,10 +33,12 @@ Permissions listed here are permission required by the Kubermatic machine-contro
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
                 "iam:GetRole",
+                "iam:GetRolePolicy",
                 "iam:ListAttachedRolePolicies",
                 "iam:ListRolePolicies",
                 "iam:PassRole",
-                "iam:PutRolePolicy"
+                "iam:PutRolePolicy",
+                "iam:TagRole"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_CLUSTER_NAME-*"
         },
@@ -54,10 +57,14 @@ Permissions listed here are permission required by the Kubermatic machine-contro
             "Effect": "Allow",
             "Action": [
                 "ec2:*",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateRule",
                 "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
                 "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:DeleteListener",
                 "elasticloadbalancing:DeleteRule",
@@ -66,6 +73,7 @@ Permissions listed here are permission required by the Kubermatic machine-contro
                 "elasticloadbalancing:DeregisterTargets",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTags",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",

--- a/content/kubeone/v1.8/architecture/requirements/machine-controller/aws/_index.en.md
+++ b/content/kubeone/v1.8/architecture/requirements/machine-controller/aws/_index.en.md
@@ -21,7 +21,8 @@ Permissions listed here are permission required by the Kubermatic machine-contro
             "Effect": "Allow",
             "Action": [
                 "iam:GetInstanceProfile",
-                "iam:ListInstanceProfiles"
+                "iam:ListInstanceProfiles",
+                "iam:TagInstanceProfile"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:instance-profile/*"
         },
@@ -32,10 +33,12 @@ Permissions listed here are permission required by the Kubermatic machine-contro
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
                 "iam:GetRole",
+                "iam:GetRolePolicy",
                 "iam:ListAttachedRolePolicies",
                 "iam:ListRolePolicies",
                 "iam:PassRole",
-                "iam:PutRolePolicy"
+                "iam:PutRolePolicy",
+                "iam:TagRole"
             ],
             "Resource": "arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_CLUSTER_NAME-*"
         },
@@ -54,10 +57,14 @@ Permissions listed here are permission required by the Kubermatic machine-contro
             "Effect": "Allow",
             "Action": [
                 "ec2:*",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateRule",
                 "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
                 "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:DeleteListener",
                 "elasticloadbalancing:DeleteRule",
@@ -66,6 +73,7 @@ Permissions listed here are permission required by the Kubermatic machine-contro
                 "elasticloadbalancing:DeregisterTargets",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTags",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",


### PR DESCRIPTION
- tested this new permissions on AWS for a standard and private
  networking setup
- may not all permissions are only for machinecontroller required, but
  for apply kubeone with the terrafrom example (what I think will be the
99% case), so as we don't have other AWS permissions document for
kubeone, I would see the terraform required permissions in scope to
enhance the expierence of our customers.
