### PR TITLE
Hide 2.26 documentation from docs.kubermatic.com until the release is out

### DIFF
--- a/data/products.yaml
+++ b/data/products.yaml
@@ -11,8 +11,9 @@ kubermatic:
   versions:
     - release: main
       name: main
-    - release: v2.26
-      name: v2.26
+    # TODO: uncomment this once 2.26 is officially released
+    #- release: v2.26
+    #  name: v2.26
     - release: v2.25
       name: v2.25
     - release: v2.24


### PR DESCRIPTION
#1761 was a bit too early, we don't want to the 2.26 documentation to be public yet.