### PR TITLE
fix minio bucket name in _index.en.md documentation

### DIFF
--- a/content/kubermatic/v2.26/installation/install-kkp-ce/add-seed-cluster/_index.en.md
+++ b/content/kubermatic/v2.26/installation/install-kkp-ce/add-seed-cluster/_index.en.md
@@ -235,7 +235,7 @@ the `Seed` resource has been created.
 
 If you are using MinIO, a bucket needs to be created for cluster backups to be stored in. This can be done for example
 via a `Job` resource that spawns a `Pod` running the `mc` command against the freshly deployed MinIO service. Below you
-find an example `Job` definition. If you want to change the bucket name, replace `src/kkpbackup` with `src/YOUR_BUCKET_NAME`
+find an example `Job` definition. If you want to change the bucket name, replace `kkpbackup` with `YOUR_BUCKET_NAME`
 in the `args` part of the template.
 
 ```yaml
@@ -254,7 +254,7 @@ spec:
           args:
             - /bin/sh
             - -c
-            - mc --insecure config host add src http://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc --insecure mb src/kkpbackup
+            - mc --insecure config host add src http://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc --insecure mb kkpbackup
           env:
             - name: MINIO_ACCESS_KEY
               valueFrom:


### PR DESCRIPTION
Trying to apply this manifest will fail

You can create buckets in MinIO with "/" in them, only lowercase letters, numbers dots and hyphens

I tried to reproduce on the MinIO UI, which is more verbose

![image](https://github.com/user-attachments/assets/5c12a6fe-993b-4d0b-b365-e4bc4e42a307)
