### PR TITLE
fix typo in velero upgrade docs

### DIFF
--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
@@ -115,8 +115,7 @@ velero:
     backupStorageLocation:
       - name: aws
         provider: aws
-        objectStorage:
-          bucket: myclusterbackups
+        bucket: myclusterbackups
         config:
           region: eu-west-1
 

--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
@@ -60,8 +60,7 @@ velero:
   backupStorageLocations:
     aws:
       provider: aws
-      objectStorage:
-        bucket: myclusterbackups
+      bucket: myclusterbackups
       config:
         region: eu-west-1
 


### PR DESCRIPTION
`bucket` is not a child of `objectStorage` anymore.