### PR TITLE
fix yet another typo in Velero upgrade notes

### DIFF
--- a/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
+++ b/content/kubermatic/v2.26/installation/upgrading/upgrade-from-2.25-to-2.26/_index.en.md
@@ -60,7 +60,8 @@ velero:
   backupStorageLocations:
     aws:
       provider: aws
-      bucket: myclusterbackups
+      objectStorage:
+        bucket: myclusterbackups
       config:
         region: eu-west-1
 
@@ -114,8 +115,7 @@ velero:
     backupStorageLocation:
       - name: aws
         provider: aws
-        objectStorage:
-          bucket: myclusterbackups
+        bucket: myclusterbackups
         config:
           region: eu-west-1
 


### PR DESCRIPTION
In #1784 I accidentally mixed up the old and new Velero config samples. This PR rectifies that.