### PR TITLE
Add KubeOne v1.9 to products.yaml

### DIFF
--- a/content/kubeone/main/known-issues/_index.en.md
+++ b/content/kubeone/main/known-issues/_index.en.md
@@ -9,7 +9,7 @@ This page documents the list of known issues in Kubermatic KubeOne along with
 possible workarounds and recommendations.
 
 This list applies to KubeOne 1.9 release. For KubeOne 1.8, please consider
-the [v1.8 version of this document][known-issues-1.7]. For earlier releases,
+the [v1.8 version of this document][known-issues-1.8]. For earlier releases,
 please consult the [appropriate changelog][changelogs].
 
 [known-issues-1.8]: {{< ref "../../v1.8/known-issues" >}}

--- a/content/kubeone/v1.9/known-issues/_index.en.md
+++ b/content/kubeone/v1.9/known-issues/_index.en.md
@@ -9,7 +9,7 @@ This page documents the list of known issues in Kubermatic KubeOne along with
 possible workarounds and recommendations.
 
 This list applies to KubeOne 1.9 release. For KubeOne 1.8, please consider
-the [v1.8 version of this document][known-issues-1.7]. For earlier releases,
+the [v1.8 version of this document][known-issues-1.8]. For earlier releases,
 please consult the [appropriate changelog][changelogs].
 
 [known-issues-1.8]: {{< ref "../../v1.8/known-issues" >}}

--- a/data/products.yaml
+++ b/data/products.yaml
@@ -51,6 +51,8 @@ kubeone:
   versions:
     - release: main
       name: main
+    - release: v1.9
+      name: v1.9
     - release: v1.8
       name: v1.8
     - release: v1.7


### PR DESCRIPTION
This PR adds KubeOne v1.9 to `products.yaml` which will make the v1.9 docs public.

/assign @kron4eg 
/hold
unhold before cutting the final release