### PR TITLE
add explanation for oidc refresh token issue

### DIFF
--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -13,18 +13,42 @@ This page documents the list of known issues and possible work arounds/solutions
 
 ### Problem
 
-One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+For oidc authentication to user cluster there is always the same issuer used. This leads to invalidation of refresh tokens when a new authentication happens with the same user because existing refresh tokens for the same user/client pair are invalidated when a new one is requested.
 
 
 ### Root Cause
 
-With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+By default it is only possible to have one refresh token per user/client pair in dex for security reasons. There is an open issue regarding this in the [upstream repository](https://github.com/dexidp/dex/issues/981). The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
 
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one.
 
 ### Solution
 
-You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+You can either change this in dex configuration by setting `userIDKey` to `jti` in the connector section or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default.
 
-For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+#### dex
+
+The following yaml snippet is an example how to configure an oidc connector to keep the refresh tokens.
+
+```yaml
+    connectors:
+      - config:
+          clientID: <client_id>
+          clientSecret: <client_secret>
+          orgs:
+          - name: <github_organization>
+          redirectURI: https://kubermatic.test/dex/callback
+        id: github
+        name: GitHub
+        type: github
+        userIDKey: jti
+        userNameKey: email
+```
+
+#### external provider
 
 For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).
+
+### security implications regarding dex solution
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.

--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -8,3 +8,23 @@ weight = 25
 ## Overview
 
 This page documents the list of known issues and possible work arounds/solutions.
+
+## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
+
+### Problem
+
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+
+
+### Root Cause
+
+With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+
+
+### Solution
+
+You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+
+For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).

--- a/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
@@ -164,3 +164,23 @@ This adjustment will help ensure that the issue no longer disrupts the provision
 For additional details and discussions related to this issue, you can refer to the following GitHub issues:
 - [open-vm-tools](https://github.com/vmware/open-vm-tools/issues/684).
 - [cloud-init](https://github.com/canonical/cloud-init/issues/4188).
+
+## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
+
+### Problem
+
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+
+
+### Root Cause
+
+With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+
+
+### Solution
+
+You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh token belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+
+For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).

--- a/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
@@ -169,18 +169,42 @@ For additional details and discussions related to this issue, you can refer to t
 
 ### Problem
 
-One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+For oidc authentication to user cluster there is always the same issuer used. This leads to invalidation of refresh tokens when a new authentication happens with the same user because existing refresh tokens for the same user/client pair are invalidated when a new one is requested.
 
 
 ### Root Cause
 
-With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+By default it is only possible to have one refresh token per user/client pair in dex for security reasons. There is an open issue regarding this in the [upstream repository](https://github.com/dexidp/dex/issues/981). The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
 
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one.
 
 ### Solution
 
-You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+You can either change this in dex configuration by setting `userIDKey` to `jti` in the connector section or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default.
 
-For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh token belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+#### dex
+
+The following yaml snippet is an example how to configure an oidc connector to keep the refresh tokens.
+
+```yaml
+    connectors:
+      - config:
+          clientID: <client_id>
+          clientSecret: <client_secret>
+          orgs:
+          - name: <github_organization>
+          redirectURI: https://kubermatic.test/dex/callback
+        id: github
+        name: GitHub
+        type: github
+        userIDKey: jti
+        userNameKey: email
+```
+
+#### external provider
 
 For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).
+
+### security implications regarding dex solution
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.

--- a/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
@@ -149,3 +149,23 @@ The root cause of this issue is an update to Azure CCM's deployment's selector (
 We need to delete the ccm deployment for all the user clusters on Azure & let it get re-created as per the latest spec.
 
 `kubectl delete deployment azure-cloud-controller-manager -n cluster-<cluster-id>`
+
+## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
+
+### Problem
+
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+
+
+### Root Cause
+
+With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+
+
+### Solution
+
+You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh token belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+
+For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).

--- a/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
@@ -154,18 +154,42 @@ We need to delete the ccm deployment for all the user clusters on Azure & let it
 
 ### Problem
 
-One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+For oidc authentication to user cluster there is always the same issuer used. This leads to invalidation of refresh tokens when a new authentication happens with the same user because existing refresh tokens for the same user/client pair are invalidated when a new one is requested.
 
 
 ### Root Cause
 
-With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+By default it is only possible to have one refresh token per user/client pair in dex for security reasons. There is an open issue regarding this in the [upstream repository](https://github.com/dexidp/dex/issues/981). The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
 
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one.
 
 ### Solution
 
-You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+You can either change this in dex configuration by setting `userIDKey` to `jti` in the connector section or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default.
 
-For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh token belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+#### dex
+
+The following yaml snippet is an example how to configure an oidc connector to keep the refresh tokens.
+
+```yaml
+    connectors:
+      - config:
+          clientID: <client_id>
+          clientSecret: <client_secret>
+          orgs:
+          - name: <github_organization>
+          redirectURI: https://kubermatic.test/dex/callback
+        id: github
+        name: GitHub
+        type: github
+        userIDKey: jti
+        userNameKey: email
+```
+
+#### external provider
 
 For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).
+
+### security implications regarding dex solution
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.

--- a/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
@@ -9,3 +9,22 @@ weight = 25
 
 This page documents the list of known issues and possible work arounds/solutions.
 
+## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
+
+### Problem
+
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+
+
+### Root Cause
+
+With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+
+
+### Solution
+
+You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh token belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+
+For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).

--- a/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
@@ -13,18 +13,42 @@ This page documents the list of known issues and possible work arounds/solutions
 
 ### Problem
 
-One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one. This happens when a new one was requested. 
+For oidc authentication to user cluster there is always the same issuer used. This leads to invalidation of refresh tokens when a new authentication happens with the same user because existing refresh tokens for the same user/client pair are invalidated when a new one is requested.
 
 
 ### Root Cause
 
-With the default helm chart values for dex it is only possible to have one refresh token per user/client pair for security reasons. The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
+By default it is only possible to have one refresh token per user/client pair in dex for security reasons. There is an open issue regarding this in the [upstream repository](https://github.com/dexidp/dex/issues/981). The refresh token has by default also no expiration set. This is useful to stay logged in over a longer time because the id_token can be refreshed unless the refresh token is invalidated.
 
+One example would be to download a kubeconfig of one cluster and then of another with the same user. You should only be able to use the first kubeconfig until the id_token expires because the refresh token was already invalidated by the download of the second one.
 
 ### Solution
 
-You can either change this in dex helm values by setting `userIDKey` to `jti` and `userNameKey` for example to `email` in the config section of a connector or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default. 
+You can either change this in dex configuration by setting `userIDKey` to `jti` in the connector section or you could configure an other oidc provider which supports multiple refresh tokens per user-client pair like keycloak does by default.
 
-For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh token belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.
+#### dex
+
+The following yaml snippet is an example how to configure an oidc connector to keep the refresh tokens.
+
+```yaml
+    connectors:
+      - config:
+          clientID: <client_id>
+          clientSecret: <client_secret>
+          orgs:
+          - name: <github_organization>
+          redirectURI: https://kubermatic.test/dex/callback
+        id: github
+        name: GitHub
+        type: github
+        userIDKey: jti
+        userNameKey: email
+```
+
+#### external provider
 
 For an explanation how to configure an other oidc provider than dex take a look at [oidc-provider-configuration]({{< ref "../../tutorials-howtos/oidc-provider-configuration" >}}).
+
+### security implications regarding dex solution
+
+For dex this has some implications. With this configuration a token is generated for each user session. The number of objects stored in kubernetes regarding refresh tokens has no limit anymore. The principle that one refresh belongs to one user/client pair is a security consideration which would be ignored in that case. The only way to revoke a refresh token is then to do it via grpc api which is not exposed by default or by manually deleting the related refreshtoken resource in the kubernetes cluster.


### PR DESCRIPTION
This pr adds information about a problem regarding oidc authentication on kkp usercluster observed in https://github.com/kubermatic/kubermatic/issues/13573 to known issues.