### PR TITLE
Os compatibility update

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/os-support-matrix/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/os-support-matrix/_index.en.md
@@ -11,7 +11,7 @@ KKP supports a multitude of operating systems. One of the unique features of KKP
 
 The following operating systems are currently supported by Kubermatic:
 
-* Ubuntu 20.04 and 22.04
+* Ubuntu 20.04, 22.04 and 24.04
 * RHEL beginning with 8.0 (support is cloud provider-specific)
 * Flatcar (Stable channel)
 * Rocky Linux beginning with 8.0

--- a/content/kubermatic/v2.26/architecture/compatibility/os-support-matrix/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/compatibility/os-support-matrix/_index.en.md
@@ -11,7 +11,7 @@ KKP supports a multitude of operating systems. One of the unique features of KKP
 
 The following operating systems are currently supported by Kubermatic:
 
-* Ubuntu 20.04 and 22.04
+* Ubuntu 20.04, 22.04 and 24.04
 * RHEL beginning with 8.0 (support is cloud provider-specific)
 * Flatcar (Stable channel)
 * Rocky Linux beginning with 8.0


### PR DESCRIPTION
Updating the docs as per the changelog.

I'm not sure if this file also need an update: `architecture/supported-providers/edge/_index.en.md`

> Currently, the edge provider only support Ubuntu 20.04 and 22.04 as an operating system. More support for other operating system will be added in the future.`