### PR TITLE
(fix): minor typos and broken links in docs

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/cluster-templates/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/cluster-templates/_index.en.md
@@ -25,7 +25,7 @@ The regular user with owner or editor privileges can create template in project 
 The admin user can create a template for every project in every scope. Template in `global` scope can be created only by admins.
 
 ## Credentials
-Creating cluster from the template requires credentials to authenticate with the cloud provider. During template creation
+Creating a cluster from the template requires credentials to authenticate with the cloud provider. During template creation,
 the credentials are stored in the secret which is assigned to the cluster template. The credential secret is independent.
 It's just a copy of credentials specified manually by the user or taken from the preset. Any credentials update must be
 processed on the cluster template.
@@ -33,5 +33,5 @@ processed on the cluster template.
 ## Creating and Using Templates
 Cluster templates can be created from scratch to pre-define the cluster configuration. The whole process is done in the UI wizard for the cluster creation.
 
-During the cluster creation process, the end user can pick template and specify the desired number of cluster instances.
-The cluster template doesn't create any link to the clusters. They work independently.
+During the cluster creation process, the end user can pick a template and specify the desired number of cluster instances.
+The cluster template doesn't create any links to the clusters. They work independently.

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/_index.en.md
@@ -8,4 +8,4 @@ weight = 20
 
 ## KKP Security
 
-The information on this section entails how to ensure the security of your KKP deployments. It also include how to enable Pod Security Policy as well as securing your system services.
+The information on this section entails how to ensure the security of your KKP deployments. It also includes how to enable Pod Security Policy as well as securing your system services.

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
@@ -25,7 +25,7 @@ OpenID Connect. For this to work you have to configure both Dex (the `oauth` Hel
 For each service that is supposed to use Dex as an authentication provider, configure a `client`. The callback URL is
 called after authentication has been completed and must point to `https://<domain>/oauth/callback`. Remember that this
 will point to OAuth2-Proxy and is therefore independent of the actual underlying application (Gatekeeper will
-intercept the requesta and not forward it to the upstream service). Generate a secure random secret for each client,
+intercept the request and not forward it to the upstream service). Generate a secure random secret for each client,
 for example by doing `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
 
 A sample configuration for Prometheus and Alertmanager could look like this:

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
@@ -116,7 +116,7 @@ Furthermore, a project quota widget of the active project is visible in the dash
 ## Some Additional Information
 
 {{% notice note %}}
-**Note:** If multiple nodes are created in the same time there is a possibility of a race happening and the quota being exceeded.
+**Note:** If multiple nodes are created at the same time there is a possibility of a race happening and the quota being exceeded.
 As an example, there is a quota which CPU is filled 3/5, a user creates a cluster with 2 nodes, both using 2 CPU. There is a possibility
 of a race happening between calculating and adding the quota for the first machine and the second machine being created. So
 the end result could be that both nodes get created, and the quota ends up exceeded 7/5.
@@ -137,7 +137,7 @@ Nodes which join the cluster using other means than through KKP are not supporte
 
 ## Default Project Resource Quotas
 
-It is possible to set the a default resource quota for all projects which do not have a quota already set.
+It is possible to set the default resource quota for all projects which do not have a quota already set.
 
 In the KKP's KubermaticSettings `globalsettings` resource, there is a field in `spec.defaultQuota` through which
 default project resource quotas can be managed:

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/service-account/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/service-account/_index.en.md
@@ -16,8 +16,8 @@ by default expires after 3 years.
 
 ## Core Concept
 
-Service accounts are considered as project's resource. Only the owner of the project  can create a service account.
-There is no need to create a new groups for SA, we want to assign a service account to one of the already defined groups:
+Service accounts are considered as project's resource. Only the owner of the project can create a service account.
+There is no need to create a new group for SA, we want to assign a service account to one of the already defined groups:
 `editors`, `viewers` or `projectmanagers`.
 
 The KKP User object is used as a service account. To avoid confusion about the purpose of the user the name convention

--- a/content/kubermatic/main/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/main/architecture/requirements/cluster-requirements/_index.en.md
@@ -49,7 +49,7 @@ If you have more than one network adapter, and your Kubernetes components are no
 ## Check Required Ports
 
 Please ensure that all nodes in a user cluster can communicate without restriction to ensure functionality of CNI/CSI and Kubernetes itself.
-In addition, user cluster nodes must be able to connect to the Seed cluster's nodeport-proxy. This depends on the [expose strategy]({{< ref "../../../tutorials-howtos/networking/expose-strategies" >}}.
+In addition, user cluster nodes must be able to connect to the Seed cluster's nodeport-proxy. This depends on the [expose strategy]({{< ref "../../../tutorials-howtos/networking/expose-strategies" >}}).
 
 It is recommended to make yourself familiar with the [concept of networking]({{< ref "../../../architecture/concept/kkp-concepts/networking" >}}) in KKP.
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/cluster-templates/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/cluster-templates/_index.en.md
@@ -25,7 +25,7 @@ The regular user with owner or editor privileges can create template in project 
 The admin user can create a template for every project in every scope. Template in `global` scope can be created only by admins.
 
 ## Credentials
-Creating cluster from the template requires credentials to authenticate with the cloud provider. During template creation
+Creating a cluster from the template requires credentials to authenticate with the cloud provider. During template creation,
 the credentials are stored in the secret which is assigned to the cluster template. The credential secret is independent.
 It's just a copy of credentials specified manually by the user or taken from the preset. Any credentials update must be
 processed on the cluster template.
@@ -33,5 +33,5 @@ processed on the cluster template.
 ## Creating and Using Templates
 Cluster templates can be created from scratch to pre-define the cluster configuration. The whole process is done in the UI wizard for the cluster creation.
 
-During the cluster creation process, the end user can pick template and specify the desired number of cluster instances.
-The cluster template doesn't create any link to the clusters. They work independently.
+During the cluster creation process, the end user can pick a template and specify the desired number of cluster instances.
+The cluster template doesn't create any links to the clusters. They work independently.

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/kkp-security/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/kkp-security/_index.en.md
@@ -8,4 +8,4 @@ weight = 20
 
 ## KKP Security
 
-The information on this section entails how to ensure the security of your KKP deployments. It also include how to enable Pod Security Policy as well as securing your system services.
+The information on this section entails how to ensure the security of your KKP deployments. It also includes how to enable Pod Security Policy as well as securing your system services.

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
@@ -25,7 +25,7 @@ OpenID Connect. For this to work you have to configure both Dex (the `oauth` Hel
 For each service that is supposed to use Dex as an authentication provider, configure a `client`. The callback URL is
 called after authentication has been completed and must point to `https://<domain>/oauth/callback`. Remember that this
 will point to OAuth2-Proxy and is therefore independent of the actual underlying application (Gatekeeper will
-intercept the requesta and not forward it to the upstream service). Generate a secure random secret for each client,
+intercept the request and not forward it to the upstream service). Generate a secure random secret for each client,
 for example by doing `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
 
 A sample configuration for Prometheus and Alertmanager could look like this:

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/resource-quotas/_index.en.md
@@ -116,7 +116,7 @@ Furthermore, a project quota widget of the active project is visible in the dash
 ## Some Additional Information
 
 {{% notice note %}}
-**Note:** If multiple nodes are created in the same time there is a possibility of a race happening and the quota being exceeded.
+**Note:** If multiple nodes are created at the same time there is a possibility of a race happening and the quota being exceeded.
 As an example, there is a quota which CPU is filled 3/5, a user creates a cluster with 2 nodes, both using 2 CPU. There is a possibility
 of a race happening between calculating and adding the quota for the first machine and the second machine being created. So
 the end result could be that both nodes get created, and the quota ends up exceeded 7/5.
@@ -137,7 +137,7 @@ Nodes which join the cluster using other means than through KKP are not supporte
 
 ## Default Project Resource Quotas
 
-It is possible to set the a default resource quota for all projects which do not have a quota already set.
+It is possible to set the default resource quota for all projects which do not have a quota already set.
 
 In the KKP's KubermaticSettings `globalsettings` resource, there is a field in `spec.defaultQuota` through which
 default project resource quotas can be managed:

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/service-account/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/service-account/_index.en.md
@@ -16,8 +16,8 @@ by default expires after 3 years.
 
 ## Core Concept
 
-Service accounts are considered as project's resource. Only the owner of the project  can create a service account.
-There is no need to create a new groups for SA, we want to assign a service account to one of the already defined groups:
+Service accounts are considered as project's resource. Only the owner of the project can create a service account.
+There is no need to create a new group for SA, we want to assign a service account to one of the already defined groups:
 `editors`, `viewers` or `projectmanagers`.
 
 The KKP User object is used as a service account. To avoid confusion about the purpose of the user the name convention

--- a/content/kubermatic/v2.26/architecture/requirements/cluster-requirements/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/requirements/cluster-requirements/_index.en.md
@@ -49,7 +49,7 @@ If you have more than one network adapter, and your Kubernetes components are no
 ## Check Required Ports
 
 Please ensure that all nodes in a user cluster can communicate without restriction to ensure functionality of CNI/CSI and Kubernetes itself.
-In addition, user cluster nodes must be able to connect to the Seed cluster's nodeport-proxy. This depends on the [expose strategy]({{< ref "../../../tutorials-howtos/networking/expose-strategies" >}}.
+In addition, user cluster nodes must be able to connect to the Seed cluster's nodeport-proxy. This depends on the [expose strategy]({{< ref "../../../tutorials-howtos/networking/expose-strategies" >}}).
 
 It is recommended to make yourself familiar with the [concept of networking]({{< ref "../../../architecture/concept/kkp-concepts/networking" >}}) in KKP.
 


### PR DESCRIPTION
This PR fixes minor typos and 1 broken link across various documentation pages to improve readability and clarity. 

Besides the link fix, no functional changes.