### PR TITLE
add KKP 2.27 release notes

### DIFF
--- a/content/kubermatic/v2.27/release-notes/_index.en.md
+++ b/content/kubermatic/v2.27/release-notes/_index.en.md
@@ -4,7 +4,4 @@ date = 2023-11-14T15:00:00+01:00
 weight = 70
 +++
 
-<!--
-Uncomment this and update the URL to the right url:
-{{< render_external_markdown "https://raw.githubusercontent.com/kubermatic/kubermatic/v2.27/docs/changelogs/CHANGELOG-<RELEASE>.md" >}}
--->
+{{< render_external_markdown "https://raw.githubusercontent.com/kubermatic/kubermatic/main/docs/changelogs/CHANGELOG-2.27.md" >}}


### PR DESCRIPTION
This ensures the current release notes for KKP 2.27 are shown.