### PR TITLE
add page for app templating in ee edition

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/application-templating/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/application-templating/_index.en.md
@@ -1,0 +1,20 @@
++++
+title = "Templating"
+date = 2025-03-03T08:31:15+02:00
+weight = 4
+enterprise = true
+
++++
+
+#### Values Templating
+
+KKP treats each `valuesBlock` string value or `values` map in an application installation resource as a
+[Go template](https://golang.org/pkg/text/template/), so it is possible to inject user-cluster related information into applications at runtime. Please refer to the Go documentation for
+the exact templating syntax.
+
+KKP injects an instance of the `TemplateData` struct into each template. The following
+Go snippet shows the available information:
+
+```
+{{< readfile "kubermatic/main/data/applicationdata.go" >}}
+```

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/application-templating/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/application-templating/_index.en.md
@@ -1,0 +1,20 @@
++++
+title = "Templating"
+date = 2025-03-03T08:31:15+02:00
+weight = 4
+enterprise = true
+
++++
+
+#### Values Templating
+
+KKP treats each `valuesBlock` string value or `values` map in an application installation resource as a
+[Go template](https://golang.org/pkg/text/template/), so it is possible to inject user-cluster related information into applications at runtime. Please refer to the Go documentation for
+the exact templating syntax.
+
+KKP injects an instance of the `TemplateData` struct into each template. The following
+Go snippet shows the available information:
+
+```
+{{< readfile "kubermatic/main/data/applicationdata.go" >}}
+```


### PR DESCRIPTION
This pr adds a site to explain how templating can be used for application installation resources in kkp enterprise edition which was added with this [pr](https://github.com/kubermatic/kubermatic/pull/13945) in kubermatic v2.27.