### PR TITLE
use main branch in prometheus AppDef examples

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/applications/create-application-catalog/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/applications/create-application-catalog/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```

--- a/content/kubermatic/v2.21/data/applicationDefinition.yaml
+++ b/content/kubermatic/v2.21/data/applicationDefinition.yaml
@@ -73,7 +73,7 @@ spec:
             # For large repositories, we recommend to either use Tag, Branch or Branch+Commit. This allows a shallow clone, which dramatically speeds up performance
             ref:
               # Branch to checkout. Only the last commit of the branch will be checkout in order to reduce the amount of data to download.
-              branch: master
+              branch: main
               # Commit SHA in a Branch to checkout.
 
               # It must be used in conjunction with branch field.

--- a/content/kubermatic/v2.21/tutorials-howtos/applications/create-application-catalogue/_index.en.md
+++ b/content/kubermatic/v2.21/tutorials-howtos/applications/create-application-catalogue/_index.en.md
@@ -46,7 +46,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```
@@ -242,6 +242,7 @@ spec:
 ```
 
 ## ApplicationDefinition Reference
+
 **The following is an example of ApplicationDefinition, showing all the possible options**.
 
 ```yaml

--- a/content/kubermatic/v2.22/tutorials-howtos/applications/create-application-catalogue/_index.en.md
+++ b/content/kubermatic/v2.22/tutorials-howtos/applications/create-application-catalogue/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```

--- a/content/kubermatic/v2.23/tutorials-howtos/applications/create-application-catalogue/_index.en.md
+++ b/content/kubermatic/v2.23/tutorials-howtos/applications/create-application-catalogue/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```

--- a/content/kubermatic/v2.24/tutorials-howtos/applications/create-application-catalogue/_index.en.md
+++ b/content/kubermatic/v2.24/tutorials-howtos/applications/create-application-catalogue/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```

--- a/content/kubermatic/v2.25/tutorials-howtos/applications/create-application-catalogue/_index.en.md
+++ b/content/kubermatic/v2.25/tutorials-howtos/applications/create-application-catalogue/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```

--- a/content/kubermatic/v2.26/tutorials-howtos/applications/create-application-catalog/_index.en.md
+++ b/content/kubermatic/v2.26/tutorials-howtos/applications/create-application-catalog/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```

--- a/content/kubermatic/v2.27/tutorials-howtos/applications/create-application-catalog/_index.en.md
+++ b/content/kubermatic/v2.27/tutorials-howtos/applications/create-application-catalog/_index.en.md
@@ -42,7 +42,7 @@ spec:
         git:
           path: charts/prometheus
           ref:
-            branch: master
+            branch: main
           remote: https://github.com/prometheus-community/helm-charts
     version: 0.0.0-dev
 ```


### PR DESCRIPTION
The prometheus community helm charts are now hosted at the main branch. Therefore update all of our examples