### PR TITLE
fix sync for KKP

### DIFF
--- a/hack/convert-runbook.sh
+++ b/hack/convert-runbook.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 cd $(dirname $0)/..
 
 SOURCE="${GOPATH}/src/k8c.io/kubermatic/charts/monitoring/prometheus/rules/src"

--- a/hack/convert-runbook.sh
+++ b/hack/convert-runbook.sh
@@ -2,7 +2,7 @@
 
 cd $(dirname $0)/..
 
-SOURCE="${GOPATH}/src/github.com/kubermatic/kubermatic/charts/monitoring/prometheus/rules/src"
+SOURCE="${GOPATH}/src/k8c.io/kubermatic/charts/monitoring/prometheus/rules/src"
 
 # merge all files and convert to JSON,
 # filter out rules that are not alerts,

--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -9,11 +9,11 @@ OUTPUT_VERSION="${OUTPUT_VERSION:-main}"
 
 if [[ -z "$SOURCE" ]]; then
   gopath="$(go env GOPATH)"
-  SOURCE="$gopath/src/k8c.io/kubermatic/pkg/apis"
+  SOURCE="$gopath/src/k8c.io/kubermatic/sdk/apis"
 
   if ! [ -d "$SOURCE" ]; then
     # legacy path before we set the path_alias on the sync job
-    SOURCE="$gopath/src/github.com/kubermatic/kubermatic/pkg/apis"
+    SOURCE="$gopath/src/github.com/kubermatic/kubermatic/sdk/apis"
 
     if ! [ -d "$SOURCE" ]; then
       echo "\$SOURCE not set and KKP not automatically found."


### PR DESCRIPTION
Since the SDK was introduced, the path detection did not work again.

Also, the runbook script has been failing for a long time because of the broken path. 

This PR fixes both issues.