### PR TITLE
Improve KKP runbook versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CODESPELL_IMAGE ?= quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+CODESPELL_IMAGE ?= quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-1
 CODESPELL_BIN := $(shell which codespell)
 DOCKER_BIN := $(shell which docker)
 

--- a/hack/convert-runbook.sh
+++ b/hack/convert-runbook.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 cd $(dirname $0)/..
 
+KKP_RELEASE="${KKP_RELEASE:-main}"
+
 SOURCE="${GOPATH}/src/k8c.io/kubermatic/charts/monitoring/prometheus/rules/src"
 
 # merge all files and convert to JSON,
@@ -21,4 +23,4 @@ yq eval-all '. as $item ireduce ({}; . *+ $item)' ${SOURCE}/*/*.yaml -o json | \
       select (.rules | length > 0)
     ]
   }" \
-  > data/kubermatic/main/runbook.json
+  > data/kubermatic/$KKP_RELEASE/runbook.json

--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -5,19 +5,25 @@ set -euo pipefail
 cd $(dirname $0)/..
 
 SOURCE="${SOURCE:-}"
-OUTPUT_VERSION="${OUTPUT_VERSION:-main}"
+KKP_RELEASE="${KKP_RELEASE:-main}"
 
 if [[ -z "$SOURCE" ]]; then
   gopath="$(go env GOPATH)"
   SOURCE="$gopath/src/k8c.io/kubermatic/sdk/apis"
 
   if ! [ -d "$SOURCE" ]; then
-    # legacy path before we set the path_alias on the sync job
-    SOURCE="$gopath/src/github.com/kubermatic/kubermatic/sdk/apis"
+    # legacy path before KKP 2.28 got its new SDK
+    SOURCE="$gopath/src/k8c.io/kubermatic/pkg/apis"
 
     if ! [ -d "$SOURCE" ]; then
-      echo "\$SOURCE not set and KKP not automatically found."
-      exit 1
+      # legacy path before we set the path_alias on the sync job;
+      # this can be removed sometime in 2026
+      SOURCE="$gopath/src/github.com/kubermatic/kubermatic/pkg/apis"
+
+      if ! [ -d "$SOURCE" ]; then
+        echo "\$SOURCE not set and KKP not automatically found."
+        exit 1
+      fi
     fi
   fi
 fi
@@ -48,4 +54,4 @@ $(go env GOPATH)/bin/crd-ref-docs \
   --renderer markdown \
   --templates-dir hack/crd-templates \
   --config "$configFile" \
-  --output-path content/kubermatic/${OUTPUT_VERSION}/references/crds/_index.en.md
+  --output-path "content/kubermatic/$KKP_RELEASE/references/crds/_index.en.md"


### PR DESCRIPTION
https://github.com/kubermatic/kubermatic/pull/14288 will now set `KKP_RELEASE` to either "main" or a "vX.Y" string. We can now use this to put the generated docs in the right place.

Right now the prowjob is only triggered for the KKP main branch, so KKP_RELEASE will currently always be "main". But once the job is updated (and 14288 is backported in KKP), we should see more different releases here.