### PR TITLE
Fix configuration snippet for refresh token issue workaround

### DIFF
--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -7,7 +7,7 @@ weight = 25
 
 ## Overview
 
-This page documents the list of known issues and possible work arounds/solutions.
+This page documents the list of known issues and possible workarounds/solutions.
 
 ## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
 
@@ -45,7 +45,12 @@ The following yaml snippet is an example how to configure an oidc connector to k
             - email
             - offline_access
           # Workaround to support multiple user_id/client_id pairs concurrently
-          userIDKey: jti
+          # Configurable key for user ID look up
+          # Default: id
+          userIDKey: <<userIDValue>>
+          # Optional: Configurable key for user name look up
+          # Default: user_name
+          userNameKey: <<userNameValue>>
 ```
 
 #### external provider

--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -32,17 +32,20 @@ The following yaml snippet is an example how to configure an oidc connector to k
 
 ```yaml
     connectors:
-      - config:
+      - id: oidc
+        name: OIDC
+        type: Google
+        config:
           clientID: <client_id>
           clientSecret: <client_secret>
-          orgs:
-          - name: <github_organization>
-          redirectURI: https://kubermatic.test/dex/callback
-        id: github
-        name: GitHub
-        type: github
-        userIDKey: jti
-        userNameKey: email
+          redirectURI: https://kkp.example.com/dex/callback
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          # Workaround to support multiple user_id/client_id pairs concurrently
+          userIDKey: jti
 ```
 
 #### external provider

--- a/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
@@ -7,7 +7,7 @@ weight = 25
 
 ## Overview
 
-This page documents the list of known issues and possible work arounds/solutions.
+This page documents the list of known issues and possible workarounds/solutions.
 
 ## Latest Ubuntu 22.04 image prevents creating new EBS volumes on AWS
 
@@ -201,7 +201,12 @@ The following yaml snippet is an example how to configure an oidc connector to k
             - email
             - offline_access
           # Workaround to support multiple user_id/client_id pairs concurrently
-          userIDKey: jti
+          # Configurable key for user ID look up
+          # Default: id
+          userIDKey: <<userIDValue>>
+          # Optional: Configurable key for user name look up
+          # Default: user_name
+          userNameKey: <<userNameValue>>
 ```
 
 #### external provider

--- a/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/known-issues/_index.en.md
@@ -188,17 +188,20 @@ The following yaml snippet is an example how to configure an oidc connector to k
 
 ```yaml
     connectors:
-      - config:
+      - id: oidc
+        name: OIDC
+        type: Google
+        config:
           clientID: <client_id>
           clientSecret: <client_secret>
-          orgs:
-          - name: <github_organization>
-          redirectURI: https://kubermatic.test/dex/callback
-        id: github
-        name: GitHub
-        type: github
-        userIDKey: jti
-        userNameKey: email
+          redirectURI: https://kkp.example.com/dex/callback
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          # Workaround to support multiple user_id/client_id pairs concurrently
+          userIDKey: jti
 ```
 
 #### external provider

--- a/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
@@ -7,7 +7,7 @@ weight = 25
 
 ## Overview
 
-This page documents the list of known issues and possible work arounds/solutions.
+This page documents the list of known issues and possible workarounds/solutions.
 
 ## Latest Ubuntu 22.04 image prevents creating new EBS volumes on AWS
 
@@ -186,7 +186,12 @@ The following yaml snippet is an example how to configure an oidc connector to k
             - email
             - offline_access
           # Workaround to support multiple user_id/client_id pairs concurrently
-          userIDKey: jti
+          # Configurable key for user ID look up
+          # Default: id
+          userIDKey: <<userIDValue>>
+          # Optional: Configurable key for user name look up
+          # Default: user_name
+          userNameKey: <<userNameValue>>
 ```
 
 #### external provider

--- a/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/known-issues/_index.en.md
@@ -173,17 +173,20 @@ The following yaml snippet is an example how to configure an oidc connector to k
 
 ```yaml
     connectors:
-      - config:
+      - id: oidc
+        name: OIDC
+        type: Google
+        config:
           clientID: <client_id>
           clientSecret: <client_secret>
-          orgs:
-          - name: <github_organization>
-          redirectURI: https://kubermatic.test/dex/callback
-        id: github
-        name: GitHub
-        type: github
-        userIDKey: jti
-        userNameKey: email
+          redirectURI: https://kkp.example.com/dex/callback
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          # Workaround to support multiple user_id/client_id pairs concurrently
+          userIDKey: jti
 ```
 
 #### external provider

--- a/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
@@ -7,7 +7,7 @@ weight = 25
 
 ## Overview
 
-This page documents the list of known issues and possible work arounds/solutions.
+This page documents the list of known issues and possible workarounds/solutions.
 
 ## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
 
@@ -45,7 +45,12 @@ The following yaml snippet is an example how to configure an oidc connector to k
             - email
             - offline_access
           # Workaround to support multiple user_id/client_id pairs concurrently
-          userIDKey: jti
+          # Configurable key for user ID look up
+          # Default: id
+          userIDKey: <<userIDValue>>
+          # Optional: Configurable key for user name look up
+          # Default: user_name
+          userNameKey: <<userNameValue>>
 ```
 
 #### external provider

--- a/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/known-issues/_index.en.md
@@ -32,17 +32,20 @@ The following yaml snippet is an example how to configure an oidc connector to k
 
 ```yaml
     connectors:
-      - config:
+      - id: oidc
+        name: OIDC
+        type: Google
+        config:
           clientID: <client_id>
           clientSecret: <client_secret>
-          orgs:
-          - name: <github_organization>
-          redirectURI: https://kubermatic.test/dex/callback
-        id: github
-        name: GitHub
-        type: github
-        userIDKey: jti
-        userNameKey: email
+          redirectURI: https://kkp.example.com/dex/callback
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          # Workaround to support multiple user_id/client_id pairs concurrently
+          userIDKey: jti
 ```
 
 #### external provider

--- a/content/kubermatic/v2.27/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/known-issues/_index.en.md
@@ -7,7 +7,7 @@ weight = 25
 
 ## Overview
 
-This page documents the list of known issues and possible work arounds/solutions.
+This page documents the list of known issues and possible workarounds/solutions.
 
 ## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
 
@@ -45,7 +45,12 @@ The following yaml snippet is an example how to configure an oidc connector to k
             - email
             - offline_access
           # Workaround to support multiple user_id/client_id pairs concurrently
-          userIDKey: jti
+          # Configurable key for user ID look up
+          # Default: id
+          userIDKey: <<userIDValue>>
+          # Optional: Configurable key for user name look up
+          # Default: user_name
+          userNameKey: <<userNameValue>>
 ```
 
 #### external provider

--- a/content/kubermatic/v2.27/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/known-issues/_index.en.md
@@ -32,17 +32,20 @@ The following yaml snippet is an example how to configure an oidc connector to k
 
 ```yaml
     connectors:
-      - config:
+      - id: oidc
+        name: OIDC
+        type: Google
+        config:
           clientID: <client_id>
           clientSecret: <client_secret>
-          orgs:
-          - name: <github_organization>
-          redirectURI: https://kubermatic.test/dex/callback
-        id: github
-        name: GitHub
-        type: github
-        userIDKey: jti
-        userNameKey: email
+          redirectURI: https://kkp.example.com/dex/callback
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          # Workaround to support multiple user_id/client_id pairs concurrently
+          userIDKey: jti
 ```
 
 #### external provider

--- a/content/kubermatic/v2.28/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/known-issues/_index.en.md
@@ -7,7 +7,7 @@ weight = 25
 
 ## Overview
 
-This page documents the list of known issues and possible work arounds/solutions.
+This page documents the list of known issues and possible workarounds/solutions.
 
 ## Oidc refresh tokens are invalidated when the same user/client id pair is authenticated multiple times
 
@@ -32,17 +32,25 @@ The following yaml snippet is an example how to configure an oidc connector to k
 
 ```yaml
     connectors:
-      - config:
+      - id: oidc
+        name: OIDC
+        type: Google
+        config:
           clientID: <client_id>
           clientSecret: <client_secret>
-          orgs:
-          - name: <github_organization>
-          redirectURI: https://kubermatic.test/dex/callback
-        id: github
-        name: GitHub
-        type: github
-        userIDKey: jti
-        userNameKey: email
+          redirectURI: https://kkp.example.com/dex/callback
+          scopes:
+            - openid
+            - profile
+            - email
+            - offline_access
+          # Workaround to support multiple user_id/client_id pairs concurrently
+          # Configurable key for user ID look up
+          # Default: id
+          userIDKey: <<userIDValue>>
+          # Optional: Configurable key for user name look up
+          # Default: user_name
+          userNameKey: <<userNameValue>>
 ```
 
 #### external provider


### PR DESCRIPTION
Part of this https://github.com/kubermatic/docs/pull/1808
Updated the connector snippet which includes fix for the `userIDKey` mapping placement under `config`.