### PR TITLE
KDP: document delete permission for api-syncagent

### DIFF
--- a/content/developer-platform/tutorials/agent-without-kdp/_index.en.md
+++ b/content/developer-platform/tutorials/agent-without-kdp/_index.en.md
@@ -126,6 +126,7 @@ rules:
       - watch
       - create
       - update
+      - delete
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The api-syncagent should alwaays have delete permissions on objects so it can delete objects when the representation in kcp has been deleted by the user.