### PR TITLE
Add upgrade guide for blackbox-exporter in 2.28

### DIFF
--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.27-to-2.28/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.27-to-2.28/_index.en.md
@@ -38,10 +38,35 @@ If you are using `kubermatic-installer` for the Seed MLA installation, then it w
 ./kubermatic-installer deploy seed-mla --helm-values values.yaml
 ```
 
-If you are installing MLA using GitOps / Manual way using HelmCLI, before upgrading, you must delete the existing delete the existing Helm release before doing the upgrade.
+If you are installing MLA using GitOps / Manual way using Helm CLI, before upgrading, you must delete the existing Helm release before doing the upgrade.
 
 ```bash
 helm --namespace monitoring delete node-exporter
+```
+Afterwards you can install the new release from the chart using Helm CLI or using your favourite GitOps tool.
+
+### Blackbox Exporter Upgrade (Seed MLA)
+
+KKP 2.28 removes the custom Helm chart for Blackbox Exporter and instead now reuses the official [upstream Helm chart](https://prometheus-community.github.io/helm-charts).
+
+#### Migration Procedure
+
+The following actions are required for migration before performing the upgrade:
+- Replace the top-level key `blackboxExporter` with `blackbox-exporter` in the `values.yaml`
+- Any custom modules should be moved from `blackboxExporter.modules` to `blackbox-exporter.config.modules`.
+
+Once the above adjustments have been made, you can do the seed-mla installation.
+
+If you are using `kubermatic-installer` for the Seed MLA installation, then it will take care of removing the resources for the deprecated node-exporter helm-chart and installing the new upstream based helm-chart by itself.
+
+```bash
+./kubermatic-installer deploy seed-mla --helm-values values.yaml
+```
+
+If you are installing MLA using GitOps / Manual way using Helm CLI, before upgrading, you must delete the existing Helm release before doing the upgrade.
+
+```bash
+helm --namespace monitoring delete blackbox-exporter
 ```
 Afterwards you can install the new release from the chart using Helm CLI or using your favourite GitOps tool.
 


### PR DESCRIPTION
Adds instructions for values migration and manual installation of new version of blackbox-exporter helm chart.