### PR TITLE
Updated k8s compatability matrix

### DIFF
--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -28,11 +28,11 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version          | 1.31 | 1.30 | 1.29 | 1.28 | 1.27[^2] | 1.26[^2] |
-| -------------------- | -----| ---- | ---- | ---- | ---------| -------- |
-| 2.27.x               | ✓    |  ✓   | ✓    | ✓    | --       | --       |
-| 2.26.x               | ✓    |  ✓   | ✓    | ✓    | --       | --       |
-| 2.25.x               | --   | --   | ✓    | ✓    | ✓        | --       |
+| KKP version          |  1.33 |1.32 | 1.31 | 1.30 | 1.29[^2]  | 1.28[^2]  |
+| -------------------- | -----|-----|-----| ---- | ---- | ---- |
+| 2.28.x               | ✓    |  ✓    |  ✓   | ✓    | --    | --       |
+| 2.27.x               | --   | ✓    |  ✓    |  ✓   | ✓    | --    |
+| 2.26.x               | --   | --   | ✓    |  ✓   | ✓    | ✓    |
 
 [^2]: Kubernetes releases below version 1.27 have reached End-of-Life (EOL). We strongly
 recommend upgrading to a supported Kubernetes release as soon as possible. Refer to the

--- a/content/kubermatic/v2.27/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/compatibility/supported-versions/_index.en.md
@@ -28,11 +28,11 @@ these migrations.
 In the following table you can find the supported Kubernetes versions for the
 current KKP version.
 
-| KKP version          | 1.31 | 1.30 | 1.29 | 1.28 | 1.27[^2] | 1.26[^2] |
+| KKP version          | 1.32 |1.31 | 1.30 | 1.29[^2] | 1.28[^2] | 1.27[^2] |
 | -------------------- | -----| ---- | ---- | ---- | ---------| -------- |
 | 2.27.x               | ✓    |  ✓   | ✓    | ✓    | --       | --       |
-| 2.26.x               | ✓    |  ✓   | ✓    | ✓    | --       | --       |
-| 2.25.x               | --   | --   | ✓    | ✓    | ✓        | --       |
+| 2.26.x               | --   | ✓    |  ✓   | ✓    | ✓    | --       |
+| 2.25.x               | --   | --   | --   | ✓    | ✓    | ✓        |
 
 [^2]: Kubernetes releases below version 1.27 have reached End-of-Life (EOL). We strongly
 recommend upgrading to a supported Kubernetes release as soon as possible. Refer to the


### PR DESCRIPTION
This PR is to update the kubernetes compatability matrix corresponding to KKP `main` and `v2.27` version.