### PR TITLE
Followup of #1852 - replicated loki ingester storage documentation from 2.25 to newer versions

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -228,7 +228,16 @@ For larger scales, you will may start with tweaking the following:
 - Cortex Ingester replicas (cortex values.yaml - `cortex.ingester.replicas`) - default 3
 - Cortex Ingester volume sizes (cortex values.yaml - `cortex.ingester.persistentVolume.size`) - default 10Gi
 - Loki Ingester replicas (loki values.yaml - `loki-distributed.ingester.replicas`) - default 3
-- Loki Ingester volume sizes (loki values.yaml - `loki-distributed.ingester.persistentVolume.size`) - default 10Gi
+- Loki Ingester Storage as follows:
+```yaml
+loki-distributed:
+  ingester:
+    persistence:
+      claims:
+        - name: data
+          size: 250Gi # <---- your storage size here
+          storageClass: kubermatic-fast
+```
 
 For more details about configuring these components in an HA manner, you can review the following links:
 

--- a/content/kubermatic/v2.26/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/v2.26/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -228,7 +228,16 @@ For larger scales, you will may start with tweaking the following:
 - Cortex Ingester replicas (cortex values.yaml - `cortex.ingester.replicas`) - default 3
 - Cortex Ingester volume sizes (cortex values.yaml - `cortex.ingester.persistentVolume.size`) - default 10Gi
 - Loki Ingester replicas (loki values.yaml - `loki-distributed.ingester.replicas`) - default 3
-- Loki Ingester volume sizes (loki values.yaml - `loki-distributed.ingester.persistentVolume.size`) - default 10Gi
+- Loki Ingester Storage as follows:
+```yaml
+loki-distributed:
+  ingester:
+    persistence:
+      claims:
+        - name: data
+          size: 250Gi # <---- your storage size here
+          storageClass: kubermatic-fast
+```
 
 For more details about configuring these components in an HA manner, you can review the following links:
 

--- a/content/kubermatic/v2.27/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/v2.27/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -228,7 +228,16 @@ For larger scales, you will may start with tweaking the following:
 - Cortex Ingester replicas (cortex values.yaml - `cortex.ingester.replicas`) - default 3
 - Cortex Ingester volume sizes (cortex values.yaml - `cortex.ingester.persistentVolume.size`) - default 10Gi
 - Loki Ingester replicas (loki values.yaml - `loki-distributed.ingester.replicas`) - default 3
-- Loki Ingester volume sizes (loki values.yaml - `loki-distributed.ingester.persistentVolume.size`) - default 10Gi
+- Loki Ingester Storage as follows:
+```yaml
+loki-distributed:
+  ingester:
+    persistence:
+      claims:
+        - name: data
+          size: 250Gi # <---- your storage size here
+          storageClass: kubermatic-fast
+```
 
 For more details about configuring these components in an HA manner, you can review the following links:
 


### PR DESCRIPTION
We had external contribution (https://github.com/kubermatic/docs/pull/1852) which fixed documentation only foe KKP v2.25.

This PR brings that documentation over to other later versions of KKP and unreleased main branch as well.