### PR TITLE
Rearrange the Dex migration section in Upgrading to KKP 2.28 docs

### DIFF
--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.27-to-2.28/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.27-to-2.28/_index.en.md
@@ -111,33 +111,6 @@ Finally, cleanup the leftover PVC resources from old helm chart installation.
 kubectl delete pvc -n monitoring -l app=alertmanager
 ```
 
-## Upgrade Procedure
-
-Before starting the upgrade, make sure your KKP Master and Seed clusters are healthy with no failing or pending Pods. If any Pod is showing problems, investigate and fix the individual problems before applying the upgrade. This includes the control plane components for user clusters, unhealthy user clusters should not be submitted to an upgrade.
-
-### KKP Master Upgrade
-
-Download the latest 2.28.x release archive for the correct edition (`ce` for Community Edition, `ee` for Enterprise Edition) from [the release page](https://github.com/kubermatic/kubermatic/releases) and extract it locally on your computer. Make sure you have the `values.yaml` you used to deploy KKP 2.28 available and already adjusted for any 2.28 changes (also see [Pre-Upgrade Considerations](#pre-upgrade-considerations)), as you need to pass it to the installer. The `KubermaticConfiguration` is no longer necessary (unless you are adjusting it), as the KKP operator will use its in-cluster representation. From within the extracted directory, run the installer:
-
-```sh
-$ ./kubermatic-installer deploy kubermatic-master --helm-values path/to/values.yaml
-
-# Placeholder for example output for a successful upgrade
-
-```
-
-Upgrading seed clusters is not necessary, unless you are running the `minio` Helm chart or User Cluster MLA as distributed by KKP on them. They will be automatically upgraded by KKP components.
-
-You can follow the upgrade process by either supervising the Pods on master and seed clusters (by simply checking `kubectl get pods -n kubermatic` frequently) or checking status information for the `Seed` objects. A possible command to extract the current status by seed would be:
-
-```sh
-$ kubectl get seeds -A -o jsonpath="{range .items[*]}{.metadata.name} - {.status}{'\n'}{end}"
-
-# Place holder for output
-```
-
-Of particular interest to the upgrade process is if the `ResourcesReconciled` condition succeeded and if the `versions.kubermatic` field is showing the target KKP version. If this is not the case yet, the upgrade is still in flight. If the upgrade is stuck, try `kubectl -n kubermatic describe seed <seed name>` to see what exactly is keeping the KKP Operator from updating the Seed cluster.
-
 ### Dex Migration
 
 The custom `oauth` Helm chart in KKP was deprecated in 2.27 and has been removed in 2.28. `dex`, which is based on the [official upstream chart](https://github.com/dexidp/helm-charts/tree/master/charts/dex) has replaced it.
@@ -308,6 +281,33 @@ Once you have verified that the new Dex installation is up and running, you can 
 
 - point KKP to the new Dex installation (if its new URL is meant to be permanent) by changing the `tokenIssuer` in the `KubermaticConfiguration`, or
 - delete the old `oauth` release (`helm -n oauth delete oauth`) and then re-deploy the new Dex release, but with the same host+path as the old `oauth` chart used, so that no further changes are necessary in downstream components like KKP. This will incur a short downtime, while no Ingress exists for the issuer URL configured in KKP.
+
+## Upgrade Procedure
+
+Before starting the upgrade, make sure your KKP Master and Seed clusters are healthy with no failing or pending Pods. If any Pod is showing problems, investigate and fix the individual problems before applying the upgrade. This includes the control plane components for user clusters, unhealthy user clusters should not be submitted to an upgrade.
+
+### KKP Master Upgrade
+
+Download the latest 2.28.x release archive for the correct edition (`ce` for Community Edition, `ee` for Enterprise Edition) from [the release page](https://github.com/kubermatic/kubermatic/releases) and extract it locally on your computer. Make sure you have the `values.yaml` you used to deploy KKP 2.28 available and already adjusted for any 2.28 changes (also see [Pre-Upgrade Considerations](#pre-upgrade-considerations)), as you need to pass it to the installer. The `KubermaticConfiguration` is no longer necessary (unless you are adjusting it), as the KKP operator will use its in-cluster representation. From within the extracted directory, run the installer:
+
+```sh
+$ ./kubermatic-installer deploy kubermatic-master --helm-values path/to/values.yaml
+
+# Placeholder for example output for a successful upgrade
+
+```
+
+Upgrading seed clusters is not necessary, unless you are running the `minio` Helm chart or User Cluster MLA as distributed by KKP on them. They will be automatically upgraded by KKP components.
+
+You can follow the upgrade process by either supervising the Pods on master and seed clusters (by simply checking `kubectl get pods -n kubermatic` frequently) or checking status information for the `Seed` objects. A possible command to extract the current status by seed would be:
+
+```sh
+$ kubectl get seeds -A -o jsonpath="{range .items[*]}{.metadata.name} - {.status}{'\n'}{end}"
+
+# Place holder for output
+```
+
+Of particular interest to the upgrade process is if the `ResourcesReconciled` condition succeeded and if the `versions.kubermatic` field is showing the target KKP version. If this is not the case yet, the upgrade is still in flight. If the upgrade is stuck, try `kubectl -n kubermatic describe seed <seed name>` to see what exactly is keeping the KKP Operator from updating the Seed cluster.
 
 ## Post-Upgrade Considerations
 


### PR DESCRIPTION
This PR is to move Dex migration sub-section under Pre-upgrade consideration section in `main`  and to fix the broken content of Alertmanager upgrade sub-section  Dex migration movement done under Pre-upgrade consideration section in `2.28`.