### PR TITLE
Update compatibility matrix for OSM

### DIFF
--- a/content/operatingsystemmanager/compatibility/_index.en.md
+++ b/content/operatingsystemmanager/compatibility/_index.en.md
@@ -34,7 +34,7 @@ The following operating systems are currently supported by the default Operating
 
 Currently supported K8S versions are:
 
+* 1.33
+* 1.32
 * 1.31
 * 1.30
-* 1.29
-* 1.28


### PR DESCRIPTION
This PR is for updating the supported k8s versions in compatibility matrix of OSM. 
Related to https://github.com/kubermatic/operating-system-manager/pull/465