### PR TITLE
Add values for Gateway API CRDs installation in KubeLB CCM configuration

### DIFF
--- a/content/kubelb/main/installation/tenant-cluster/_index.en.md
+++ b/content/kubelb/main/installation/tenant-cluster/_index.en.md
@@ -138,6 +138,8 @@ helm upgrade --install kubelb-ccm kubelb-ccm-ee --namespace kubelb -f kubelb-ccm
 | kubelb.disableUDPRouteController | bool | `false` | disableUDPRouteController specifies whether to disable the UDPRoute Controller. |
 | kubelb.enableLeaderElection | bool | `true` | Enable the leader election. |
 | kubelb.enableSecretSynchronizer | bool | `false` | Enable to automatically convert Secrets labelled with `kubelb.k8c.io/managed-by: kubelb` to Sync Secrets. This is used to sync secrets from tenants to the LB cluster in a controlled and secure way. |
+| kubelb.gatewayAPICRDsChannel | string | `"experimental"` | gatewayAPICRDsChannel specifies the channel for the Gateway API CRDs. Options are `standard` and `experimental`. |
+| kubelb.installGatewayAPICRDs | bool | `false` | installGatewayAPICRDs Installs and manages the Gateway API CRDs using gateway crd controller. |
 | kubelb.nodeAddressType | string | `"ExternalIP"` | Address type to use for routing traffic to node ports. Values are ExternalIP, InternalIP. |
 | kubelb.tenantName | string | `nil` | Name of the tenant, must be unique against a load balancer cluster. |
 | kubelb.useGatewayClass | bool | `true` | useGatewayClass specifies whether to target resources with `kubelb` gateway class or all resources. |
@@ -206,6 +208,8 @@ helm upgrade --install kubelb-ccm kubelb-ccm --namespace kubelb -f kubelb-ccm/va
 | kubelb.disableIngressController | bool | `false` | disableIngressController specifies whether to disable the Ingress Controller. |
 | kubelb.enableLeaderElection | bool | `true` | Enable the leader election. |
 | kubelb.enableSecretSynchronizer | bool | `false` | Enable to automatically convert Secrets labelled with `kubelb.k8c.io/managed-by: kubelb` to Sync Secrets. This is used to sync secrets from tenants to the LB cluster in a controlled and secure way. |
+| kubelb.gatewayAPICRDsChannel | string | `"standard"` | gatewayAPICRDsChannel specifies the channel for the Gateway API CRDs. Options are `standard` and `experimental`. |
+| kubelb.installGatewayAPICRDs | bool | `false` | installGatewayAPICRDs Installs and manages the Gateway API CRDs using gateway crd controller. |
 | kubelb.nodeAddressType | string | `"ExternalIP"` | Address type to use for routing traffic to node ports. Values are ExternalIP, InternalIP. |
 | kubelb.tenantName | string | `nil` | Name of the tenant, must be unique against a load balancer cluster. |
 | kubelb.useGatewayClass | bool | `true` | useGatewayClass specifies whether to target resources with `kubelb` gateway class or all resources. |
@@ -241,40 +245,6 @@ helm upgrade --install kubelb-ccm kubelb-ccm --namespace kubelb -f kubelb-ccm/va
 {{% /tab %}}
 {{< /tabs >}}
 
-## Setup the tenant cluster
-
-### Install Gateway API CRDs
-
-At this point, the KubeLB CCM should be installed and running in the tenant cluster. Next steps are to install the Gateway API CRDs in the cluster. This is required to use the Gateway API resources in the tenant cluster.
-
-{{< tabs name="Gateway APIs" >}}
-{{% tab name="Enterprise Edition" %}}
-
-Use the Experimental channel to install the CRDs:
-
-```sh
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml
-```
-
-For more details: [Experimental Install](https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel)
-{{% /tab %}}
-{{% tab name="Community Edition" %}}
-
-Use the Standard channel to install the CRDs:
-
-```sh
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
-```
-
-For more details: [Standard Install](https://gateway-api.sigs.k8s.io/guides/#install-standard-channel)
-
-{{% /tab %}}
-{{< /tabs >}}
-
 {{% notice info %}}
-Due to the following reasons this has been left as a manual step and we haven't added these CRDs to the KubeLB Manager chart, for automated installation:
-
-* We can't have optional CRDs in a helm chart.
-* Installing it through the helm chart would result in the existing CRDs in the tenant cluster to be overwritten. Which is not the desired behavior.
-
+The manual step needed to install the Gateway API CRDs has been automated and can be enabled by setting `kubelb.installGatewayAPICRDs` to `true` in the `values.yaml` file. This will install the CRDs automatically when the KubeLB CCM is deployed.
 {{% /notice %}}


### PR DESCRIPTION
This PR updates docs for Kubelb CCM to add 2 values in Kubelb CCM chart related to installation of Gateway API CRDs.
 - kubelb.gatewayAPICRDsChannel
 - kubelb.installGatewayAPICRDs	

