### PR TITLE
add explanation for introduced osm containerd device ownership flag

### DIFF
--- a/content/operatingsystemmanager/guides/osm-configuration/_index.en.md
+++ b/content/operatingsystemmanager/guides/osm-configuration/_index.en.md
@@ -34,6 +34,7 @@ OSM can be configured using the following command line flags:
 | `bootstrap-token-service-account-name` | string | false | `""` | When set use the service account token from this SA as bootstrap token instead of creating a temporary one. Passed in `namespace/name` format. |
 | `worker-count` | int | false | `10` | Number of workers which process reconciliation in parallel. |
 | `ca-bundle` | string | false | `""` | Path to a file containing all PEM-encoded CA certificates. Will be used for Kubernetes CA certificates. |
+| `device-ownership-from-security-context` | bool | false | `false` | Containerd setting for whether non-root users should be allowed to use devices on the node. |
 
 ## Configuring Operating System Profile
 


### PR DESCRIPTION
This pr adds explanation of new introduced flag `device-ownership-from-security-context` to configure this setting for containerd.
ref: https://github.com/kubermatic/operating-system-manager/pull/499