### PR TITLE
Minor update KKP KubeLB doc

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/kubelb/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kubelb/_index.en.md
@@ -25,7 +25,9 @@ KubeLB can be configured in the following way:
 ```yaml
 apiVersion: v1
 data:
-  kubelb: xxx-base64-encoded-xxx
+  # You can use `base64 -w0 kubelb-management-kubeconfig` to encode the
+  # kubeconfig properly for inserting into this Secret.
+  kubeconfig: <base64 encoded kubeconfig>
 kind: Secret
 metadata:
   name: kubelb-management-cluster

--- a/content/kubermatic/v2.27/tutorials-howtos/kubelb/_index.en.md
+++ b/content/kubermatic/v2.27/tutorials-howtos/kubelb/_index.en.md
@@ -25,7 +25,9 @@ KubeLB can be configured in the following way:
 ```yaml
 apiVersion: v1
 data:
-  kubelb: xxx-base64-encoded-xxx
+  # You can use `base64 -w0 kubelb-management-kubeconfig` to encode the
+  # kubeconfig properly for inserting into this Secret.
+  kubeconfig: <base64 encoded kubeconfig>
 kind: Secret
 metadata:
   name: kubelb-management-cluster

--- a/content/kubermatic/v2.28/tutorials-howtos/kubelb/_index.en.md
+++ b/content/kubermatic/v2.28/tutorials-howtos/kubelb/_index.en.md
@@ -25,7 +25,9 @@ KubeLB can be configured in the following way:
 ```yaml
 apiVersion: v1
 data:
-  kubelb: xxx-base64-encoded-xxx
+  # You can use `base64 -w0 kubelb-management-kubeconfig` to encode the
+  # kubeconfig properly for inserting into this Secret.
+  kubeconfig: <base64 encoded kubeconfig>
 kind: Secret
 metadata:
   name: kubelb-management-cluster


### PR DESCRIPTION
This PR is made to take care of: 
- Mainly to make correction for the key `.data.kubelb` --> `.data.kubeconfig` in the `kubelb-management-cluster` secret example. 
- Add hint for end user on how to generate base64 encoded kubeconfig secret. 