### PR TITLE
Fix indentation of ClusterIssuer

### DIFF
--- a/content/developer-platform/setup/quickstart/data/letsencrypt.cluster-issuer.yaml
+++ b/content/developer-platform/setup/quickstart/data/letsencrypt.cluster-issuer.yaml
@@ -11,5 +11,5 @@ spec:
       name: letsencrypt-prod-credentials
     solvers:
       - http01:
-        ingress:
-          class: nginx
+          ingress:
+            class: nginx


### PR DESCRIPTION
This PR corrects the indentation of the Let's Encrypt ClusterIssuer used in the KDP quickstart guide.