### PR TITLE
Fix typo in Default applications documentation

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -26,7 +26,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select cert-manager Application](01-select-application-cert-manager-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for cert-manager Application](02-settings-cert-manager-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Falco Application](01-select-application-falco-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Falco Application](02-settings-falco-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
@@ -28,7 +28,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Flux2 Application](01-select-application-flux2-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Flux2 Application](02-settings-flux2-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
@@ -25,7 +25,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select K8sGPT Application](01-select-application-k8sgpt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for K8sGPT Application](02-settings-k8sgpt-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Kube-VIP Application](01-select-application-kube-vip-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Kube-VIP Application](02-settings-kube-vip-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
@@ -30,6 +30,6 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select KubeVirt Application](01-select-application-kubevirt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for KubeVirt Application](02-settings-kubevirt-app.png)

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
@@ -23,7 +23,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select MetalLB Application](01-select-application-metallb-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for MetalLB Application](02-settings-metallb-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nginx Application](01-select-application-nginx-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nginx Application](02-settings-nginx-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
@@ -21,7 +21,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nvidia GPU Operator Application](01-select-application-nvidia-gpu-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nvidia GPU Operator Application](02-settings-nvidia-gpu-operator-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
@@ -24,7 +24,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Operator Application](01-select-application-trivy-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Operator Application](02-settings-trivy-operator-app.png)
 

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
@@ -41,7 +41,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Application](01-select-application-trivy-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Application](02-settings-trivy-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/argocd/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/argocd/_index.en.md
@@ -30,7 +30,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select ArgoCD Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-argocd-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for ArgoCD Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-argocd-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -26,7 +26,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Cert-Manager Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-cert-manager-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Cert-Manager Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-cert-manager-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Falco Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-falco-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Falco Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-falco-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
@@ -28,7 +28,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Flux2 Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-flux2-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Flux2 Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-flux2-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Kube-VIP Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-kube-vip-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Kube-VIP Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-kube-vip-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
@@ -23,7 +23,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select MetalLB Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-metallb-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for MetalLB Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-metallb-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nginx Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-nginx-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nginx Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-nginx-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
@@ -24,7 +24,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Operator Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-trivy-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Operator Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-trivy-operator-app.png)
 

--- a/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
+++ b/content/kubermatic/v2.24/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
@@ -41,7 +41,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/01-select-application-trivy-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Application](/img/kubermatic/v2.24/architecture/concepts/applications/default-applications-catalog/02-settings-trivy-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/argocd/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/argocd/_index.en.md
@@ -30,7 +30,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select ArgoCD Application](01-select-application-argocd-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for ArgoCD Application](02-settings-argocd-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -26,7 +26,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select cert-manager Application](01-select-application-cert-manager-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for cert-manager Application](02-settings-cert-manager-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Falco Application](01-select-application-falco-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Falco Application](02-settings-falco-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
@@ -28,7 +28,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Flux2 Application](01-select-application-flux2-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Flux2 Application](02-settings-flux2-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
@@ -25,7 +25,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select K8sGPT Application](01-select-application-k8sgpt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for K8sGPT Application](02-settings-k8sgpt-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Kube-VIP Application](01-select-application-kube-vip-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Kube-VIP Application](02-settings-kube-vip-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
@@ -30,6 +30,6 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select KubeVirt Application](01-select-application-kubevirt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for KubeVirt Application](02-settings-kubevirt-app.png)

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
@@ -23,7 +23,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select MetalLB Application](01-select-application-metallb-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for MetalLB Application](02-settings-metallb-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nginx Application](01-select-application-nginx-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nginx Application](02-settings-nginx-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
@@ -21,7 +21,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nvidia GPU Operator Application](01-select-application-nvidia-gpu-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nvidia GPU Operator Application](02-settings-nvidia-gpu-operator-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
@@ -24,7 +24,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Operator Application](01-select-application-trivy-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Operator Application](02-settings-trivy-operator-app.png)
 

--- a/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
+++ b/content/kubermatic/v2.25/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
@@ -41,7 +41,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Application](01-select-application-trivy-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Application](02-settings-trivy-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/argocd/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/argocd/_index.en.md
@@ -30,7 +30,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select ArgoCD Application](01-select-application-argocd-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for ArgoCD Application](02-settings-argocd-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -26,7 +26,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select cert-manager Application](01-select-application-cert-manager-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for cert-manager Application](02-settings-cert-manager-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Falco Application](01-select-application-falco-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Falco Application](02-settings-falco-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
@@ -28,7 +28,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Flux2 Application](01-select-application-flux2-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Flux2 Application](02-settings-flux2-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
@@ -25,7 +25,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select K8sGPT Application](01-select-application-k8sgpt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for K8sGPT Application](02-settings-k8sgpt-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Kube-VIP Application](01-select-application-kube-vip-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Kube-VIP Application](02-settings-kube-vip-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
@@ -30,6 +30,6 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select KubeVirt Application](01-select-application-kubevirt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for KubeVirt Application](02-settings-kubevirt-app.png)

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
@@ -23,7 +23,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select MetalLB Application](01-select-application-metallb-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for MetalLB Application](02-settings-metallb-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nginx Application](01-select-application-nginx-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nginx Application](02-settings-nginx-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
@@ -21,7 +21,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nvidia GPU Operator Application](01-select-application-nvidia-gpu-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nvidia GPU Operator Application](02-settings-nvidia-gpu-operator-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
@@ -24,7 +24,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Operator Application](01-select-application-trivy-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Operator Application](02-settings-trivy-operator-app.png)
 

--- a/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
+++ b/content/kubermatic/v2.26/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
@@ -41,7 +41,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Application](01-select-application-trivy-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Application](02-settings-trivy-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -26,7 +26,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select cert-manager Application](01-select-application-cert-manager-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for cert-manager Application](02-settings-cert-manager-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Falco Application](01-select-application-falco-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Falco Application](02-settings-falco-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
@@ -28,7 +28,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Flux2 Application](01-select-application-flux2-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Flux2 Application](02-settings-flux2-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
@@ -25,7 +25,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select K8sGPT Application](01-select-application-k8sgpt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for K8sGPT Application](02-settings-k8sgpt-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Kube-VIP Application](01-select-application-kube-vip-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Kube-VIP Application](02-settings-kube-vip-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
@@ -30,6 +30,6 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select KubeVirt Application](01-select-application-kubevirt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for KubeVirt Application](02-settings-kubevirt-app.png)

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
@@ -23,7 +23,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select MetalLB Application](01-select-application-metallb-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for MetalLB Application](02-settings-metallb-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nginx Application](01-select-application-nginx-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nginx Application](02-settings-nginx-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
@@ -21,7 +21,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nvidia GPU Operator Application](01-select-application-nvidia-gpu-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nvidia GPU Operator Application](02-settings-nvidia-gpu-operator-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
@@ -24,7 +24,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Operator Application](01-select-application-trivy-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Operator Application](02-settings-trivy-operator-app.png)
 

--- a/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
+++ b/content/kubermatic/v2.27/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
@@ -41,7 +41,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Application](01-select-application-trivy-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Application](02-settings-trivy-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/cert-manager/_index.en.md
@@ -26,7 +26,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select cert-manager Application](01-select-application-cert-manager-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for cert-manager Application](02-settings-cert-manager-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/falco/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Falco Application](01-select-application-falco-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Falco Application](02-settings-falco-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/flux2/_index.en.md
@@ -28,7 +28,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Flux2 Application](01-select-application-flux2-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Flux2 Application](02-settings-flux2-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/k8sgpt/_index.en.md
@@ -25,7 +25,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select K8sGPT Application](01-select-application-k8sgpt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for K8sGPT Application](02-settings-k8sgpt-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/kube-vip/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Kube-VIP Application](01-select-application-kube-vip-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Kube-VIP Application](02-settings-kube-vip-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/kubevirt/_index.en.md
@@ -30,6 +30,6 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select KubeVirt Application](01-select-application-kubevirt-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for KubeVirt Application](02-settings-kubevirt-app.png)

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/metallb/_index.en.md
@@ -23,7 +23,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select MetalLB Application](01-select-application-metallb-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for MetalLB Application](02-settings-metallb-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/nginx/_index.en.md
@@ -22,7 +22,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nginx Application](01-select-application-nginx-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nginx Application](02-settings-nginx-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/nvidia-gpu-operator/_index.en.md
@@ -21,7 +21,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Nvidia GPU Operator Application](01-select-application-nvidia-gpu-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Nvidia GPU Operator Application](02-settings-nvidia-gpu-operator-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy-operator/_index.en.md
@@ -24,7 +24,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Operator Application](01-select-application-trivy-operator-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Operator Application](02-settings-trivy-operator-app.png)
 

--- a/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/concept/kkp-concepts/applications/default-applications-catalog/trivy/_index.en.md
@@ -41,7 +41,7 @@ It can be deployed to the user cluster either during the cluster creation or aft
 
 ![Select Trivy Application](01-select-application-trivy-app.png)
 
-* Under the Settings section, select and provide appropriate details and clck `-> Next` button.
+* Under the Settings section, select and provide appropriate details and click `-> Next` button.
 
 ![Settings for Trivy Application](02-settings-trivy-app.png)
 


### PR DESCRIPTION
This PR is to fix typo `clck` --> `click`  in Default applications documentation across `main` and all the releases folder.