### PR TITLE
Update OSM compatibility matrix in KKP docs

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
@@ -6,6 +6,14 @@ weight = 6
 
 The page provides an overview for the supported operating systems on various cloud providers. These are the combinations that are covered by the "default" OperatingSystemProfiles that OSM will install in your cluster. Users can create custom OperatingSystemProfiles that work with a provider/OS combination that are not listed here.
 
+The following operating systems are currently supported by the default OperatingSystemProfiles:
+
+* Ubuntu 20.04 and 22.04
+* RHEL beginning with 8.0 (support is cloud provider-specific)
+* Flatcar (Stable channel)
+* Rocky Linux beginning with 8.0
+* Amazon Linux 2
+
 ## Operating System
 
 |   | Ubuntu | Flatcar | Amazon Linux 2 | RHEL | Rocky Linux |
@@ -26,7 +34,7 @@ The page provides an overview for the supported operating systems on various clo
 
 Currently supported K8S versions are:
 
+* 1.33
+* 1.32
 * 1.31
 * 1.30
-* 1.29
-* 1.28

--- a/content/kubermatic/v2.28/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
+++ b/content/kubermatic/v2.28/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
@@ -6,6 +6,14 @@ weight = 6
 
 The page provides an overview for the supported operating systems on various cloud providers. These are the combinations that are covered by the "default" OperatingSystemProfiles that OSM will install in your cluster. Users can create custom OperatingSystemProfiles that work with a provider/OS combination that are not listed here.
 
+The following operating systems are currently supported by the default OperatingSystemProfiles:
+
+* Ubuntu 20.04 and 22.04
+* RHEL beginning with 8.0 (support is cloud provider-specific)
+* Flatcar (Stable channel)
+* Rocky Linux beginning with 8.0
+* Amazon Linux 2
+
 ## Operating System
 
 |   | Ubuntu | Flatcar | Amazon Linux 2 | RHEL | Rocky Linux |
@@ -26,7 +34,7 @@ The page provides an overview for the supported operating systems on various clo
 
 Currently supported K8S versions are:
 
+* 1.33
+* 1.32
 * 1.31
 * 1.30
-* 1.29
-* 1.28


### PR DESCRIPTION
This PR is to update OSM compatibility matrix in KKP docs which includes the supported OS and k8s. Follow-up of https://github.com/kubermatic/docs/pull/1912