### PR TITLE
Update supported k8s version matrix for machine-controller

### DIFF
--- a/content/machine-controller/main/_index.en.md
+++ b/content/machine-controller/main/_index.en.md
@@ -40,10 +40,10 @@ machine-controller tries to follow the Kubernetes version
 
 Currently supported Kubernetes versions are:
 
+- 1.34
+- 1.33
+- 1.32
 - 1.31
-- 1.30
-- 1.29
-- 1.28
 
 ## Community Providers
 


### PR DESCRIPTION
This is to update supported k8s version matrix for machine-controller. Related to https://github.com/kubermatic/machine-controller/pull/1955