### PR TITLE
Update supported k8s version matrix for operating-system-manager

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
@@ -34,7 +34,7 @@ The following operating systems are currently supported by the default Operating
 
 Currently supported K8S versions are:
 
+* 1.34
 * 1.33
 * 1.32
 * 1.31
-* 1.30

--- a/content/operatingsystemmanager/compatibility/_index.en.md
+++ b/content/operatingsystemmanager/compatibility/_index.en.md
@@ -34,7 +34,7 @@ The following operating systems are currently supported by the default Operating
 
 Currently supported K8S versions are:
 
+* 1.34
 * 1.33
 * 1.32
 * 1.31
-* 1.30


### PR DESCRIPTION
This PR is to update supported k8s version matrix for operating-system-manager. Related to https://github.com/kubermatic/operating-system-manager/pull/512