### PR TITLE
Bump the crd-ref-docs version to v0.2.0 and Go build image to 1.25.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CODESPELL_IMAGE ?= quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-1
+CODESPELL_IMAGE ?= quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-4
 CODESPELL_BIN := $(shell which codespell)
 DOCKER_BIN := $(shell which docker)
 

--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -29,9 +29,9 @@ if [[ -z "$SOURCE" ]]; then
 fi
 
 which crd-ref-docs >/dev/null || {
-  echo "running go install github.com/elastic/crd-ref-docs@v0.1.0 in 5s... (ctrl-c to cancel)"
+  echo "running go install github.com/elastic/crd-ref-docs@v0.2.0 in 5s... (ctrl-c to cancel)"
   sleep 5
-  go install github.com/elastic/crd-ref-docs@v0.1.0
+  go install github.com/elastic/crd-ref-docs@v0.2.0
 }
 
 # get latest stable Kubernetes version


### PR DESCRIPTION
This PR is to fix the `post-kubermatic-update-docs` prow job failure. 

```
# golang.org/x/tools/internal/tokeninternal
../../../../pkg/mod/golang.org/x/tools@v0.19.0/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)
```