### PR TITLE
Bump hugo image version to 0.150.0-0

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -35,7 +35,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/docs.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/hugo:0.119.0-0
+        - image: quay.io/kubermatic/hugo:0.150.0-0
           command:
             - "./hack/ci/verify-hugo.sh"
           resources:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ preview:
 		--name kubermatic-docs \
 		-p 1313:1313 \
 		-w /docs \
-		-v `pwd`:/docs quay.io/kubermatic/hugo:0.119.0-0 \
+		-v `pwd`:/docs quay.io/kubermatic/hugo:0.150.0-0 \
 		hugo server -D -F --bind 0.0.0.0
 
 .PHONY: runbook

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,9 @@
 [build.environment]
 HUGO_VERSION = "0.150.0"
+GO_VERSION = "1.25.1"
 
 [context.production]
-command = "hugo --minify"
+command = "hugo --gc --minify"
 
 [context.deploy-preview]
 command = "hugo -D -F -b $DEPLOY_PRIME_URL"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,8 @@
 [build.environment]
 HUGO_VERSION = "0.150.0"
-GO_VERSION = "1.25.1"
 
 [context.production]
-command = "hugo --gc --minify"
+command = "hugo --minify"
 
 [context.deploy-preview]
 command = "hugo -D -F -b $DEPLOY_PRIME_URL"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-HUGO_VERSION = "0.119.0"
+HUGO_VERSION = "0.150.0"
 
 [context.production]
 command = "hugo --minify"


### PR DESCRIPTION
This PR is to bump hugo image version to 0.150.0-0 from quite older version 0.119.0-0 in use. 