### PR TITLE
Fix post-kubermatic-update-docs job for KKP release 2.27 and 2.26

### DIFF
--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -29,9 +29,18 @@ if [[ -z "$SOURCE" ]]; then
 fi
 
 which crd-ref-docs >/dev/null || {
-  echo "running go install github.com/elastic/crd-ref-docs@v0.2.0 in 5s... (ctrl-c to cancel)"
-  sleep 5
-  go install github.com/elastic/crd-ref-docs@v0.2.0
+  goversion=$(go version | awk '{print $3}' | sed 's/go//')
+  gomajorversion=$(echo "$goversion" | awk -F'.' '{print $2}')
+  requiredmajorversion=24
+  if [ $gomajorversion -lt $requiredmajorversion ]; then
+    echo "running go install github.com/elastic/crd-ref-docs@v0.1.0 in 5s... (ctrl-c to cancel)"
+    sleep 5
+    go install github.com/elastic/crd-ref-docs@v0.1.0
+  else
+    echo "running go install github.com/elastic/crd-ref-docs@v0.2.0 in 5s... (ctrl-c to cancel)"
+    sleep 5
+    go install github.com/elastic/crd-ref-docs@v0.2.0
+  fi
 }
 
 # get latest stable Kubernetes version

--- a/hack/render-crds.sh
+++ b/hack/render-crds.sh
@@ -6,6 +6,7 @@ cd $(dirname $0)/..
 
 SOURCE="${SOURCE:-}"
 KKP_RELEASE="${KKP_RELEASE:-main}"
+CRD_REF_VERSION=v0.2.0
 
 if [[ -z "$SOURCE" ]]; then
   gopath="$(go env GOPATH)"
@@ -28,19 +29,15 @@ if [[ -z "$SOURCE" ]]; then
   fi
 fi
 
+
 which crd-ref-docs >/dev/null || {
   goversion=$(go version | awk '{print $3}' | sed 's/go//')
   gomajorversion=$(echo "$goversion" | awk -F'.' '{print $2}')
   requiredmajorversion=24
   if [ $gomajorversion -lt $requiredmajorversion ]; then
-    echo "running go install github.com/elastic/crd-ref-docs@v0.1.0 in 5s... (ctrl-c to cancel)"
-    sleep 5
-    go install github.com/elastic/crd-ref-docs@v0.1.0
-  else
-    echo "running go install github.com/elastic/crd-ref-docs@v0.2.0 in 5s... (ctrl-c to cancel)"
-    sleep 5
-    go install github.com/elastic/crd-ref-docs@v0.2.0
+    CRD_REF_VERSION=v0.1.0
   fi
+
 }
 
 # get latest stable Kubernetes version
@@ -57,8 +54,10 @@ configFile=hack/crd-ref-docs.yaml
 # Version of Kubernetes to use when generating links to Kubernetes API documentation.
 yq --inplace ".render.kubernetesVersion = \"$currentRelease\"" "$configFile"
 
-$(go env GOPATH)/bin/crd-ref-docs \
-  --source-path "$SOURCE" \
+echo "running go run github.com/elastic/crd-ref-docs@$CRD_REF_VERSION in 5s... (ctrl-c to cancel)"
+sleep 5
+CRD_REF_BIN="go run github.com/elastic/crd-ref-docs@$CRD_REF_VERSION"
+$CRD_REF_BIN --source-path "$SOURCE" \
   --max-depth 10 \
   --renderer markdown \
   --templates-dir hack/crd-templates \


### PR DESCRIPTION
Previous PR https://github.com/kubermatic/docs/pull/1980 fixed the `post-kubermatic-update-docs` prow job failure for KKP  `main` and 2.28, however broke for the 2.27 and 2.26. This PR is to follow-up to fix post-kubermatic-update-docs-x.xx job failures for KKP release 2.27 and 2.26.  When Go version is <1.24, then `github.com/elastic/crd-ref-docs@v0.1.0` should be installed instead of `github.com/elastic/crd-ref-docs@v0.2.0`. 