### PR TITLE
Fix timezone conflict for publish CIS benchmark docs

### DIFF
--- a/content/kubermatic/main/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/main/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -1,6 +1,6 @@
 +++
 title = "Benchmark on Kubernetes 1.33 with KKP 2.28.3"
-date = 2025-09-23T13:22:14+02:00
+date = 2025-09-19T09:00:00+02:00
 +++
 
 This guide helps you evaluate the security of a Kubernetes cluster created using KKP against each control in the CIS Kubernetes Benchmark.

--- a/content/kubermatic/v2.28/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/v2.28/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -1,6 +1,6 @@
 +++
 title = "Benchmark on Kubernetes 1.33 with KKP 2.28.3"
-date = 2025-09-23T13:22:14+02:00
+date = 2025-09-19T09:00:00+02:00
 +++
 
 This guide helps you evaluate the security of a Kubernetes cluster created using KKP against each control in the CIS Kubernetes Benchmark.


### PR DESCRIPTION
The `date` was generated based on my timezone which is ahead of what Hugo expects, this results in the docs not being published.