### PR TITLE
Update Kubernetes version in KubeOne docs

### DIFF
--- a/content/kubeone/main/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/main/architecture/operating-system-manager/usage/_index.en.md
@@ -13,7 +13,7 @@ To fallback to legacy user-data from Machine Controller, we can disable OSM for 
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.34.1
 addons:
   enable: true
 operatingSystemManager:

--- a/content/kubeone/main/guides/addons/_index.en.md
+++ b/content/kubeone/main/guides/addons/_index.en.md
@@ -64,7 +64,7 @@ the `addons` config:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.34.1
 cloudProvider:
   aws: {}
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
@@ -113,7 +113,7 @@ Example:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.34.1
 
 addons:
   enable: true
@@ -145,7 +145,7 @@ To delete embedded addon from the cluster, use the new `delete` field from the
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.34.1
 
 addons:
   enable: true
@@ -180,7 +180,7 @@ you can use it to override globally defined parameters.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.34.1
 
 addons:
   enable: true

--- a/content/kubeone/main/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/main/guides/autoscaler-addon/_index.en.md
@@ -33,7 +33,7 @@ kubeone.yaml
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.34.1'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:
@@ -52,7 +52,7 @@ If you're running a cluster with nodes in the multiple zones for the HA purposes
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.34.1'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:

--- a/content/kubeone/main/guides/encryption-providers/_index.en.md
+++ b/content/kubeone/main/guides/encryption-providers/_index.en.md
@@ -34,7 +34,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -82,7 +82,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -140,7 +140,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 features:
   encryptionProviders:
     enable: true
@@ -175,7 +175,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: kms-test
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 cloudProvider:
   aws: {}
 features:

--- a/content/kubeone/main/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/main/guides/registry-configuration/_index.en.md
@@ -99,7 +99,7 @@ stanza to your KubeOne configuration file, such as:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.34.1
 cloudProvider:
   aws: {}
 registryConfiguration:

--- a/content/kubeone/main/tutorials/creating-clusters-oidc/_index.en.md
+++ b/content/kubeone/main/tutorials/creating-clusters-oidc/_index.en.md
@@ -47,7 +47,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   hetzner: {}
@@ -331,7 +331,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   hetzner: {}
@@ -482,7 +482,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   hetzner: {}

--- a/content/kubeone/main/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/main/tutorials/creating-clusters/_index.en.md
@@ -585,7 +585,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   aws: {}
@@ -613,7 +613,7 @@ with your cluster name in the cloud-config example below.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   azure: {}
   external: true
@@ -648,7 +648,7 @@ and fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   digitalocean: {}
   external: true
@@ -666,7 +666,7 @@ configs.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   gce: {}
   external: true
@@ -697,7 +697,7 @@ The Hetzner CCM fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   hetzner: {}
   external: true
@@ -715,7 +715,7 @@ replace the placeholder values.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   nutanix: {}
 addons:
@@ -745,7 +745,7 @@ cloud-config section.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   openstack: {}
   external: true
@@ -767,7 +767,7 @@ cloudProvider:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   openstack: {}
   external: true
@@ -791,7 +791,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   vmwareCloudDirector: {}
@@ -810,7 +810,7 @@ automatically by KubeOne.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   vsphere: {}
   external: true

--- a/content/kubeone/v1.10/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/v1.10/architecture/operating-system-manager/usage/_index.en.md
@@ -13,7 +13,7 @@ To fallback to legacy user-data from Machine Controller, we can disable OSM for 
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 addons:
   enable: true
 operatingSystemManager:

--- a/content/kubeone/v1.10/examples/addons-calico-vxlan/_index.en.md
+++ b/content/kubeone/v1.10/examples/addons-calico-vxlan/_index.en.md
@@ -13,7 +13,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 
 cloudProvider:
   aws: {}

--- a/content/kubeone/v1.10/guides/addons/_index.en.md
+++ b/content/kubeone/v1.10/guides/addons/_index.en.md
@@ -64,7 +64,7 @@ the `addons` config:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 cloudProvider:
   aws: {}
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
@@ -113,7 +113,7 @@ Example:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 
 addons:
   enable: true
@@ -145,7 +145,7 @@ To delete embedded addon from the cluster, use the new `delete` field from the
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 
 addons:
   enable: true
@@ -180,7 +180,7 @@ you can use it to override globally defined parameters.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 
 addons:
   enable: true

--- a/content/kubeone/v1.10/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/v1.10/guides/autoscaler-addon/_index.en.md
@@ -33,7 +33,7 @@ kubeone.yaml
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.32.9'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:
@@ -52,7 +52,7 @@ If you're running a cluster with nodes in the multiple zones for the HA purposes
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.32.9'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:

--- a/content/kubeone/v1.10/guides/encryption-providers/_index.en.md
+++ b/content/kubeone/v1.10/guides/encryption-providers/_index.en.md
@@ -34,7 +34,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -82,7 +82,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -140,7 +140,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 features:
   encryptionProviders:
     enable: true
@@ -175,7 +175,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: kms-test
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   aws: {}
 features:

--- a/content/kubeone/v1.10/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/v1.10/guides/registry-configuration/_index.en.md
@@ -77,7 +77,7 @@ stanza to your KubeOne configuration file, such as:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.32.9
 cloudProvider:
   aws: {}
 registryConfiguration:

--- a/content/kubeone/v1.10/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.10/tutorials/creating-clusters-baremetal/_index.en.md
@@ -222,7 +222,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: bm-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   none: {}
 

--- a/content/kubeone/v1.10/tutorials/creating-clusters-oidc/_index.en.md
+++ b/content/kubeone/v1.10/tutorials/creating-clusters-oidc/_index.en.md
@@ -47,7 +47,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 
 cloudProvider:
   hetzner: {}
@@ -331,7 +331,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 
 cloudProvider:
   hetzner: {}
@@ -482,7 +482,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 
 cloudProvider:
   hetzner: {}

--- a/content/kubeone/v1.10/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/v1.10/tutorials/creating-clusters/_index.en.md
@@ -615,7 +615,7 @@ supported provider.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   aws: {}
   external: true
@@ -642,7 +642,7 @@ with your cluster name in the cloud-config example below.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   azure: {}
   external: true
@@ -677,7 +677,7 @@ and fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   digitalocean: {}
   external: true
@@ -695,7 +695,7 @@ configs.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   gce: {}
   external: true
@@ -726,7 +726,7 @@ The Hetzner CCM fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   hetzner: {}
   external: true
@@ -744,7 +744,7 @@ replace the placeholder values.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   nutanix: {}
 addons:
@@ -774,7 +774,7 @@ cloud-config section.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   openstack: {}
   external: true
@@ -796,7 +796,7 @@ cloudProvider:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   openstack: {}
   external: true
@@ -824,7 +824,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 
 cloudProvider:
   equinixmetal: {}
@@ -845,7 +845,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 
 cloudProvider:
   vmwareCloudDirector: {}
@@ -864,7 +864,7 @@ automatically by KubeOne.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.32.9'
 cloudProvider:
   vsphere: {}
   external: true

--- a/content/kubeone/v1.11/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/v1.11/architecture/operating-system-manager/usage/_index.en.md
@@ -13,7 +13,7 @@ To fallback to legacy user-data from Machine Controller, we can disable OSM for 
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.33.5
 addons:
   enable: true
 operatingSystemManager:

--- a/content/kubeone/v1.11/guides/addons/_index.en.md
+++ b/content/kubeone/v1.11/guides/addons/_index.en.md
@@ -64,7 +64,7 @@ the `addons` config:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.33.5
 cloudProvider:
   aws: {}
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
@@ -113,7 +113,7 @@ Example:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.33.5
 
 addons:
   enable: true
@@ -145,7 +145,7 @@ To delete embedded addon from the cluster, use the new `delete` field from the
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.33.5
 
 addons:
   enable: true
@@ -180,7 +180,7 @@ you can use it to override globally defined parameters.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.33.5
 
 addons:
   enable: true

--- a/content/kubeone/v1.11/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/v1.11/guides/autoscaler-addon/_index.en.md
@@ -33,7 +33,7 @@ kubeone.yaml
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.33.5'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:
@@ -52,7 +52,7 @@ If you're running a cluster with nodes in the multiple zones for the HA purposes
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.33.5'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:

--- a/content/kubeone/v1.11/guides/encryption-providers/_index.en.md
+++ b/content/kubeone/v1.11/guides/encryption-providers/_index.en.md
@@ -34,7 +34,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -82,7 +82,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -140,7 +140,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 features:
   encryptionProviders:
     enable: true
@@ -175,7 +175,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: kms-test
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 cloudProvider:
   aws: {}
 features:

--- a/content/kubeone/v1.11/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/v1.11/guides/registry-configuration/_index.en.md
@@ -99,7 +99,7 @@ stanza to your KubeOne configuration file, such as:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.33.5
 cloudProvider:
   aws: {}
 registryConfiguration:

--- a/content/kubeone/v1.11/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.11/tutorials/creating-clusters-baremetal/_index.en.md
@@ -222,7 +222,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: bm-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 cloudProvider:
   none: {}
 

--- a/content/kubeone/v1.11/tutorials/creating-clusters-oidc/_index.en.md
+++ b/content/kubeone/v1.11/tutorials/creating-clusters-oidc/_index.en.md
@@ -47,7 +47,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 
 cloudProvider:
   hetzner: {}
@@ -331,7 +331,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 
 cloudProvider:
   hetzner: {}
@@ -482,7 +482,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.33.5'
 
 cloudProvider:
   hetzner: {}

--- a/content/kubeone/v1.11/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/v1.11/tutorials/creating-clusters/_index.en.md
@@ -585,7 +585,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   aws: {}
@@ -613,7 +613,7 @@ with your cluster name in the cloud-config example below.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   azure: {}
   external: true
@@ -648,7 +648,7 @@ and fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   digitalocean: {}
   external: true
@@ -666,7 +666,7 @@ configs.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   gce: {}
   external: true
@@ -697,7 +697,7 @@ The Hetzner CCM fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   hetzner: {}
   external: true
@@ -715,7 +715,7 @@ replace the placeholder values.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   nutanix: {}
 addons:
@@ -745,7 +745,7 @@ cloud-config section.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   openstack: {}
   external: true
@@ -767,7 +767,7 @@ cloudProvider:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   openstack: {}
   external: true
@@ -791,7 +791,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 
 cloudProvider:
   vmwareCloudDirector: {}
@@ -810,7 +810,7 @@ automatically by KubeOne.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.33.2'
+  kubernetes: '1.34.1'
 cloudProvider:
   vsphere: {}
   external: true

--- a/content/kubeone/v1.9/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/v1.9/architecture/operating-system-manager/usage/_index.en.md
@@ -13,7 +13,7 @@ To fallback to legacy user-data from Machine Controller, we can disable OSM for 
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 addons:
   enable: true
 operatingSystemManager:

--- a/content/kubeone/v1.9/examples/addons-calico-vxlan/_index.en.md
+++ b/content/kubeone/v1.9/examples/addons-calico-vxlan/_index.en.md
@@ -13,7 +13,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 
 cloudProvider:
   aws: {}

--- a/content/kubeone/v1.9/guides/addons/_index.en.md
+++ b/content/kubeone/v1.9/guides/addons/_index.en.md
@@ -64,7 +64,7 @@ the `addons` config:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 cloudProvider:
   aws: {}
 # Addons are Kubernetes manifests to be deployed after provisioning the cluster
@@ -113,7 +113,7 @@ Example:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 
 addons:
   enable: true
@@ -145,7 +145,7 @@ To delete embedded addon from the cluster, use the new `delete` field from the
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 
 addons:
   enable: true
@@ -180,7 +180,7 @@ you can use it to override globally defined parameters.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 
 addons:
   enable: true

--- a/content/kubeone/v1.9/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/v1.9/guides/autoscaler-addon/_index.en.md
@@ -33,7 +33,7 @@ kubeone.yaml
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.31.13'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:
@@ -52,7 +52,7 @@ If you're running a cluster with nodes in the multiple zones for the HA purposes
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'   ## kubernetes version
+  kubernetes: '1.31.13'   ## kubernetes version
 cloudProvider:  ## This field is sourced automatically if terraform is used for the cluster
   aws: {}
 addons:

--- a/content/kubeone/v1.9/guides/encryption-providers/_index.en.md
+++ b/content/kubeone/v1.9/guides/encryption-providers/_index.en.md
@@ -34,7 +34,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -82,7 +82,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 features:
   # enable encryption providers
   encryptionProviders:
@@ -140,7 +140,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: k1-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 features:
   encryptionProviders:
     enable: true
@@ -175,7 +175,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: kms-test
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   aws: {}
 features:

--- a/content/kubeone/v1.9/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/v1.9/guides/registry-configuration/_index.en.md
@@ -77,7 +77,7 @@ stanza to your KubeOne configuration file, such as:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: 1.29.4
+  kubernetes: 1.31.13
 cloudProvider:
   aws: {}
 registryConfiguration:

--- a/content/kubeone/v1.9/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.9/tutorials/creating-clusters-baremetal/_index.en.md
@@ -222,7 +222,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: bm-cluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   none: {}
 

--- a/content/kubeone/v1.9/tutorials/creating-clusters-oidc/_index.en.md
+++ b/content/kubeone/v1.9/tutorials/creating-clusters-oidc/_index.en.md
@@ -47,7 +47,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 
 cloudProvider:
   hetzner: {}
@@ -331,7 +331,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 
 cloudProvider:
   hetzner: {}
@@ -482,7 +482,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 
 cloudProvider:
   hetzner: {}

--- a/content/kubeone/v1.9/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/v1.9/tutorials/creating-clusters/_index.en.md
@@ -615,7 +615,7 @@ supported provider.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   aws: {}
   external: true
@@ -642,7 +642,7 @@ with your cluster name in the cloud-config example below.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   azure: {}
   external: true
@@ -677,7 +677,7 @@ and fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   digitalocean: {}
   external: true
@@ -695,7 +695,7 @@ configs.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   gce: {}
   external: true
@@ -726,7 +726,7 @@ The Hetzner CCM fetches information about nodes from the API.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   hetzner: {}
   external: true
@@ -744,7 +744,7 @@ replace the placeholder values.
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   nutanix: {}
 addons:
@@ -774,7 +774,7 @@ cloud-config section.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   openstack: {}
   external: true
@@ -796,7 +796,7 @@ cloudProvider:
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   openstack: {}
   external: true
@@ -824,7 +824,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 
 cloudProvider:
   equinixmetal: {}
@@ -845,7 +845,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 
 cloudProvider:
   vmwareCloudDirector: {}
@@ -864,7 +864,7 @@ automatically by KubeOne.**
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: '1.29.4'
+  kubernetes: '1.31.13'
 cloudProvider:
   vsphere: {}
   external: true


### PR DESCRIPTION
This PR updates the supported Kubernetes version in `kubeone.yaml` manifest across KubeOne docs for main, v1.11, v1.10 and v1.9 version.