### PR TITLE
Fix the supported k8s version across the docs

### DIFF
--- a/content/kubeone/main/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/main/architecture/operating-system-manager/usage/_index.en.md
@@ -163,7 +163,7 @@ The variable `initial_machinedeployment_operating_system_profile` can also be co
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: "1.29.4"
+  kubernetes: "1.34.1"
 cloudProvider:
   aws: {}
 addons:

--- a/content/kubeone/main/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/main/guides/autoscaler-addon/_index.en.md
@@ -146,9 +146,9 @@ Run the following kubectl command to inspect the available Machinedeployments:
 ```bash
 $ kubectl get machinedeployments -n kube-system
 NAME       		        REPLICAS   AVAILABLE-REPLICAS   PROVIDER       OS     KUBELET  AGE
-kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.20.4   10h
+kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.34.1   10h
+kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.34.1   10h
+kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.34.1   10h
 ```
 
 ### Step 2: Annotate Machinedeployments

--- a/content/kubeone/main/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/main/guides/registry-configuration/_index.en.md
@@ -54,7 +54,7 @@ The `kubeone mirror-images` command pulls, re-tags, and pushes images to your re
 ```bash
 kubeone mirror-images \
   [--filter base,optional,control-plane] \
-  [--kubernetes-versions v1.29.4,v1.28.8] \
+  [--kubernetes-versions v1.34.1,v1.33.5] \
   [--insecure]  # Allow pushing to insecure registries (HTTP) \
   --registry <your-registry> 
 ```
@@ -73,7 +73,7 @@ kubeone mirror-images \
 ```bash
 kubeone mirror-images \
   --filter base \
-  --kubernetes-versions v1.29.4,v1.28.8 \
+  --kubernetes-versions v1.34.1,v1.33.5 \
   registry.example.com:5000 
 ```
 

--- a/content/kubeone/main/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/main/tutorials/creating-clusters-baremetal/_index.en.md
@@ -222,7 +222,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 name: bm-cluster
 versions:
-  kubernetes: '1.32.3'
+  kubernetes: '1.34.1'
 cloudProvider:
   none: {}
 
@@ -298,11 +298,11 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
-  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.20.4
-  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.20.4
+  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.34.1
+  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.34.1
+  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.34.1
+  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.34.1
+  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.34.1
 
 Do you want to proceed (yes/no):
 ```
@@ -356,11 +356,11 @@ You should see output such as the following one.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
-ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.34.1
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.34.1
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.34.1
+ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.34.1
+ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.34.1
 ```
 
 ## Conclusion

--- a/content/kubeone/main/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/main/tutorials/creating-clusters/_index.en.md
@@ -858,18 +858,18 @@ In the following table, you can find a list of supported Kubernetes version
 for latest KubeOne versions (you can run `kubeone version` to find the version
 that you're running).
 
-| KubeOne \ Kubernetes | 1.33 | 1.32 | 1.31 | 1.30 | 1.29[^1] |
+| KubeOne \ Kubernetes | 1.34 | 1.33 | 1.32 | 1.31 | 1.30[^1] |
 | -------------------- | ---- | ---- | ---- | -----| -------- |
-| v1.11                | ✓   | ✓   | ✓   | -    | -        |
-| v1.10                | -    | ✓   | ✓   | ✓   | -        |
-| v1.9                 | -    | -    | ✓   | ✓   | ✓       |
+| v1.12                | ✓   | ✓   | ✓   | -    | -        |
+| v1.11                | -    | ✓   | ✓   | ✓   | -        |
+| v1.10                 | -    | -    | ✓   | ✓   | ✓       |
 
-[^1]: Kubernetes 1.29 has reached End-of-Life (EOL) and is not supported any longer.
+[^1]: Kubernetes 1.30 has reached End-of-Life (EOL) and is not supported any longer.
 We strongly recommend upgrading to a newer supported Kubernetes release as soon as possible.
 
 We recommend using a Kubernetes release that's not older than one minor release
-than the latest Kubernetes release. For example, with 1.33 being the latest
-release, we recommend running at least Kubernetes 1.32.
+than the latest Kubernetes release. For example, with 1.34 being the latest
+release, we recommend running at least Kubernetes 1.33.
 
 Now, we're ready to provision the cluster! This is done by running the
 `kubeone apply` command and providing it the configuration manifest and the
@@ -897,9 +897,9 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
+        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.34.1
+        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.34.1
+        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.34.1
         + ensure machinedeployment "marko-1-eu-west-3a" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3b" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3c" with 1 replica(s) exists
@@ -977,12 +977,12 @@ cluster.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.20.4
-ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
+ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.34.1
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.34.1
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.34.1
+ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.34.1
+ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.34.1
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.34.1
 ```
 
 ## Conclusion

--- a/content/kubeone/v1.10/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/v1.10/architecture/operating-system-manager/usage/_index.en.md
@@ -163,7 +163,7 @@ The variable `initial_machinedeployment_operating_system_profile` can also be co
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: "1.29.4"
+  kubernetes: "1.32.9"
 cloudProvider:
   aws: {}
 addons:

--- a/content/kubeone/v1.10/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/v1.10/guides/autoscaler-addon/_index.en.md
@@ -146,9 +146,9 @@ Run the following kubectl command to inspect the available Machinedeployments:
 ```bash
 $ kubectl get machinedeployments -n kube-system
 NAME       		        REPLICAS   AVAILABLE-REPLICAS   PROVIDER       OS     KUBELET  AGE
-kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.20.4   10h
+kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.32.9   10h
+kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.32.9   10h
+kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.32.9   10h
 ```
 
 ### Step 2: Annotate Machinedeployments

--- a/content/kubeone/v1.10/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/v1.10/guides/registry-configuration/_index.en.md
@@ -62,7 +62,7 @@ to use (without the `v` prefix), as well as, replace the `TARGET_REGISTRY` with
 the address to your image registry.
 
 ```
-KUBERNETES_VERSION=1.29.4 TARGET_REGISTRY=127.0.0.1:5000 ./image-loader.sh
+KUBERNETES_VERSION=1.32.9 TARGET_REGISTRY=127.0.0.1:5000 ./image-loader.sh
 ```
 
 The preloading process can take a several minutes, depending on your

--- a/content/kubeone/v1.10/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.10/tutorials/creating-clusters-baremetal/_index.en.md
@@ -297,11 +297,11 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
-  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.20.4
-  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.20.4
+  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.32.9
+  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.32.9
+  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.32.9
+  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.32.9
+  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.32.9
 
 Do you want to proceed (yes/no):
 ```
@@ -355,11 +355,11 @@ You should see output such as the following one.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
-ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.32.9
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.32.9
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.32.9
+ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.32.9
+ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.32.9
 ```
 
 ## Conclusion

--- a/content/kubeone/v1.10/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/v1.10/tutorials/creating-clusters/_index.en.md
@@ -950,9 +950,9 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
+        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.32.9
+        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.32.9
+        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.32.9
         + ensure machinedeployment "marko-1-eu-west-3a" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3b" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3c" with 1 replica(s) exists
@@ -1030,12 +1030,12 @@ cluster.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.20.4
-ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
+ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.32.9
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.32.9
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.32.9
+ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.32.9
+ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.32.9
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.32.9
 ```
 
 ## Conclusion

--- a/content/kubeone/v1.11/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/v1.11/architecture/operating-system-manager/usage/_index.en.md
@@ -163,7 +163,7 @@ The variable `initial_machinedeployment_operating_system_profile` can also be co
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: "1.29.4"
+  kubernetes: "1.33.5"
 cloudProvider:
   aws: {}
 addons:

--- a/content/kubeone/v1.11/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/v1.11/guides/autoscaler-addon/_index.en.md
@@ -146,9 +146,9 @@ Run the following kubectl command to inspect the available Machinedeployments:
 ```bash
 $ kubectl get machinedeployments -n kube-system
 NAME       		        REPLICAS   AVAILABLE-REPLICAS   PROVIDER       OS     KUBELET  AGE
-kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.20.4   10h
+kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.33.5   10h
+kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.33.5   10h
+kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.33.5   10h
 ```
 
 ### Step 2: Annotate Machinedeployments

--- a/content/kubeone/v1.11/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/v1.11/guides/registry-configuration/_index.en.md
@@ -54,7 +54,7 @@ The `kubeone mirror-images` command pulls, re-tags, and pushes images to your re
 ```bash
 kubeone mirror-images \
   [--filter base,optional,control-plane] \
-  [--kubernetes-versions v1.29.4,v1.28.8] \
+  [--kubernetes-versions v1.33.5,v1.32.9] \
   [--insecure]  # Allow pushing to insecure registries (HTTP) \
   --registry <your-registry> 
 ```
@@ -73,7 +73,7 @@ kubeone mirror-images \
 ```bash
 kubeone mirror-images \
   --filter base \
-  --kubernetes-versions v1.29.4,v1.28.8 \
+  --kubernetes-versions v1.33.5,v1.32.9 \
   registry.example.com:5000 
 ```
 

--- a/content/kubeone/v1.11/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.11/tutorials/creating-clusters-baremetal/_index.en.md
@@ -298,11 +298,11 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
-  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.20.4
-  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.20.4
+  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.33.5
+  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.33.5
+  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.33.5
+  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.33.5
+  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.33.5
 
 Do you want to proceed (yes/no):
 ```
@@ -356,11 +356,11 @@ You should see output such as the following one.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
-ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.33.5
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.33.5
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.33.5
+ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.33.5
+ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.33.5
 ```
 
 ## Conclusion

--- a/content/kubeone/v1.11/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/v1.11/tutorials/creating-clusters/_index.en.md
@@ -791,7 +791,7 @@ apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 
 versions:
-  kubernetes: '1.34.1'
+  kubernetes: '1.33.5'
 
 cloudProvider:
   vmwareCloudDirector: {}
@@ -897,9 +897,9 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
+        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.33.5
+        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.33.5
+        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.33.5
         + ensure machinedeployment "marko-1-eu-west-3a" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3b" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3c" with 1 replica(s) exists
@@ -977,12 +977,12 @@ cluster.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.20.4
-ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
+ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.33.5
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.33.5
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.33.5
+ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.33.5
+ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.33.5
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.33.5
 ```
 
 ## Conclusion

--- a/content/kubeone/v1.9/architecture/operating-system-manager/usage/_index.en.md
+++ b/content/kubeone/v1.9/architecture/operating-system-manager/usage/_index.en.md
@@ -163,7 +163,7 @@ The variable `initial_machinedeployment_operating_system_profile` can also be co
 apiVersion: kubeone.k8c.io/v1beta2
 kind: KubeOneCluster
 versions:
-  kubernetes: "1.29.4"
+  kubernetes: "1.31.13"
 cloudProvider:
   aws: {}
 addons:

--- a/content/kubeone/v1.9/guides/autoscaler-addon/_index.en.md
+++ b/content/kubeone/v1.9/guides/autoscaler-addon/_index.en.md
@@ -146,9 +146,9 @@ Run the following kubectl command to inspect the available Machinedeployments:
 ```bash
 $ kubectl get machinedeployments -n kube-system
 NAME       		        REPLICAS   AVAILABLE-REPLICAS   PROVIDER       OS     KUBELET  AGE
-kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.20.4   10h
-kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.20.4   10h
+kb-cluster-eu-west-3a      1            1                 aws        ubuntu   1.31.13   10h
+kb-cluster-eu-west-3b      1            1                 aws        ubuntu   1.31.13   10h
+kb-cluster-eu-west-3c      1            1                 aws        ubuntu   1.31.13   10h
 ```
 
 ### Step 2: Annotate Machinedeployments

--- a/content/kubeone/v1.9/guides/registry-configuration/_index.en.md
+++ b/content/kubeone/v1.9/guides/registry-configuration/_index.en.md
@@ -62,7 +62,7 @@ to use (without the `v` prefix), as well as, replace the `TARGET_REGISTRY` with
 the address to your image registry.
 
 ```
-KUBERNETES_VERSION=1.29.4 TARGET_REGISTRY=127.0.0.1:5000 ./image-loader.sh
+KUBERNETES_VERSION=1.31.13 TARGET_REGISTRY=127.0.0.1:5000 ./image-loader.sh
 ```
 
 The preloading process can take a several minutes, depending on your

--- a/content/kubeone/v1.9/tutorials/creating-clusters-baremetal/_index.en.md
+++ b/content/kubeone/v1.9/tutorials/creating-clusters-baremetal/_index.en.md
@@ -301,11 +301,11 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
-  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.20.4
-  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.20.4
+  + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.31.13
+  + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.31.13
+  + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.31.13
+  + join worker node "ip-172-31-223-103.eu-west-3.compute.internal" (172.31.223.103) using 1.31.13
+  + join worker node "ip-172-31-224-178.eu-west-3.compute.internal" (172.31.224.178) using 1.31.13
 
 Do you want to proceed (yes/no):
 ```
@@ -359,11 +359,11 @@ You should see output such as the following one.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
-ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.31.13
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.31.13
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.31.13
+ip-172-31-223-103.eu-west-3.compute.internal   Ready    <none>   38m   v1.31.13
+ip-172-31-224-178.eu-west-3.compute.internal   Ready    <none>   38m   v1.31.13
 ```
 
 ## Conclusion

--- a/content/kubeone/v1.9/tutorials/creating-clusters/_index.en.md
+++ b/content/kubeone/v1.9/tutorials/creating-clusters/_index.en.md
@@ -954,9 +954,9 @@ INFO[11:37:28 CEST] Determine operating system…
 INFO[11:37:30 CEST] Running host probes…
 The following actions will be taken:
 Run with --verbose flag for more information.
-        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.20.4
-        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.20.4
-        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.20.4
+        + initialize control plane node "ip-172-31-220-51.eu-west-3.compute.internal" (172.31.220.51) using 1.31.13
+        + join control plane node "ip-172-31-221-177.eu-west-3.compute.internal" (172.31.221.177) using 1.31.13
+        + join control plane node "ip-172-31-222-48.eu-west-3.compute.internal" (172.31.222.48) using 1.31.13
         + ensure machinedeployment "marko-1-eu-west-3a" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3b" with 1 replica(s) exists
         + ensure machinedeployment "marko-1-eu-west-3c" with 1 replica(s) exists
@@ -1034,12 +1034,12 @@ cluster.
 
 ```
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.20.4
-ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.20.4
-ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.20.4
-ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.20.4
-ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.20.4
+ip-172-31-220-166.eu-west-3.compute.internal   Ready    <none>   38m   v1.31.13
+ip-172-31-220-51.eu-west-3.compute.internal    Ready    master   43m   v1.31.13
+ip-172-31-221-177.eu-west-3.compute.internal   Ready    master   42m   v1.31.13
+ip-172-31-221-18.eu-west-3.compute.internal    Ready    <none>   38m   v1.31.13
+ip-172-31-222-211.eu-west-3.compute.internal   Ready    <none>   38m   v1.31.13
+ip-172-31-222-48.eu-west-3.compute.internal    Ready    master   41m   v1.31.13
 ```
 
 ## Conclusion

--- a/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
+++ b/content/kubermatic/main/architecture/compatibility/supported-versions/_index.en.md
@@ -34,13 +34,13 @@ current KKP version.
 | 2.28.x               | --   | ✓    |  ✓    |  ✓   | ✓    | --    |
 | 2.27.x               | --   | --   | ✓    |  ✓   | ✓    | ✓    |
 
-[^2]: Kubernetes releases below version 1.30 have reached End-of-Life (EOL). We strongly
+[^2]: Kubernetes releases below version 1.31 have reached End-of-Life (EOL). We strongly
 recommend upgrading to a supported Kubernetes release as soon as possible. Refer to the
 [Kubernetes website](https://kubernetes.io/releases/) for more information on the supported
 releases.
 
 Upgrades from a previous Kubernetes version are generally supported whenever a version is
-marked as supported, for example KKP 2.28 supports updating clusters from Kubernetes 1.30 to 1.31.
+marked as supported, for example KKP 2.28 supports updating clusters from Kubernetes 1.32 to 1.33.
 
 ## Provider Incompatibilities
 


### PR DESCRIPTION
This PR is to fix the supported k8s version across the docs, mainly the k8s version in the output/console log. 