### PR TITLE
Add deprecation warning for OPA after it was deprecated in 2.28

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/opa-integration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/opa-integration/_index.en.md
@@ -5,6 +5,10 @@ weight = 11
 
 +++
 
+{{% notice warning %}}
+OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be removed in a future release. [Kyverno]({{< ref "../kyverno-policies/" >}}) has replaced it as an Enterprise Edition feature for policy management.
+{{% /notice %}}
+
 This manual explains how Kubermatic integrates with OPA and how to use it.
 
 ## OPA

--- a/content/kubermatic/v2.28/tutorials-howtos/opa-integration/_index.en.md
+++ b/content/kubermatic/v2.28/tutorials-howtos/opa-integration/_index.en.md
@@ -5,6 +5,10 @@ weight = 11
 
 +++
 
+{{% notice warning %}}
+OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be removed in a future release. [Kyverno]({{< ref "../kyverno-policies/" >}}) has replaced it as an Enterprise Edition feature for policy management.
+{{% /notice %}}
+
 This manual explains how Kubermatic integrates with OPA and how to use it.
 
 ## OPA

--- a/content/kubermatic/v2.29/tutorials-howtos/opa-integration/_index.en.md
+++ b/content/kubermatic/v2.29/tutorials-howtos/opa-integration/_index.en.md
@@ -5,6 +5,10 @@ weight = 11
 
 +++
 
+{{% notice warning %}}
+OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be removed in a future release. [Kyverno]({{< ref "../kyverno-policies/" >}}) has replaced it as an Enterprise Edition feature for policy management.
+{{% /notice %}}
+
 This manual explains how Kubermatic integrates with OPA and how to use it.
 
 ## OPA


### PR DESCRIPTION
OPA (Open Policy Agent) was deprecated in KKP 2.28 with Kyverno replacing it as the Enterprise Edition feature for policy management. The dashboard already displays this deprecation warning, but the documentation is missing this notice.
