### PR TITLE
Add missing permissions for IAM and EC2 to recommended IAM policy

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/administration/presets/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/administration/presets/_index.en.md
@@ -313,6 +313,7 @@ For AWS no root is required and we recommend the following IAM policy:
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListRolePolicies",
+        "iam:PassRole",
         "iam:PutRolePolicy",
         "iam:TagRole"
       ],
@@ -336,6 +337,7 @@ For AWS no root is required and we recommend the following IAM policy:
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
         "ec2:DescribeVpcs",
         "ec2:RunInstances",
         "ec2:TerminateInstances"

--- a/content/kubermatic/v2.29/tutorials-howtos/administration/presets/_index.en.md
+++ b/content/kubermatic/v2.29/tutorials-howtos/administration/presets/_index.en.md
@@ -313,6 +313,7 @@ For AWS no root is required and we recommend the following IAM policy:
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListRolePolicies",
+        "iam:PassRole",
         "iam:PutRolePolicy",
         "iam:TagRole"
       ],
@@ -336,6 +337,7 @@ For AWS no root is required and we recommend the following IAM policy:
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
         "ec2:DescribeVpcs",
         "ec2:RunInstances",
         "ec2:TerminateInstances"


### PR DESCRIPTION
While setting up KKP, I used the recommended IAM policy from the [documentation](https://docs.kubermatic.com/kubermatic/v2.29/tutorials-howtos/administration/presets/#limiting-permissions-for-credentials-used-in-presets) for AWS seed cluster creation.

When I tried to create my first user cluster, the following errors appeared due to missing permissions:

> failed to retrieve VPC attributes: failed to describe vpc attributes, due to operation error EC2: DescribeVpcAttribute, https response error StatusCode: 403

> failed cloud provider init: failed to add role to the instance profile: operation error IAM: AddRoleToInstanceProfile, https response error StatusCode: 403

These errors have been solved by adding the permissions **iam:PassRole** and **ec2:DescribeVpcAttribute** to the IAM policy. So my proposal would be to add them to the recommended IAM policy.