### PR TITLE
Add documentation for CIS Pod Security Standards compliance results

### DIFF
--- a/content/kubermatic/main/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/main/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -353,7 +353,7 @@ _Baseline-enforced namespaces block hostNetwork. Privileged system namespaces ne
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allowPrivilegeEscalation: false`. Components in privileged system namespaces may not have this restriction._
+_Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allowPrivilegeEscalation: false`. Components in privileged system namespaces require privilege escalation._
 
 ---
 
@@ -363,7 +363,7 @@ _Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allo
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Workloads in baseline-enforced namespaces set `runAsNonRoot: true` and run as non-root users. Components in privileged system namespaces may run as root._
+_Workloads in baseline-enforced namespaces set `runAsNonRoot: true` and run as non-root users. Components in privileged system namespaces run as root._
 
 ---
 
@@ -421,7 +421,7 @@ _Baseline-enforced namespaces do not use hostPath volumes. Components in privile
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Baseline-enforced namespaces do not use hostPorts. Some components in privileged system namespaces may require hostPorts._
+_Baseline-enforced namespaces do not use hostPorts. Components in privileged system namespaces require hostPorts._
 
 ---
 
@@ -493,9 +493,9 @@ _Baseline-enforced namespaces do not use hostPorts. Some components in privilege
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
+**Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_The issue is under investigation to provide a fix in a future KKP release_
+_Workloads in baseline-enforced namespaces (default, kubernetes-dashboard) have security contexts applied with runAsNonRoot, allowPrivilegeEscalation: false, and capabilities dropped. Components in privileged system namespaces require elevated privileges._
 
 ---
 

--- a/content/kubermatic/v2.28/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/v2.28/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -353,7 +353,7 @@ _Baseline-enforced namespaces block hostNetwork. Privileged system namespaces ne
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allowPrivilegeEscalation: false`. Components in privileged system namespaces may not have this restriction._
+_Workloads in baseline-enforced namespaces set `allowPrivilegeEscalation: false`. Components in privileged system namespaces require privilege escalation._
 
 ---
 
@@ -363,7 +363,7 @@ _Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allo
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Workloads in baseline-enforced namespaces set `runAsNonRoot: true` and run as non-root users. Components in privileged system namespaces may run as root._
+_Workloads in baseline-enforced namespaces set `runAsNonRoot: true` and run as non-root users. Components in privileged system namespaces run as root._
 
 ---
 
@@ -421,7 +421,7 @@ _Baseline-enforced namespaces do not use hostPath volumes. Components in privile
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Baseline-enforced namespaces do not use hostPorts. Some components in privileged system namespaces may require hostPorts._
+_Baseline-enforced namespaces do not use hostPorts. Components in privileged system namespaces require hostPorts._
 
 ---
 
@@ -493,9 +493,9 @@ _Baseline-enforced namespaces do not use hostPorts. Some components in privilege
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
+**Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_The issue is under investigation to provide a fix in a future KKP release_
+_Workloads in baseline-enforced namespaces (default, kubernetes-dashboard) have security contexts applied with runAsNonRoot, allowPrivilegeEscalation: false, and capabilities dropped. Components in privileged system namespaces require elevated privileges._
 
 ---
 

--- a/content/kubermatic/v2.29/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/v2.29/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -353,7 +353,7 @@ _Baseline-enforced namespaces block hostNetwork. Privileged system namespaces ne
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allowPrivilegeEscalation: false`. Components in privileged system namespaces may not have this restriction._
+_Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allowPrivilegeEscalation: false`. Components in privileged system namespaces require privilege escalation._
 
 ---
 
@@ -363,7 +363,7 @@ _Workloads in baseline-enforced namespaces (dashboard-metrics-scraper) set `allo
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Workloads in baseline-enforced namespaces set `runAsNonRoot: true` and run as non-root users. Components in privileged system namespaces may run as root._
+_Workloads in baseline-enforced namespaces set `runAsNonRoot: true` and run as non-root users. Components in privileged system namespaces run as root._
 
 ---
 
@@ -421,7 +421,7 @@ _Baseline-enforced namespaces do not use hostPath volumes. Components in privile
 
 **Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_Baseline-enforced namespaces do not use hostPorts. Some components in privileged system namespaces may require hostPorts._
+_Baseline-enforced namespaces do not use hostPorts. Components in privileged system namespaces require hostPorts._
 
 ---
 
@@ -493,9 +493,9 @@ _Baseline-enforced namespaces do not use hostPorts. Some components in privilege
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
+**Result:** 🔵 Pass (Baseline-Enforced Namespaces) / Expected Fail (Privileged System Namespaces)
 
-_The issue is under investigation to provide a fix in a future KKP release_
+_Workloads in baseline-enforced namespaces (default, kubernetes-dashboard) have security contexts applied with runAsNonRoot, allowPrivilegeEscalation: false, and capabilities dropped. Components in privileged system namespaces require elevated privileges._
 
 ---
 


### PR DESCRIPTION
This PR updates the CIS benchmark documentation to reflect Pod Security Standards (5.2.x) compliance after implementing PSA labels on user cluster namespaces.

xref: https://github.com/kubermatic/kubermatic/issues/15076, https://github.com/kubermatic/kubermatic/pull/15273