### PR TITLE
Update CIS benchmark docs for worker node fixes

### DIFF
--- a/content/kubermatic/main/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/main/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -43,9 +43,7 @@ Each control in the CIS Kubernetes Benchmark was evaluated. These are the possib
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
-
-_The issue is under investigation to provide a fix in a future KKP release_
+**Result:** 🟢 Pass
 
 ---
 
@@ -77,9 +75,7 @@ _The issue is under investigation to provide a fix in a future KKP release_
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
-
-_The issue is under investigation to provide a fix in a future KKP release_
+**Result:** 🟢 Pass
 
 ---
 
@@ -185,9 +181,9 @@ _The issue is under investigation to provide a fix in a future KKP release_
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
+**Result:** 🔵 Expected Fail (Architectural Requirement)
 
-_The issue is under investigation to provide a fix in a future KKP release_
+_The `--hostname-override` flag is used to ensure consistent node naming across all cloud providers, matching the KKP machine deployment naming pattern. This is required for proper node identification by Cloud Controller Managers._
 
 ---
 

--- a/content/kubermatic/v2.28/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/v2.28/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -43,9 +43,7 @@ Each control in the CIS Kubernetes Benchmark was evaluated. These are the possib
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
-
-_The issue is under investigation to provide a fix in a future KKP release_
+**Result:** 🟢 Pass
 
 ---
 
@@ -77,9 +75,7 @@ _The issue is under investigation to provide a fix in a future KKP release_
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
-
-_The issue is under investigation to provide a fix in a future KKP release_
+**Result:** 🟢 Pass
 
 ---
 
@@ -185,9 +181,9 @@ _The issue is under investigation to provide a fix in a future KKP release_
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
+**Result:** 🔵 Expected Fail (Architectural Requirement)
 
-_The issue is under investigation to provide a fix in a future KKP release_
+_The `--hostname-override` flag is used to ensure consistent node naming across all cloud providers, matching the KKP machine deployment naming pattern. This is required for proper node identification by Cloud Controller Managers._
 
 ---
 

--- a/content/kubermatic/v2.29/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
+++ b/content/kubermatic/v2.29/security/cis-benchmarking/kkp2.28-k8s1.33/_index.en.md
@@ -43,9 +43,7 @@ Each control in the CIS Kubernetes Benchmark was evaluated. These are the possib
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
-
-_The issue is under investigation to provide a fix in a future KKP release_
+**Result:** 🟢 Pass
 
 ---
 
@@ -77,9 +75,7 @@ _The issue is under investigation to provide a fix in a future KKP release_
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
-
-_The issue is under investigation to provide a fix in a future KKP release_
+**Result:** 🟢 Pass
 
 ---
 
@@ -185,9 +181,9 @@ _The issue is under investigation to provide a fix in a future KKP release_
 
 **Severity:** HIGH
 
-**Result:** 🔴 Fail
+**Result:** 🔵 Expected Fail (Architectural Requirement)
 
-_The issue is under investigation to provide a fix in a future KKP release_
+_The `--hostname-override` flag is used to ensure consistent node naming across all cloud providers, matching the KKP machine deployment naming pattern. This is required for proper node identification by Cloud Controller Managers._
 
 ---
 


### PR DESCRIPTION
This PR updates the CIS benchmark documentation after the Worker Node fixes were merged.

xref: https://github.com/kubermatic/kubermatic/issues/15076