### PR TITLE
fix incorrect field name to configure user cluster prometheus

### DIFF
--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
@@ -33,7 +33,7 @@ KKP provides a default set of rules. However, new custom rules can be added, or 
 
 #### Custom rules
 
-Custom rules can be added by defining them as a YAML-formatted string under the `spec.monitoring.customRules` field.
+Custom rules can be added by defining them as a YAML-formatted string under the `spec.userCluster.monitoring.customRules` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -89,7 +89,7 @@ The scraping behavior of Prometheus can be customized. New scraping configuratio
 
 #### Add Custom Scraping Configurations
 
-Custom scraping configurations can be specified by adding them under the `spec.monitoring.customScrapingConfigs` field.
+Custom scraping configurations can be specified by adding them under the `spec.userCluster.monitoring.customScrapingConfigs` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1

--- a/content/kubermatic/v2.26/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
+++ b/content/kubermatic/v2.26/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
@@ -33,7 +33,7 @@ KKP provides a default set of rules. However, new custom rules can be added, or 
 
 #### Custom rules
 
-Custom rules can be added by defining them as a YAML-formatted string under the `spec.monitoring.customRules` field.
+Custom rules can be added by defining them as a YAML-formatted string under the `spec.userCluster.monitoring.customRules` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -88,7 +88,7 @@ The scraping behavior of Prometheus can be customized. New scraping configuratio
 
 #### Add Custom Scraping Configurations
 
-Custom scraping configurations can be specified by adding them under the `spec.monitoring.customScrapingConfigs` field.
+Custom scraping configurations can be specified by adding them under the `spec.userCluster.monitoring.customScrapingConfigs` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1

--- a/content/kubermatic/v2.27/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
+++ b/content/kubermatic/v2.27/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
@@ -33,7 +33,7 @@ KKP provides a default set of rules. However, new custom rules can be added, or 
 
 #### Custom rules
 
-Custom rules can be added by defining them as a YAML-formatted string under the `spec.monitoring.customRules` field.
+Custom rules can be added by defining them as a YAML-formatted string under the `spec.userCluster.monitoring.customRules` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -89,7 +89,7 @@ The scraping behavior of Prometheus can be customized. New scraping configuratio
 
 #### Add Custom Scraping Configurations
 
-Custom scraping configurations can be specified by adding them under the `spec.monitoring.customScrapingConfigs` field.
+Custom scraping configurations can be specified by adding them under the `spec.userCluster.monitoring.customScrapingConfigs` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1

--- a/content/kubermatic/v2.28/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
+++ b/content/kubermatic/v2.28/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
@@ -33,7 +33,7 @@ KKP provides a default set of rules. However, new custom rules can be added, or 
 
 #### Custom rules
 
-Custom rules can be added by defining them as a YAML-formatted string under the `spec.monitoring.customRules` field.
+Custom rules can be added by defining them as a YAML-formatted string under the `spec.userCluster.monitoring.customRules` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -89,7 +89,7 @@ The scraping behavior of Prometheus can be customized. New scraping configuratio
 
 #### Add Custom Scraping Configurations
 
-Custom scraping configurations can be specified by adding them under the `spec.monitoring.customScrapingConfigs` field.
+Custom scraping configurations can be specified by adding them under the `spec.userCluster.monitoring.customScrapingConfigs` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1

--- a/content/kubermatic/v2.29/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
+++ b/content/kubermatic/v2.29/tutorials-howtos/monitoring-logging-alerting/master-seed/customization/_index.en.md
@@ -33,7 +33,7 @@ KKP provides a default set of rules. However, new custom rules can be added, or 
 
 #### Custom rules
 
-Custom rules can be added by defining them as a YAML-formatted string under the `spec.monitoring.customRules` field.
+Custom rules can be added by defining them as a YAML-formatted string under the `spec.userCluster.monitoring.customRules` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -89,7 +89,7 @@ The scraping behavior of Prometheus can be customized. New scraping configuratio
 
 #### Add Custom Scraping Configurations
 
-Custom scraping configurations can be specified by adding them under the `spec.monitoring.customScrapingConfigs` field.
+Custom scraping configurations can be specified by adding them under the `spec.userCluster.monitoring.customScrapingConfigs` field.
 
 ```yaml
 apiVersion: kubermatic.k8c.io/v1


### PR DESCRIPTION
This PR fixes the incorrect field name referenced in User Cluster Prometheus configuration page.

There is no `spec.monitoring.{customRules,customScrapingConfigs}`. These configurations are available under `spec.userCluster` field.