### PR TITLE
Drop k8s 1.32 from OSM and bump Go build image to v1.26.2

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/docs.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-2
           command:
             - make
           args:
@@ -21,7 +21,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/docs.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-2
           command:
             - "./hack/verify-filenames.sh"
           resources:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CODESPELL_IMAGE ?= quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+CODESPELL_IMAGE ?= quay.io/kubermatic/build:go-1.26-node-22-kind-0.31-2
 CODESPELL_BIN := $(shell which codespell)
 DOCKER_BIN := $(shell which docker)
 

--- a/content/kubermatic/main/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/operating-system-manager/compatibility/_index.en.md
@@ -35,4 +35,3 @@ Currently supported K8S versions are:
 - 1.35
 - 1.34
 - 1.33
-- 1.32

--- a/content/operatingsystemmanager/compatibility/_index.en.md
+++ b/content/operatingsystemmanager/compatibility/_index.en.md
@@ -35,4 +35,3 @@ Currently supported K8S versions are:
 * 1.35
 * 1.34
 * 1.33
-* 1.32


### PR DESCRIPTION
Drop k8s 1.32 from OSM and bump Go build image to v1.26.2