### PR TITLE
Add End Of Life banner for products

### DIFF
--- a/data/products.yaml
+++ b/data/products.yaml
@@ -93,6 +93,7 @@ kubelb:
   description: KubeLB is a tool to centrally manage load balancers across multicloud and on-prem environments.
   weight: 3
   shareImage: img/share-kubelb.png
+  supportedReleases: 3
   versions:
     - release: main
       name: main

--- a/themes/kubermatic-docs/layouts/partials/header.html
+++ b/themes/kubermatic-docs/layouts/partials/header.html
@@ -64,6 +64,18 @@
             {{end}}
           {{end}}
         {{end}}
+        {{if and $versions (gt (len $versions) 1)}}
+          {{$product := index $products .Section}}
+          {{$supported := $product.supportedReleases | default 0}}
+          {{range $i, $v := $versions}}
+            {{$autoEol := and (gt $supported 0) (gt $i $supported)}}
+            {{if and (or $v.eol $autoEol) (in (split $.RelPermalink "/") $v.release)}}
+              {{with $.Site.GetPage (printf "/%s/%s" $.Section (index $versions 1).release)}}
+              <div class="noticebar">You're viewing documentation for an older version of {{$product.title}} that has reached End of Life (EOL). Please use <a href="{{.RelPermalink}}" class="noticebar-link">an official release</a> version</div>
+              {{end}}
+            {{end}}
+          {{end}}
+        {{end}}
         <div id="overlay"></div>
         <div class="padding highlightable">
         <div class="top-bar">


### PR DESCRIPTION
## Summary

Adds an EOL noticebar that renders on documentation pages for versions that are no longer supported, mirroring the existing "under construction" banner shown on `main`.

Two ways to mark a version as EOL:

1. **Per-version override**: set `eol: true` on a version entry in `data/products.yaml`.
2. **Automatic via support policy**: set `supportedReleases: N` at the product level. Versions beyond the first N stable releases (index 0 is always `main`) are auto-flagged as EOL. With `supportedReleases: 3` (n, n-1, n-2), anything older than n-2 shows the banner.

Applied `supportedReleases: 3` to `kubelb`, marking v1.1 and v1.0 as EOL. Other products are unchanged; opt them in by adding the same field.

Banner copy:
> You're viewing documentation for an older version of {Product} that has reached End of Life (EOL). Please use [an official release](…) version
