### PR TITLE
docs(kubelb): document deniedAnnotations and glob pattern support

### DIFF
--- a/content/kubelb/main/tutorials/config/_index.en.md
+++ b/content/kubelb/main/tutorials/config/_index.en.md
@@ -82,7 +82,11 @@ spec:
   propagateAllAnnotations: true
 ```
 
+Keys listed in `deniedAnnotations` are still excluded — see [Deny annotations](#3-deny-annotations) below.
+
 #### 2. Propagate specific annotations
+
+Keys in `propagatedAnnotations` support shell-style glob patterns (`*`, `?`, `[abc]`), which is useful for allowing a whole family of controller annotations at once.
 
 ```yaml
 apiVersion: kubelb.k8c.io/v1alpha1
@@ -92,13 +96,36 @@ metadata:
   namespace: kubelb
 spec:
   propagatedAnnotations:
-    # If the key is empty, any value can be configured for propagation.
-    metalb.universe.tf/allow-shared-ip: ""
-    # Since the value is explicitly provided, only this value will be allowed for propagation.
+    # If the value is empty, any value is allowed for this key.
+    metallb.universe.tf/allow-shared-ip: ""
+    # If the value is non-empty, it is treated as a comma-separated list of permitted exact values.
     metallb.universe.tf/loadBalancerIPs: "8.8.8.8"
+    # Glob patterns match all keys under a prefix.
+    nginx.ingress.kubernetes.io/*: ""
 ```
 
-#### 3. Default annotations
+#### 3. Deny annotations
+
+`deniedAnnotations` is a list of key patterns that are excluded from propagation. Deny rules **always take precedence** over `propagatedAnnotations` and `propagateAllAnnotations`, so this is the right place to enforce hard exclusions (sensitive keys, controller-internal keys, etc.). Patterns support the same shell-style glob syntax as `propagatedAnnotations`.
+
+```yaml
+apiVersion: kubelb.k8c.io/v1alpha1
+kind: Config
+metadata:
+  name: default
+  namespace: kubelb
+spec:
+  propagateAllAnnotations: true
+  deniedAnnotations:
+    - "kubernetes.io/last-applied-configuration"
+    - "internal.company.io/*"
+```
+
+{{% notice note %}}
+`defaultAnnotations` are not subject to deny rules — they represent explicit administrator intent and are merged in last without being filtered.
+{{% /notice %}}
+
+#### 4. Default annotations
 
 Default annotations for resources that KubeLB generates in the management cluster can also be configured. This is useful for setting annotations that are required by the cloud provider to configure the LoadBalancers. For example, the `service.beta.kubernetes.io/aws-load-balancer-internal` annotation is used to create an internal LoadBalancer in AWS.
 

--- a/content/kubelb/main/tutorials/tenants/_index.en.md
+++ b/content/kubelb/main/tutorials/tenants/_index.en.md
@@ -32,6 +32,10 @@ spec:
   propagatedAnnotations: null
   # Propagate all annotations to the resources.
   propagateAllAnnotations: true
+  # Exclude these annotation key patterns regardless of propagateAllAnnotations / propagatedAnnotations.
+  # Patterns support shell-style globs.
+  deniedAnnotations:
+    - "internal.company.io/*"
   loadBalancer:
     class: "metallb.universe.tf/metallb"
     # Enterprise Edition Only
@@ -58,6 +62,7 @@ spec:
 With this CR we are creating a tenant named `shroud` with the following configurations:
 
 * **propagateAllAnnotations: true** - Propagate all annotations to the resources.
+* **deniedAnnotations** - Annotation key patterns to exclude from propagation. Deny rules always take precedence over `propagateAllAnnotations` and `propagatedAnnotations`. See [Annotation Settings]({{< relref "../config#annotation-settings" >}}) for details.
 * **loadBalancer.class: metallb.universe.tf/metallb** - The class to use for LoadBalancer resources for tenants in the management cluster.
 * **loadBalancer.limit: 10** - The limit of LoadBalancer resources that can be created by the tenant.
 * **ingress.class: nginx** - The class to use for Ingress resources for tenants in the management cluster.


### PR DESCRIPTION
## Summary

Documents the new annotation handling features added in kubermatic/kubelb#454 / kubermatic/kubelb#452:

- `deniedAnnotations` field on `Config` and `Tenant`.
- Glob pattern support for keys in `propagatedAnnotations` and entries in `deniedAnnotations`.
