### PR TITLE
Add SecureGuard docs (unlisted, in development)

### DIFF
--- a/content/secureguard/_index.en.md
+++ b/content/secureguard/_index.en.md
@@ -1,0 +1,10 @@
++++
+title = "SecureGuard Docs"
+sitemapexclude = true
+searchexclude = true
+private = true
++++
+
+SecureGuard is a Kubermatic product currently under development. This documentation is a work in progress and is not yet publicly announced.
+
+For the latest documentation, please visit the [SecureGuard documentation]({{< ref "./main/" >}}).

--- a/content/secureguard/main/_index.en.md
+++ b/content/secureguard/main/_index.en.md
@@ -1,0 +1,34 @@
++++
+title = "Kubermatic SecureGuard"
+date = 2026-06-13T09:00:00+02:00
+weight = 8
+description = "Learn how to use Kubermatic SecureGuard to secure your Kubernetes workloads across multi-cloud and on-premise environments."
+sitemapexclude = true
+searchexclude = true
+private = true
++++
+
+{{% notice warning %}}
+SecureGuard is currently under active development. This documentation is a preview and is not yet publicly announced. Content is subject to change.
+{{% /notice %}}
+
+## What is SecureGuard?
+
+SecureGuard is a project by Kubermatic, providing security and compliance capabilities for Kubernetes workloads across multi-cloud and on-premise environments.
+
+## Motivation and Background
+
+This section will describe the motivation and background for SecureGuard.
+
+## Table of Content
+
+{{% children depth=5 %}}
+{{% /children %}}
+
+## Further Information
+
+Visit [kubermatic.com](https://www.kubermatic.com/) for further information.
+
+{{% notice tip %}}
+For latest updates follow us on Twitter [@Kubermatic](https://twitter.com/Kubermatic)
+{{% /notice %}}

--- a/data/products.yaml
+++ b/data/products.yaml
@@ -166,3 +166,15 @@ conformance-ee:
 #   description: <TODO>
 #   weight: 6
 #   shareImage: img/share-developer-platform.png
+# SecureGuard is still in development - do not yet reveal to the public.
+# The content tree exists under content/secureguard/ and is reachable via direct
+# link only (excluded from sitemap and search). Uncomment this block to publish.
+# secureguard:
+#   name: secureguard
+#   title: SecureGuard
+#   textName: SecureGuard
+#   description: <TODO>
+#   weight: 8
+#   versions:
+#     - release: main
+#       name: main


### PR DESCRIPTION
## What this does

Adds the main documentation tree for the new **SecureGuard** product.


## Files

- `content/secureguard/_index.en.md` — top-level product landing (redirect note to main).
- `content/secureguard/main/_index.en.md` — `main` version landing page with an under-development notice.
- `data/products.yaml` — commented-out reservation block for SecureGuard.

## Notes

The content is placeholder/skeleton and should be filled later.