### PR TITLE
docs(secureguard): accuracy pass, feature coverage, launch unhide, OpenBao 0.3.0

### DIFF
--- a/content/secureguard/_index.en.md
+++ b/content/secureguard/_index.en.md
@@ -1,10 +1,5 @@
 +++
 title = "SecureGuard Docs"
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
-
-SecureGuard is a Kubermatic product currently under development. This documentation is a work in progress and is not yet publicly announced.
 
 For the latest documentation, please visit the [SecureGuard documentation]({{< ref "./main/" >}}).

--- a/content/secureguard/main/_index.en.md
+++ b/content/secureguard/main/_index.en.md
@@ -80,7 +80,7 @@ Not sure which doc to read first? Pick the path that matches you:
 | **Just want to try it locally** | [Getting Started]({{< ref "/secureguard/main/getting-started/" >}}) | [User Guide]({{< ref "/secureguard/main/user-guide/" >}}) |
 | **A developer using the dashboard day-to-day** | [User Guide]({{< ref "/secureguard/main/user-guide/" >}}) | [Glossary]({{< ref "/secureguard/main/glossary/" >}}) |
 | **An operator deploying to production** | [Installation]({{< ref "/secureguard/main/installation/" >}}) | [Security Hardening]({{< ref "/secureguard/main/security-hardening/" >}}), [Advanced Configuration]({{< ref "/secureguard/main/advanced-configuration/" >}}) |
-| **Integrating or debugging the API** | [Architecture]({{< ref "/secureguard/main/architecture/" >}}) | [API Reference](https://github.com/kubermatic/secureguard/blob/main/docs/api-reference.md) |
+| **Integrating or debugging the API** | [Architecture]({{< ref "/secureguard/main/architecture/" >}}) | [API Reference]({{< ref "/secureguard/main/api-reference/" >}}) |
 
 {{% notice tip %}}
 Keep the [Glossary]({{< ref "/secureguard/main/glossary/" >}}) open in a tab. Whenever a term like *ESO*, *SecretStore*, *CRD*, *OIDC*, or *unsealing* is unclear, it's defined there in one line.

--- a/content/secureguard/main/_index.en.md
+++ b/content/secureguard/main/_index.en.md
@@ -3,14 +3,7 @@ title = "Kubermatic SecureGuard"
 date = 2026-06-13T09:00:00+02:00
 weight = 8
 description = "Protect and manage secrets with open-source transparency — a Kubernetes-native secrets management platform built on OpenBao and the External Secrets Operator."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
-
-{{% notice warning %}}
-SecureGuard is currently under active development. This documentation is a preview and is not yet publicly announced. Content is subject to change.
-{{% /notice %}}
 
 **Protect and manage secrets with open-source transparency.**
 

--- a/content/secureguard/main/_index.en.md
+++ b/content/secureguard/main/_index.en.md
@@ -54,7 +54,7 @@ You manage steps 1–2 from the SecureGuard dashboard. New to the terms above? S
 - **Centralized Management:** Provides a single source of truth across all environments and clusters.
 - **Multi-Cluster Support:** Manage ESO deployments across clusters via the SG Agent Controller and ESODeployment CRDs.
 - **Federation (optional):** Serve secrets to remote clusters over mTLS without exposing the backend stores — via a standalone broker and the `fedclient` consumer.
-- **ReloaderConfig:** Event-driven workload reloading when synced secrets change.
+- **ReloaderConfig (optional):** Event-driven rotation — roll out a Deployment or trigger ESO to reconcile in response to a Secret/ConfigMap change, cloud event, or webhook, instead of waiting for the next poll.
 - **Developer First:** Built-in React dashboard for visualizing and managing the secret sync lifecycle.
 - **Zero-Knowledge Security:** Secret values are redacted at the proxy layer — they never reach the browser.
 

--- a/content/secureguard/main/_index.en.md
+++ b/content/secureguard/main/_index.en.md
@@ -29,7 +29,7 @@ SecureGuard answers both by combining three open-source tools and putting a frie
 - **SecureGuard's dashboard** is the **control room** — it lets you see and manage all of this without memorizing `kubectl` commands, and **without ever exposing the secret values themselves** (the dashboard shows `••••••••`, never the real value).
 
 {{% notice note %}}
-**OpenBao is optional.** It's our **opinionated default** so teams without a vault get a complete, batteries-included stack out of the box. But SecureGuard is **provider-agnostic**: ESO supports many backends (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and [more](https://external-secrets.io/latest/provider/aws-secrets-manager/)). If you already have a vault, point your `SecretStore`s at it and disable the bundled OpenBao (`--set openbao.enabled=false`). Everything else works the same.
+**OpenBao is optional.** It's our **opinionated default** so teams without a vault get a complete, batteries-included stack out of the box. But SecureGuard is **provider-agnostic**: ESO supports many backends (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and [more](https://external-secrets.io/latest/introduction/stability-support/)). If you already have a vault, point your `SecretStore`s at it and disable the bundled OpenBao (`--set openbao.enabled=false`). Everything else works the same.
 {{% /notice %}}
 
 > **Analogy:** Think of OpenBao as a bank vault, ESO as the armored truck that delivers cash to ATMs (your apps), and SecureGuard as the security desk with the camera monitors — you can watch and direct everything, but you can't reach into the vault and pull the cash out through the monitor.

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -205,7 +205,7 @@ spec:
   latest: true           # marks the recommended/default selection
   deprecated: false      # when true, hidden from new deployments
   releaseDate: "2026-05-04"
-  minKubeVersion: "1.23"
+  minKubeVersion: "1.23"   # minimum Kubernetes version of the *target* cluster for this ESO release
   notes: Latest stable release.
 ```
 
@@ -230,11 +230,12 @@ If you prefer to manage ESO installations manually, you can deploy ESO independe
 
 1.  Ensure the Management OpenBao API (`https://openbao.secureguard.yourcompany.com`) is reachable from the Target cluster nodes.
 2.  Configure Kubernetes authentication in OpenBao for the Target cluster. This requires setting up a Kubernetes Auth Role in the central OpenBao instance that trusts the Service Account tokens issued by the Target cluster's API server.
-3.  Deploy ESO to the Target Cluster:
+3.  Deploy ESO to the Target Cluster (pin a supported **2.x** release — see the [version catalog](#eso-version-catalog-esoversion-crd)):
     ```bash
     helm install external-secrets external-secrets/external-secrets \
       --namespace external-secrets \
       --create-namespace \
+      --version 2.6.0 \
       --set installCRDs=true
     ```
 4.  Create a `ClusterSecretStore` in the Target cluster pointing to the Central OpenBao URL.
@@ -254,16 +255,26 @@ This creates per-cluster Secrets and optionally registers an SGAgent CR. See the
 
 ## Proxy Configuration
 
-The backend proxy is configured via environment variables. See the [API Reference — Environment Variables](https://github.com/kubermatic/secureguard/blob/main/docs/api-reference.md#environment-variables) for the complete list.
+The backend proxy is configured via environment variables. The Helm chart sets these from your values; the full list below is useful for custom deployments and debugging.
 
-### Key Configuration Options
+### Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
 | `OIDC_ISSUER_URL` | — (**required**) | Dex/OIDC issuer URL — the proxy exits if unset (auth is mandatory) |
+| `OIDC_CLIENT_ID` | `secureguard` | OIDC client ID |
+| `OIDC_CLIENT_SECRET` | — | OIDC client secret |
+| `OIDC_REDIRECT_URI` | `http://localhost:30080/api/auth/callback` | OAuth2 callback URL |
+| `DEX_PUBLIC_URL` | — | External Dex URL for browser redirects (when it differs from the in-cluster issuer URL) |
+| `SESSION_SECRET` | — (**required**) | Secret for signing session cookies. Must be stable across restarts and shared by all replicas — the proxy refuses to start without it. The Helm chart auto-generates a stable value if `auth.sessionSecret` is left empty |
 | `PORT` | `3001` | Proxy listen port |
-| `DEFAULT_CONTEXT` | current-context | Default kubeconfig context |
-| `POD_NAMESPACE` | `default` | Namespace for per-cluster Secrets |
+| `DEFAULT_CONTEXT` | current-context | Default kubeconfig context for `/api/kube/*` |
+| `POD_NAMESPACE` | `default` | Namespace watched for per-cluster kubeconfig Secrets |
+| `KUBECONFIG` | — | Path to a kubeconfig file (local development only; in-cluster the proxy discovers clusters from labeled Secrets instead) |
+| `REMOTE_TOKEN_DIR` | `$TMPDIR/secureguard-tokens` | Writable directory for the rotating per-cluster token files (see below) |
+| `ALLOWED_ORIGIN` | unset | Exact origin allowed for cross-origin (CORS) API access. Unset: no CORS headers are sent and browsers enforce the same-origin policy |
+| `COOKIE_SECURE` | auto | Force the `Secure` cookie flag on (`true`) or off (`false`); by default it is derived from the redirect URI scheme |
+| `LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, or `error` (structured JSON logs on stderr) |
 
 ### Route Allowlist
 
@@ -345,11 +356,41 @@ OpenBao supports various storage backends, although Integrated Storage (Raft) is
 
 ## Monitoring
 
-SecureGuard does not currently expose a Prometheus `/metrics` endpoint. Monitoring is achieved through Kubernetes-native observability:
+All SecureGuard Go components expose **Prometheus metrics**:
 
-- **Pod health**: The proxy exposes a `/healthz` endpoint used for liveness and readiness probes
-- **Cluster health**: The `/api/clusters/{id}/health` endpoint checks connectivity to each cluster's API server
-- **Logs**: The proxy and agent use Go's standard `log` package, outputting structured logs to stdout
-- **Kubernetes events**: Use the Event Stream page in the dashboard or `kubectl get events` for real-time activity
+- **Proxy** — `/metrics` on the main listen port (unauthenticated, no session required):
 
-For comprehensive monitoring, integrate with your existing observability stack by collecting pod logs and Kubernetes events.
+  | Metric | Type | Description |
+  |---|---|---|
+  | `secureguard_proxy_requests_total` | counter | Kubernetes API proxy requests by cluster and upstream status code |
+  | `secureguard_proxy_upstream_duration_seconds` | histogram | Upstream Kubernetes API request duration by cluster |
+  | `secureguard_proxy_allowlist_rejections_total` | counter | Requests rejected by the route allowlist |
+  | `secureguard_proxy_secret_redactions_total` | counter | Secret responses redacted before reaching the browser, by kind |
+  | `secureguard_proxy_managed_clusters` | gauge | Clusters currently registered |
+  | `secureguard_proxy_token_refreshers` | gauge | Active per-cluster short-lived token refreshers |
+
+- **SG Agent** — controller-runtime metrics on `:8082` (`-metrics-addr`), health probes on `:8081` (`-health-addr`).
+- **Federation broker** — metrics on `:8080` (`-metrics-addr`), health probes on `:8081` (`-health-addr`), both plaintext and separate from the TLS serving port.
+
+### Scraping with the Prometheus Operator
+
+The Helm chart creates headless metrics Services (`metrics.enabled`, default `true`) and can generate `ServiceMonitor` / `PodMonitor` resources for the Prometheus Operator:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true        # requires the monitoring.coreos.com/v1 CRDs
+    interval: 30s
+    scrapeTimeout: 10s
+  # Alternative for setups that scrape pods directly:
+  podMonitor:
+    enabled: false
+```
+
+### Other Observability Signals
+
+- **Pod health**: the proxy exposes `/healthz`; agent and federation expose `/healthz` and `/readyz` on their health ports — all used for liveness/readiness probes.
+- **Cluster health**: the `/api/clusters/{id}/health` endpoint checks connectivity to each cluster's API server (surfaced as the status dot in the dashboard).
+- **Logs**: all components emit structured JSON logs to stdout/stderr. Verbosity is controlled via `LOG_LEVEL` on the proxy and the `logLevel` Helm values (`sgAgent.logLevel`, `federation.logLevel`).
+- **Kubernetes events**: use the Event Stream page in the dashboard or `kubectl get events` for real-time activity.

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -187,6 +187,22 @@ The controller will:
 **Only ESO 2.x is supported.** `esoVersion` must be `v2.0.0` or newer; the end-of-life 0.x line is no longer offered. The set of versions the dashboard presents is driven by the **ESO Version Catalog** (see below), not a hardcoded list.
 {{% /notice %}}
 
+### Conflict Detection
+
+The agent validates every ESODeployment against the others targeting the same effective cluster and reports violations as a `Conflict` condition (also shown as a printer column in `kubectl get esodeployments`):
+
+| Conflict | Severity | Meaning |
+|---|---|---|
+| `MultipleClusterScope` | Error (blocking) | Two cluster-scoped ESO installations on one cluster |
+| `NamespaceOverlap` | Error (blocking) | Two namespaced deployments claim the same namespace |
+| `ClusterScopeCoversNamespaced` | Warning (advisory) | A cluster-scoped deployment already covers a namespaced one |
+
+Blocking conflicts keep the resource in the `Error` phase until resolved. The dashboard's create/edit form runs the same checks client-side, so most conflicts are caught before the resource is ever submitted.
+
+### Discovery of Externally Installed ESO
+
+Every 60 seconds the agent scans connected clusters for ESO installations it does not manage (e.g. installed directly by another team). Each one is represented as a **read-only** ESODeployment named `eso-ext-<cluster>` with `managementMode: external` and phase `Discovered`, recording the discovered image and replica count. SecureGuard never modifies external installations — the CRs exist so the dashboard reflects reality and conflict detection can take them into account.
+
 ### ESO Version Catalog (ESOVersion CRD)
 
 The ESO versions offered in the dashboard's ESODeployment create/edit form are
@@ -251,7 +267,7 @@ curl -X POST http://localhost:3001/api/clusters/kubeconfig \
   -F "clusterName=prod-us-east"
 ```
 
-This creates per-cluster Secrets and optionally registers an SGAgent CR. See the [API Reference](https://github.com/kubermatic/secureguard/blob/main/docs/api-reference.md) for details.
+This creates per-cluster Secrets and optionally registers an SGAgent CR. See the [API Reference]({{< ref "../api-reference/" >}}) for details.
 
 ## Proxy Configuration
 
@@ -278,7 +294,7 @@ The backend proxy is configured via environment variables. The Helm chart sets t
 
 ### Route Allowlist
 
-The proxy only forwards Kubernetes API paths explicitly listed in `proxy/internal/proxy/routes.go`. If you add a new CRD and need dashboard access, you must add the corresponding path patterns to the allowlist. See [API Reference — Route Allowlist](https://github.com/kubermatic/secureguard/blob/main/docs/api-reference.md#route-allowlist) for the current list.
+The proxy only forwards Kubernetes API paths explicitly listed in `proxy/internal/proxy/routes.go`. If you add a new CRD and need dashboard access, you must add the corresponding path patterns to the allowlist. See [API Reference — Route Allowlist]({{< ref "../api-reference/#route-allowlist" >}}) for the current list.
 
 ### Short-Lived Remote-Cluster Tokens
 

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -39,6 +39,27 @@ dex:
 ```
 *Note: You must create an OAuth application in GitHub to obtain the Client ID and Secret, and ensure the `redirectURI` matches your Dex ingress.*
 
+### Skipping the Dex consent screen for the dashboard
+
+The SecureGuard dashboard is a **first-party** OIDC client, so the interactive
+"Grant access?" approval screen Dex shows after upstream login adds friction
+without a security benefit here. Skip it by setting `oauth2.skipApprovalScreen`
+in the Dex config — anything you put under `dex.config` passes straight through
+to Dex:
+
+```yaml
+dex:
+  config:
+    oauth2:
+      skipApprovalScreen: true
+```
+
+{{% notice note %}}
+This applies to every client Dex serves. Only enable it when the clients Dex
+serves are first-party (the bundled `secureguard` client, and the OpenBao UI if
+you use the bundled OpenBao).
+{{% /notice %}}
+
 ## User Authorization (RBAC via Impersonation)
 
 Authentication is **mandatory** in SecureGuard, and authorization is delegated entirely to Kubernetes RBAC. The backend proxy authenticates to the Kubernetes API as its own service account and then **impersonates the logged-in user** on every request, using two headers derived from the user's OIDC token:

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -359,9 +359,9 @@ For detailed RBAC configuration, see the [Security Hardening Guide]({{< ref "../
 
 ## Storage Backends
 
-While the default SecureGuard chart can deploy OpenBao with integrated Raft storage for HA, you can alternatively configure OpenBao to use external storage backends if mandated by your infrastructure team.
+The bundled OpenBao deploys as a **3-node integrated-Raft (HA) cluster by default** — each replica keeps its own copy of the data with no external storage dependency. This is the recommended backend for modern deployments.
 
-OpenBao supports various storage backends, although Integrated Storage (Raft) is highly recommended for modern deployments. If required, you can configure PostgreSQL, Consul, or cloud-specific storage (e.g., AWS DynamoDB, GCP Spanner) by modifying the `openbao.server.ha.config` block.
+If your infrastructure team mandates a different backend, OpenBao also supports PostgreSQL, Consul, or cloud-specific storage (e.g., AWS DynamoDB, GCP Spanner). Configure it — along with a KMS `seal` stanza for auto-unseal — by editing the `openbao.server.ha.raft.config` HCL block (see [Installation → OpenBao Self-Initialization & Unsealing]({{< ref "../installation/#openbao-self-initialization--unsealing" >}})).
 
 ## Monitoring
 

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -153,6 +153,10 @@ A central principle of SecureGuard is centralized governance. You deploy the cor
 1.  **Management Cluster**: Runs OpenBao, SecureGuard Dashboard, Backend Proxy, SG Agent Controller, and Dex.
 2.  **Target Clusters**: Run the External Secrets Operator (ESO), deployed and managed by the SG Agent Controller via `ESODeployment` CRDs.
 
+{{% notice warning %}}
+**RBAC is per-cluster and impersonated — a user needs bindings on _every_ cluster they touch, including targets.** The proxy impersonates the logged-in user on the API server of whichever cluster a request targets (see [User Authorization](#user-authorization-rbac-via-impersonation)). A user who is bound on the management cluster but has **no** Role/ClusterRole binding on a target cluster can select that cluster in the dashboard but sees only `403 Forbidden` for its ExternalSecrets, SecretStores, and Secrets. Create the equivalent bindings for the user/groups on each target cluster — the management-cluster binding does not carry over.
+{{% /notice %}}
+
 ### Automated Multi-Cluster Setup (ESODeployment)
 
 The SG Agent Controller automates ESO deployment to target clusters. Create an `ESODeployment` resource on the management cluster:

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -266,6 +266,41 @@ curl -X POST http://localhost:3001/api/clusters/kubeconfig \
 
 This creates per-cluster Secrets and optionally registers an SGAgent CR. See the [API Reference]({{< ref "../api-reference/" >}}) for details.
 
+**How registration is stored and discovered.** Each uploaded cluster becomes a
+Secret in the SecureGuard namespace carrying the discovery label
+`secureguard.io/cluster-kubeconfig=true`, with the connection details under a
+well-known data key. The proxy watches these labeled Secrets via an informer, so
+newly registered clusters appear without a pod restart. You can list them with:
+
+```bash
+kubectl get secrets -n secureguard-system -l secureguard.io/cluster-kubeconfig=true
+```
+
+{{% notice note %}}
+**Register the management/local cluster too.** The cluster SecureGuard runs in is
+not special-cased — for it to appear in the cluster selector and be targetable
+like any other, register it as well (upload its in-cluster kubeconfig / context).
+If you only register remote targets, the dashboard's local-cluster views can
+come up empty.
+{{% /notice %}}
+
+{{% notice warning %}}
+**Credential constraints.** At registration the proxy provisions a
+least-privilege ServiceAccount on the remote cluster and stores only a
+short-lived, self-renewing token (see [Short-Lived Remote-Cluster Tokens](#short-lived-remote-cluster-tokens)) — it never persists your uploaded credential as-is. As a result:
+
+- **Bearer tokens** and **exec-plugin** credentials (EKS/GKE/AKS `exec` blocks)
+  are supported.
+- **OIDC `auth-provider` kubeconfigs are not consumable by the proxy** and are
+  rejected at registration — the client-go OIDC auth-provider plugin is not
+  available server-side. Convert to a bearer token or an `exec` credential
+  before uploading.
+- The uploaded credential must be able to create ServiceAccounts, ClusterRoles,
+  and bindings on the target (typically cluster-admin, used exactly once).
+
+See [Kubeconfig Upload Rejected at Registration]({{< ref "../troubleshooting/#kubeconfig-upload-rejected-at-registration" >}}) in Troubleshooting.
+{{% /notice %}}
+
 ## Proxy Configuration
 
 The backend proxy is configured via environment variables. The Helm chart sets these from your values; the full list below is useful for custom deployments and debugging.

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -3,9 +3,6 @@ title = "Advanced Configuration"
 date = 2026-06-13T09:00:00+02:00
 weight = 7
 description = "Enterprise configuration for SecureGuard — custom OIDC identity providers, RBAC via impersonation, multi-cluster deployments, the ESO version catalog, and short-lived remote tokens."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 For enterprise environments, SecureGuard offers extensive configuration options targeting High Availability (HA), advanced authentication, and multi-cluster setups.

--- a/content/secureguard/main/advanced-configuration/_index.en.md
+++ b/content/secureguard/main/advanced-configuration/_index.en.md
@@ -1,6 +1,6 @@
 +++
 title = "Advanced Configuration"
-date = 2026-06-13T09:00:04+02:00
+date = 2026-06-13T09:00:00+02:00
 weight = 7
 description = "Enterprise configuration for SecureGuard — custom OIDC identity providers, RBAC via impersonation, multi-cluster deployments, the ESO version catalog, and short-lived remote tokens."
 sitemapexclude = true
@@ -58,7 +58,7 @@ This means **what a user can see and do in the dashboard is exactly what their K
 ### Prerequisites
 
 1. **Dex must emit a `groups` claim.** Group-based RBAC only works if your connector is configured to return groups (e.g. GitHub `orgs`/`teams`, an LDAP `groupSearch`, or an OIDC `groups` scope). Without it, bind roles to individual user emails instead.
-2. **The proxy service account needs the `impersonate` verb** on `users` and `groups`. The bundled Helm chart and [`k8s/rbac.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/rbac.yaml) already include this rule:
+2. **The proxy service account needs the `impersonate` verb** on `users` and `groups`. The bundled Helm chart already includes this rule:
    ```yaml
    - apiGroups: [""]
      resources: ["users", "groups"]
@@ -234,11 +234,7 @@ Behaviour in the dashboard:
   are rejected by the route allowlist. Curate the catalog with `kubectl apply`
   or via the SG Agent, which holds manage permissions on `esoversions`.
 
-A starter catalog (`v2.0.0`–`v2.6.0`) ships in
-[`k8s/samples/eso-deployments/esoversions.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/samples/eso-deployments/esoversions.yaml), and the CRD lives in
-[`k8s/esoversion-crd.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/esoversion-crd.yaml). If the catalog is empty or unreachable, the form falls
-back to the version already set on the resource (so editing existing deployments
-still works).
+A starter catalog covering `v2.0.0`–`v2.6.0` ships with the SecureGuard release manifests — apply one `ESOVersion` CR per release you want to offer, following the example above. If the catalog is empty or unreachable, the form falls back to the version already set on the resource (so editing existing deployments still works).
 
 ### Manual Multi-Cluster Setup
 
@@ -317,9 +313,9 @@ self-renewing token so nothing long-lived is ever stored:
    token file under `REMOTE_TOKEN_DIR`. The proxy transport re-reads the file per
    request. The agent does the same for clusters it talks to.
 
-This RBAC lives on the **remote** cluster and is created by code
-(`proxy/internal/remotebootstrap`) — it is intentionally **not** in the
-management-cluster `k8s/rbac.yaml`. The management-cluster proxy/agent
+This RBAC lives on the **remote** cluster and is created programmatically at
+registration — it is intentionally **not** part of the management-cluster RBAC
+templates. The management-cluster proxy/agent
 ServiceAccounts do **not** need `create` on `serviceaccounts/token`, because
 their own management-cluster identity is the kubelet-projected token, and all
 minting happens against the remote cluster with the remote SA's self-granted

--- a/content/secureguard/main/api-reference/_index.en.md
+++ b/content/secureguard/main/api-reference/_index.en.md
@@ -3,9 +3,6 @@ title = "API Reference"
 date = 2026-06-13T09:00:00+02:00
 weight = 13
 description = "REST API of the SecureGuard backend proxy — authentication endpoints, cluster management, the Kubernetes API proxy, the route allowlist, and error semantics."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 The SecureGuard backend proxy exposes a REST API that mediates **all** Kubernetes API access. The dashboard communicates exclusively with these endpoints — the browser never contacts the Kubernetes API server directly. The same endpoints can be used for scripted integrations (e.g. registering clusters from CI).

--- a/content/secureguard/main/api-reference/_index.en.md
+++ b/content/secureguard/main/api-reference/_index.en.md
@@ -1,0 +1,185 @@
++++
+title = "API Reference"
+date = 2026-06-13T09:00:00+02:00
+weight = 13
+description = "REST API of the SecureGuard backend proxy — authentication endpoints, cluster management, the Kubernetes API proxy, the route allowlist, and error semantics."
+sitemapexclude = true
+searchexclude = true
+private = true
++++
+
+The SecureGuard backend proxy exposes a REST API that mediates **all** Kubernetes API access. The dashboard communicates exclusively with these endpoints — the browser never contacts the Kubernetes API server directly. The same endpoints can be used for scripted integrations (e.g. registering clusters from CI).
+
+## Base URL
+
+| Environment | URL |
+|---|---|
+| Local development | `http://localhost:3001` |
+| In-cluster (via Service) | `http://secureguard-proxy:3001` |
+| Production (via Ingress) | `https://secureguard.yourdomain.com/api` |
+
+## Health & Metrics
+
+### `GET /healthz`
+
+Unauthenticated health check, used for liveness/readiness probes.
+
+```json
+{ "status": "ok" }
+```
+
+### `GET /metrics`
+
+Unauthenticated Prometheus metrics endpoint (scraped in-cluster). See [Monitoring]({{< ref "../advanced-configuration/#monitoring" >}}) for the metric names and Helm scrape configuration.
+
+## Authentication Endpoints
+
+These endpoints implement the OIDC authorization code flow with PKCE via Dex. They are unauthenticated — they manage their own auth lifecycle.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/auth/login` | Initiates the OIDC login flow (redirect to Dex with a PKCE code challenge) |
+| `GET /api/auth/callback` | Exchanges the authorization code for tokens, verifies the ID token, and stores user info in an HTTP-only session cookie |
+| `GET /api/auth/logout` | Clears the session cookie |
+| `GET /api/auth/user` | Returns the current user (or `401` with `{"authenticated": false}`) |
+
+**`GET /api/auth/user` response:**
+
+```json
+{
+  "authenticated": true,
+  "user": {
+    "email": "user@example.com",
+    "name": "User Name",
+    "sub": "CgVhZG1pbhIFbG9jYWw",
+    "groups": ["admin", "developers"]
+  },
+  "csrfToken": "kSJ3…"
+}
+```
+
+The `groups` claim drives impersonation and therefore Kubernetes RBAC.
+
+### CSRF Contract
+
+`csrfToken` is the session's CSRF token. Clients must echo it in the **`X-CSRF-Token`** request header on **all mutating requests** (POST/PUT/PATCH/DELETE) to any protected endpoint. Mutating requests without a matching token are rejected with `403`.
+
+## Cluster Management
+
+All cluster management endpoints require an authenticated session. Mutating endpoints additionally require the `X-CSRF-Token` header.
+
+### `GET /api/clusters`
+
+Lists all registered clusters. `status` is one of `connected`, `disconnected`, or `unknown`; `region` and `environment` are optional.
+
+```json
+[
+  { "id": "kind-secureguard", "name": "kind-secureguard", "status": "connected" }
+]
+```
+
+### `GET /api/clusters/{id}/health`
+
+Health-checks a specific cluster by connecting to its Kubernetes API server.
+
+```json
+{ "id": "kind-secureguard", "status": "connected" }
+```
+
+### `POST /api/clusters/kubeconfig`
+
+Uploads a kubeconfig to register new clusters. Each context becomes a Kubernetes Secret labeled `secureguard.io/cluster-kubeconfig=true`. Persistence is **synchronous**: the endpoint returns `200` only once the per-cluster Secrets are written; on failure the just-added clusters are rolled back and `502` is returned. The uploaded credential itself is never persisted — it is exchanged for a short-lived token at registration (see [Short-Lived Remote-Cluster Tokens]({{< ref "../advanced-configuration/#short-lived-remote-cluster-tokens" >}})).
+
+**Content-Type:** `multipart/form-data`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kubeconfig` | file | Yes | The kubeconfig file to upload |
+| `registerAgent` | string | No | Set to `"true"` to create an SGAgent CR |
+| `clusterName` | string | No | Name for the SGAgent (defaults to the first context) |
+
+```json
+{ "contexts": ["cluster-1", "cluster-2"], "agentCreated": true }
+```
+
+### `DELETE /api/clusters/{id}`
+
+Deregisters a cluster: deletes the per-cluster Secret and removes the cluster from the in-memory set. The management (default) cluster is protected and cannot be deleted.
+
+```json
+{ "deleted": "cluster-id" }
+```
+
+## Kubernetes API Proxy
+
+Each proxied request is **impersonated as the logged-in user** (`Impersonate-User` / `Impersonate-Group`), so Kubernetes RBAC governs access. Only paths in the [route allowlist](#route-allowlist) are forwarded; everything else is rejected with `403 Forbidden`.
+
+The allowlist is **query-aware**: streaming requests (`?watch=true`, `?follow=…`) are rejected on all paths — the dashboard polls instead. Mutating proxy requests require the `X-CSRF-Token` header.
+
+| Endpoint | Target |
+|---|---|
+| `* /api/kube/{path}` | The **default (management) cluster's** API server — the path is forwarded as-is |
+| `* /api/clusters/{id}/kube/{path}` | A **specific cluster's** API server, by the ID from `GET /api/clusters` |
+
+**Example:**
+
+```text
+GET /api/clusters/prod-us-east/kube/apis/external-secrets.io/v1/externalsecrets
+→ proxied to prod-us-east: GET /apis/external-secrets.io/v1/externalsecrets
+```
+
+## Route Allowlist
+
+The allowlist is **method-aware**: each path pattern permits only specific HTTP methods. The dashboard is largely read-only — most resources allow `GET` only, and mutating verbs are limited to the few flows the UI actually performs. Notably, Kubernetes `Secret` objects are **read-only** through the proxy.
+
+| API Group | Resource | Methods Allowed |
+|---|---|---|
+| Core (`v1`) | API discovery (`/api`) | `GET` |
+| Core (`v1`) | Namespaces | `GET` (list) |
+| Core (`v1`) | Events (cluster-wide & namespaced) | `GET` (list) |
+| Core (`v1`) | Secrets (cluster-wide, namespaced & single) | `GET` (read-only) |
+| `external-secrets.io/v1` | ExternalSecret | `GET` (list); `GET`/`DELETE`/`PATCH` (single) |
+| `external-secrets.io/v1` | SecretStore | `GET` (list & single) |
+| `external-secrets.io/v1` | ClusterSecretStore | `GET` (list & single) |
+| `external-secrets.io/v1alpha1` | PushSecret | `GET` (list); `GET`/`DELETE` (single) |
+| `reloader.external-secrets.io/v1alpha1` | ReloaderConfig (`configs`) | `GET` (list); `GET`/`DELETE` (single) |
+| `deploy.secureguard.io/v1alpha1` | ESODeployment | `GET` (cluster list); `GET`/`POST` (namespaced list/create); `GET`/`DELETE`/`PATCH` (single) |
+| `deploy.secureguard.io/v1alpha1` | ESOVersion | `GET` (read-only catalog) |
+| `agent.secureguard.io/v1alpha1` | SGAgent | `GET` (list) |
+| `federation.secureguard.io/v1alpha1` | FederationServer | `GET` (list & single) |
+| `federation.secureguard.io/v1alpha1` | FederationAuthorization | `GET` (list & single) |
+| `authorization.k8s.io/v1` | SelfSubjectAccessReview | `POST` |
+
+{{% notice note %}}
+**Federation CRs are read-only here.** `FederationServer` and `FederationAuthorization` carry references and policy only — never secret values. Secret serving happens in the separate [federation broker]({{< ref "../federation/" >}}), not through this proxy.
+{{% /notice %}}
+
+### Secret Value Redaction
+
+All responses containing Kubernetes Secrets (`v1/Secret` or `v1/SecretList`) are intercepted by the proxy. The `.data` and `.stringData` fields have their **values** replaced with `"REDACTED"` while key names are preserved. This is the zero-knowledge guarantee — secret content never reaches the browser, regardless of the caller's RBAC.
+
+## Environment Variables
+
+See the canonical table in [Advanced Configuration → Proxy Configuration]({{< ref "../advanced-configuration/#environment-variables" >}}).
+
+## Cluster Discovery
+
+The per-cluster kubeconfig Secrets (labeled `secureguard.io/cluster-kubeconfig=true`) are the runtime source of truth for cluster membership. Each registered cluster — including the management cluster — is one Secret named `cluster-kc-<cluster-id>` whose `config` data key holds a single-context kubeconfig.
+
+When running in-cluster, the proxy and the agent discover clusters by **watching these Secrets via an informer** scoped to `POD_NAMESPACE`: new registrations and deletions propagate to every replica at runtime, with no pod restart. When `KUBECONFIG` is set (local development), a kubeconfig file is used instead.
+
+## Error Responses
+
+All errors use a consistent JSON format:
+
+```json
+{ "error": "Human-readable error message" }
+```
+
+| Status Code | Meaning |
+|---|---|
+| `400` | Bad request (invalid input, malformed kubeconfig) |
+| `403` | Forbidden (path not in allowlist, watch/streaming request, missing or invalid CSRF token, insufficient user RBAC, or management cluster deletion) |
+| `404` | Cluster not found |
+| `502` | Upstream failure (cluster onboarding or per-cluster Secret persistence failed, invalid cluster TLS configuration) |
+| `503` | No clusters available |

--- a/content/secureguard/main/architecture/_index.en.md
+++ b/content/secureguard/main/architecture/_index.en.md
@@ -3,9 +3,6 @@ title = "Architecture & Security Model"
 date = 2026-06-13T09:00:00+02:00
 weight = 2
 description = "Component architecture, authentication flow, multi-cluster routing, and the zero-knowledge security model behind Kubermatic SecureGuard."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 Kubermatic SecureGuard is engineered with security and multi-layered protection as its core design principles. This document describes the component architecture, authentication flow, multi-cluster routing, and the zero-knowledge security model.

--- a/content/secureguard/main/architecture/_index.en.md
+++ b/content/secureguard/main/architecture/_index.en.md
@@ -138,7 +138,7 @@ The proxy and the SG Agent run under **separate** service accounts so each holds
 - **`secureguard-proxy`** — `impersonate` on users/groups, `create` on SGAgents, and management of per-cluster kubeconfig Secrets in its own namespace. It has **no** standing read/write on ESO resources (that flows through impersonation).
 - **`secureguard-agent`** — the controller/deployer permissions: SGAgent and ESODeployment reconcile (plus `/status`), and the resources the deployer creates when installing ESO into target namespaces (Deployments, ServiceAccounts, Namespaces, ClusterRoles, RoleBindings), events, and leader-election Leases.
 
-Both are defined in [`k8s/rbac.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/rbac.yaml) and [`charts/secureguard/templates/rbac.yaml`](https://github.com/kubermatic/secureguard/blob/main/charts/secureguard/templates/rbac.yaml).
+Both are provisioned by the Helm chart's RBAC templates; the proxy rule set is shown in full in [Security Hardening → Least-privilege service accounts]({{< ref "../security-hardening/#least-privilege-service-accounts" >}}).
 
 ## Multi-Cluster Routing
 

--- a/content/secureguard/main/architecture/_index.en.md
+++ b/content/secureguard/main/architecture/_index.en.md
@@ -174,7 +174,7 @@ the proxy's route allowlist, and the editing experience reflects that:
   PushSecrets, and ReloaderConfigs.
 
 This keeps version-controlled resources as the source of truth and keeps the
-browser's write surface small. See the [route allowlist](https://github.com/kubermatic/secureguard/blob/main/docs/api-reference.md#route-allowlist)
+browser's write surface small. See the [route allowlist]({{< ref "../api-reference/#route-allowlist" >}})
 for the exact permitted operations.
 
 ## Namespace Context

--- a/content/secureguard/main/eso-basics/_index.en.md
+++ b/content/secureguard/main/eso-basics/_index.en.md
@@ -3,9 +3,6 @@ title = "External Secrets Operator (ESO) Basics"
 date = 2026-06-13T09:00:00+02:00
 weight = 5
 description = "How the External Secrets Operator synchronizes secrets from OpenBao (and other providers) into native Kubernetes Secrets within SecureGuard."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 The [External Secrets Operator](https://external-secrets.io/) (ESO) is the second pillar of Kubermatic SecureGuard. While OpenBao acts as the secure storage vault, ESO acts as the intelligent delivery mechanism.

--- a/content/secureguard/main/eso-basics/_index.en.md
+++ b/content/secureguard/main/eso-basics/_index.en.md
@@ -57,7 +57,12 @@ The reverse flow. Often, components *inside* Kubernetes generate credentials (e.
 In addition to the four upstream ESO CRDs, the SecureGuard stack works with these resources:
 
 ### ReloaderConfig
-A cluster-scoped resource (`reloader.external-secrets.io/v1alpha1`, kind `Config`) that configures event-driven workload reloading. When a synced Kubernetes Secret changes, the **Reloader** controller triggers rolling restarts of dependent Deployments, StatefulSets, or DaemonSets. Reloader is an ESO companion project that SecureGuard bundles as an optional Helm sub-chart (`reloader.enabled`) and can also deploy to target clusters via an `ESODeployment`'s `reloader` block.
+A cluster-scoped resource (`reloader.external-secrets.io/v1alpha1`, kind `Config`) that makes secret delivery **event-driven** instead of poll-based. Each config wires one or more **notification sources** to one or more **trigger destinations**:
+
+- **Notification sources** — a Kubernetes `Secret` or `ConfigMap` change, a cloud event (GCP Pub/Sub, AWS SQS, Azure Event Grid), a HashiCorp Vault audit-log event, a generic webhook, or a TCP socket.
+- **Trigger destinations** — roll out a **Deployment**, or make an **ExternalSecret** / **PushSecret** reconcile immediately, or a **WorkflowRunTemplate**.
+
+Typical uses: restart a Deployment the moment its Secret rotates, or trigger ESO to re-fetch on a cloud event or webhook rather than waiting for the next `refreshInterval`. Reloader is an [External Secrets companion project](https://external-secrets.github.io/reloader/) that SecureGuard bundles as an optional Helm sub-chart (`reloader.enabled`) and can also deploy to target clusters via an `ESODeployment`'s `reloader` block.
 
 ### ESODeployment
 A namespaced SecureGuard resource (`deploy.secureguard.io/v1alpha1`) managed by the SG Agent Controller. It defines the desired ESO installation state for a target cluster, including version, namespace, component configuration, and replica counts.

--- a/content/secureguard/main/eso-basics/_index.en.md
+++ b/content/secureguard/main/eso-basics/_index.en.md
@@ -17,7 +17,7 @@ New to the terms below (CRD, SecretStore, namespace)? See the [Glossary]({{< ref
 {{% /notice %}}
 
 {{% notice note %}}
-**A note on providers:** These docs use **OpenBao** as the running example because it's SecureGuard's bundled default, but ESO is **provider-agnostic**. The same `SecretStore` → `ExternalSecret` flow works with AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and [many others](https://external-secrets.io/latest/provider/aws-secrets-manager/) — only the `SecretStore`'s `provider` block changes. Wherever you read "OpenBao" below, you can substitute your provider of choice.
+**A note on providers:** These docs use **OpenBao** as the running example because it's SecureGuard's bundled default, but ESO is **provider-agnostic**. The same `SecretStore` → `ExternalSecret` flow works with AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and [many others](https://external-secrets.io/latest/introduction/stability-support/) — only the `SecretStore`'s `provider` block changes. Wherever you read "OpenBao" below, you can substitute your provider of choice.
 {{% /notice %}}
 
 ## What is ESO?
@@ -55,18 +55,18 @@ It specifies:
 ### 4. PushSecret
 The reverse flow. Often, components *inside* Kubernetes generate credentials (e.g., a database operator generates a root password). A `PushSecret` allows you to take an existing Kubernetes `Secret` and automatically push it upstream into OpenBao for safe, centralized storage and auditing.
 
-## SecureGuard Custom Resources
+## SecureGuard & Companion Custom Resources
 
-In addition to the upstream ESO CRDs, SecureGuard introduces custom resources:
+In addition to the four upstream ESO CRDs, the SecureGuard stack works with these resources:
 
 ### ReloaderConfig
-A cluster-scoped resource that configures event-driven workload reloading. When a synced Kubernetes Secret changes, the ReloaderConfig triggers rolling restarts of dependent Deployments, StatefulSets, or DaemonSets.
+A cluster-scoped resource (`reloader.external-secrets.io/v1alpha1`, kind `Config`) that configures event-driven workload reloading. When a synced Kubernetes Secret changes, the **Reloader** controller triggers rolling restarts of dependent Deployments, StatefulSets, or DaemonSets. Reloader is an ESO companion project that SecureGuard bundles as an optional Helm sub-chart (`reloader.enabled`) and can also deploy to target clusters via an `ESODeployment`'s `reloader` block.
 
 ### ESODeployment
-A namespaced resource managed by the SG Agent Controller. It defines the desired ESO installation state for a target cluster, including version, namespace, component configuration, and replica counts.
+A namespaced SecureGuard resource (`deploy.secureguard.io/v1alpha1`) managed by the SG Agent Controller. It defines the desired ESO installation state for a target cluster, including version, namespace, component configuration, and replica counts.
 
 ### SGAgent
-A cluster-scoped resource representing an agent registered with the central SecureGuard dashboard. SGAgents maintain heartbeat health status for connected clusters.
+A cluster-scoped SecureGuard resource (`agent.secureguard.io/v1alpha1`) representing an agent registered with the central SecureGuard dashboard. SGAgents maintain heartbeat health status for connected clusters.
 
 ## Synchronization & Rotation
 

--- a/content/secureguard/main/eso-basics/_index.en.md
+++ b/content/secureguard/main/eso-basics/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "External Secrets Operator (ESO) Basics"
 date = 2026-06-13T09:00:00+02:00
-weight = 4
+weight = 5
 description = "How the External Secrets Operator synchronizes secrets from OpenBao (and other providers) into native Kubernetes Secrets within SecureGuard."
 sitemapexclude = true
 searchexclude = true

--- a/content/secureguard/main/federation/_index.en.md
+++ b/content/secureguard/main/federation/_index.en.md
@@ -91,7 +91,7 @@ spec:
         - api/stripe
 ```
 
-Sample manifests live in [`k8s/samples/federation/`](https://github.com/kubermatic/secureguard/blob/main/k8s/samples/federation/).
+The CR examples above are complete — apply them with `kubectl apply` on the hub cluster.
 
 ## Deploying the broker
 
@@ -274,7 +274,6 @@ volumes:
             path: token
 ```
 
-Full example: [`docs/examples/fedclient-sidecar.yaml`](https://github.com/kubermatic/secureguard/blob/main/docs/examples/fedclient-sidecar.yaml).
 `fedclient` exits with a [distinct code per broker outcome](#cli-reliability-version-retries-exit-codes)
 and never logs the token or the secret value; it can also be used as a one-shot
 CLI for debugging (`--insecure` for dev TLS).

--- a/content/secureguard/main/federation/_index.en.md
+++ b/content/secureguard/main/federation/_index.en.md
@@ -181,7 +181,7 @@ spec:
 For a cluster's API-server issuer, the CA is its `kube-root-ca.crt` ConfigMap,
 and the broker's anonymous discovery requests need the
 `system:service-account-issuer-discovery` ClusterRole granted (e.g. to
-`system:unauthenticated`). The cluster-e2e exercises exactly this path.
+`system:unauthenticated`).
 
 ## Consuming from a remote cluster (stock ESO)
 
@@ -252,7 +252,7 @@ in-memory volume the app reads:
 ```yaml
 initContainers:
   - name: fetch-secret
-    image: quay.io/kubermatic/secureguard-fedclient:latest
+    image: quay.io/kubermatic/secureguard-fedclient:v0.2.0   # pin to a release tag, never :latest
     args:
       - --server=https://federation.central.example:8443
       - --store=prod-vault

--- a/content/secureguard/main/federation/_index.en.md
+++ b/content/secureguard/main/federation/_index.en.md
@@ -3,9 +3,6 @@ title = "Federation — Cross-Cluster Secret Distribution"
 date = 2026-06-13T09:00:00+02:00
 weight = 8
 description = "Serve secret data to many clusters from a central SecureGuard instance over mTLS without exposing the backend secret stores — the federation broker, CRDs, fedclient, and resolution modes."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 Federation lets a central SecureGuard instance serve secret data to many

--- a/content/secureguard/main/getting-started/_index.en.md
+++ b/content/secureguard/main/getting-started/_index.en.md
@@ -3,9 +3,6 @@ title = "Getting Started"
 date = 2026-06-13T09:00:00+02:00
 weight = 1
 description = "Quickly deploy Kubermatic SecureGuard in a local or development environment and watch your first secret sync end-to-end."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 This guide will walk you through quickly deploying Kubermatic SecureGuard in a local or development environment. This deployment bundles OpenBao (in dev mode), the Dex OIDC provider, External Secrets Operator (ESO), and the SecureGuard dashboard UI.

--- a/content/secureguard/main/getting-started/_index.en.md
+++ b/content/secureguard/main/getting-started/_index.en.md
@@ -42,9 +42,12 @@ Before you begin, ensure you have the following installed:
    helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
      --namespace secureguard-system \
      --create-namespace \
-     --set openbao.server.dev.enabled=true \
-     --version 0.2.0 # replace with latest from the releases page
+     --set openbao.server.dev.enabled=true
    ```
+
+   Omitting `--version` installs the latest published chart. To pin a specific
+   release, add `--version <chart-version>` — see the
+   [Upgrade Guides]({{< ref "../upgrade-guides/" >}}) before moving between versions.
 
 2. **Verify the Deployment**
    Ensure all pods have started and are reporting `Running` status:
@@ -67,10 +70,31 @@ Once the deployment is up, you need to access the SecureGuard dashboard.
    Open your browser and navigate to `http://localhost:8080`.
 
 3. **Logging In via Dex**
-   Authentication is mandatory, so you are redirected to the Dex OIDC login page. The local dev deployment provisions a static admin user — email `admin@secureguard.local`, password `admin` — bound to `cluster-admin`. **Change these immediately for any non-local deployment.**
+   Authentication is mandatory, so you are redirected to the Dex OIDC login page. The Helm chart provisions a static admin user with the email `admin@secureguard.local` and an **auto-generated password**. Retrieve it from the `<release>-dex-admin` Secret:
+
+   ```bash
+   kubectl get secret secureguard-dex-admin \
+     -n secureguard-system \
+     -o jsonpath='{.data.password}' | base64 -d && echo
+   ```
+
+   The same command is printed in the Helm chart's post-install notes. For any non-local deployment, disable the static admin and connect a real identity provider instead — see [Static Admin User]({{< ref "../security-hardening/#static-admin-user" >}}).
 
    {{% notice note %}}
    Access is enforced per user: the proxy impersonates the logged-in user on every Kubernetes API request, so what you can see and do is governed by the RBAC bound to your user/groups. A user with no bindings can log in but sees `403` errors until granted access — see [User Authorization]({{< ref "../advanced-configuration/#user-authorization-rbac-via-impersonation" >}}).
+   {{% /notice %}}
+
+4. **Grant the Admin User Access**
+   The chart intentionally ships **no RBAC bindings for dashboard users** — without one, even the static admin sees only `403` errors. For this local walkthrough, bind `cluster-admin` to the static admin user:
+
+   ```bash
+   kubectl create clusterrolebinding secureguard-local-admin \
+     --clusterrole=cluster-admin \
+     --user=admin@secureguard.local
+   ```
+
+   {{% notice warning %}}
+   `cluster-admin` is acceptable only for a throwaway local cluster. For real deployments, create least-privilege Roles/ClusterRoles per team — see [User Authorization]({{< ref "../advanced-configuration/#user-authorization-rbac-via-impersonation" >}}).
    {{% /notice %}}
 
 ### Understanding the Security Model Basics

--- a/content/secureguard/main/glossary/_index.en.md
+++ b/content/secureguard/main/glossary/_index.en.md
@@ -80,9 +80,11 @@ theme; within each group they build on each other.
   most often.
 - **PushSecret** — The reverse direction: takes an existing Kubernetes Secret
   and **pushes it up** into an external provider for safekeeping.
-- **ReloaderConfig** — Tells the bundled **Reloader** controller to **restart
-  workloads** (Deployments, StatefulSets, DaemonSets) automatically when a
-  secret they use changes.
+- **ReloaderConfig** — Wires a **notification source** (a Secret/ConfigMap
+  change, a cloud event, a Vault audit event, a webhook, or a TCP socket) to a
+  **trigger destination** (roll out a Deployment, or reconcile an ExternalSecret
+  / PushSecret / WorkflowRunTemplate). Makes secret delivery event-driven instead
+  of poll-based. Provided by the bundled **Reloader** companion project.
 - **ESODeployment** — Describes how ESO itself should be **installed/upgraded**
   on a target cluster. The SG Agent acts on it.
 - **ESOVersion** — One entry in the operator-curated **catalog of ESO releases**

--- a/content/secureguard/main/glossary/_index.en.md
+++ b/content/secureguard/main/glossary/_index.en.md
@@ -60,7 +60,8 @@ theme; within each group they build on each other.
   them as environment variables or mounted files.
 - **CRD (Custom Resource Definition)** — A way to teach Kubernetes about new
   object types beyond its built-ins. `ExternalSecret`, `SecretStore`,
-  `PushSecret`, `ESODeployment`, and `SGAgent` are all CRDs.
+  `PushSecret`, `ESODeployment`, `ESOVersion`, `SGAgent`, `FederationServer`,
+  and `FederationAuthorization` are all CRDs.
 - **CR (Custom Resource)** — An actual instance of a CRD (e.g. *one specific*
   `ExternalSecret` named `db-creds`).
 - **Operator / Controller** — A program that watches CRs and makes the cluster
@@ -82,10 +83,13 @@ theme; within each group they build on each other.
   most often.
 - **PushSecret** — The reverse direction: takes an existing Kubernetes Secret
   and **pushes it up** into an external provider for safekeeping.
-- **ReloaderConfig** — Tells SecureGuard to **restart workloads** (Deployments,
-  StatefulSets, DaemonSets) automatically when a secret they use changes.
+- **ReloaderConfig** — Tells the bundled **Reloader** controller to **restart
+  workloads** (Deployments, StatefulSets, DaemonSets) automatically when a
+  secret they use changes.
 - **ESODeployment** — Describes how ESO itself should be **installed/upgraded**
   on a target cluster. The SG Agent acts on it.
+- **ESOVersion** — One entry in the operator-curated **catalog of ESO releases**
+  the dashboard offers when creating an ESODeployment.
 - **SGAgent** — Represents a connected cluster's agent and its **heartbeat**
   (is it alive and reporting?).
 - **Provider** — The external system a store talks to: OpenBao/Vault, AWS

--- a/content/secureguard/main/glossary/_index.en.md
+++ b/content/secureguard/main/glossary/_index.en.md
@@ -3,9 +3,6 @@ title = "Glossary"
 date = 2026-06-13T09:00:00+02:00
 weight = 12
 description = "Plain-language definitions of every key term used across the SecureGuard documentation — from secrets and vaults to ESO resources, OIDC, and federation."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 Plain-language definitions of the terms used throughout the SecureGuard docs.

--- a/content/secureguard/main/glossary/_index.en.md
+++ b/content/secureguard/main/glossary/_index.en.md
@@ -106,9 +106,12 @@ theme; within each group they build on each other.
 - **Auth Method** — How a user or machine proves its identity to OpenBao. ESO
   uses the **Kubernetes** auth method (it presents a ServiceAccount token).
 - **Sealing / Unsealing** — A sealed OpenBao knows where its encrypted data is
-  but **can't decrypt it** until it's "unsealed" with the master key. Production
-  setups use **Auto-Unseal** (e.g. AWS KMS) so pods unseal themselves on
-  restart. See [OpenBao Basics]({{< ref "../openbao-basics/" >}}).
+  but **can't decrypt it** until it's "unsealed" with the master key. By default
+  SecureGuard **self-initializes** OpenBao: the chart runs `operator init`,
+  unseals every node, and stores the Shamir key shares in the
+  `<release>-openbao-keys` Secret (back it up). For restart-resilient production,
+  use **KMS Auto-Unseal** (e.g. AWS KMS) so pods unseal themselves on restart.
+  See [OpenBao Basics]({{< ref "../openbao-basics/" >}}).
 - **Dynamic Secrets** — Credentials OpenBao generates on demand with a built-in
   expiry (TTL), instead of storing a static value.
 - **Audit Device** — OpenBao's logging of every read/write, for compliance.
@@ -183,6 +186,7 @@ theme; within each group they build on each other.
 - **High Availability (HA)** — Running multiple replicas so the service survives
   a node or pod failure.
 - **Raft / Integrated Storage** — OpenBao's built-in clustered storage used for
-  HA.
+  HA. The bundled OpenBao runs as a 3-node Raft cluster by default, with no
+  external Consul/etcd dependency.
 - **Stale secret** — A synced Secret that hasn't refreshed within its expected
   interval — the dashboard flags these so you can investigate.

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -14,8 +14,64 @@ SecureGuard ships with **OpenBao** (Vault-compatible secret engine), **Dex** (OI
 {{% /notice %}}
 
 ## Prerequisites
-- A Kubernetes cluster (v1.27 or newer recommended)
-- `helm` v3 CLI installed
+
+A local `kubectl` + `helm` v3 CLI and a Kubernetes cluster (v1.27 or newer
+recommended) are the minimum. For any non-local install you also need the
+platform pieces below — a bare cluster is **not** enough to reach a working,
+TLS-terminated login.
+
+### Cluster & tooling
+- A Kubernetes cluster (v1.27 or newer recommended).
+- `kubectl` and `helm` v3 CLIs installed and pointed at the cluster.
+- **Registry pull credentials** — SecureGuard's images are served from a
+  **private** Quay repository. Without a pull secret the pods stay in
+  `ImagePullBackOff` and `kubectl describe pod` shows `401 Unauthorized`. Create
+  a docker-registry Secret and reference it:
+  ```bash
+  kubectl create secret docker-registry secureguard-pull \
+    --namespace secureguard-system \
+    --docker-server=quay.io \
+    --docker-username='<robot-user>' \
+    --docker-password='<robot-token>'
+  ```
+  ```yaml
+  # values.yaml — reaches the first-party pods (and, via global, OpenBao + ESO)
+  imagePullSecrets:
+    - name: secureguard-pull
+  global:
+    imagePullSecrets:
+      - name: secureguard-pull
+  ```
+  See the pull-secret keys in
+  [`values.yaml`](https://github.com/kubermatic/secureguard/blob/main/charts/secureguard/values.yaml)
+  (`imagePullSecrets`, `global.imagePullSecrets`, and per–sub-chart
+  `dex.imagePullSecrets` / `reloader.imagePullSecrets`) for mirrored/air-gapped
+  registries.
+
+### Ingress, DNS & TLS (non-local installs)
+- **An ingress controller and an `IngressClass`** (e.g. ingress-nginx). Set
+  `ingress.className` to a class that exists in the cluster — the chart does not
+  install a controller for you.
+- **cert-manager plus a `ClusterIssuer`** (or a pre-created TLS Secret). The
+  ingress examples below reference `cert-manager.io/cluster-issuer`; that issuer
+  must already exist, or certificates never get issued and the browser sees TLS
+  errors.
+- **Wildcard DNS** for your SecureGuard host(s), pointed at the ingress
+  controller's load-balancer address. Dex is served at `/dex` on the dashboard
+  host and OpenBao on its own hostname, so a wildcard (e.g.
+  `*.secureguard.example.com`) is the simplest fit. See
+  [Install Order (DNS & TLS)](#install-order-dns--tls) for the exact sequence.
+
+### Storage (stateful, non-dev installs)
+- **A default `StorageClass`** (or an explicit `openbao.server.dataStorage.storageClass`).
+  Production OpenBao runs as a Raft HA cluster and each replica needs a
+  PersistentVolume; without a usable StorageClass the OpenBao pods stay
+  `Pending`.
+- **Size the volume up front.** Some StorageClasses (notably AWS EBS `gp2`/`gp3`
+  with the default provisioner settings) do **not** support online volume
+  expansion, so a PVC created too small cannot be grown in place later — pick a
+  headroom-generous `openbao.server.dataStorage.size` at install time, or use a
+  StorageClass with `allowVolumeExpansion: true`.
 
 ## Deployment Modes
 

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -3,9 +3,6 @@ title = "Installation & Deployment"
 date = 2026-06-13T09:00:00+02:00
 weight = 3
 description = "Deploy Kubermatic SecureGuard across managed, bring-your-own-provider, and bring-your-own-ESO modes, with production hardening guidance."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 Kubermatic SecureGuard is designed to be highly flexible, offering several deployment modes depending on your existing infrastructure and production requirements.

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -7,7 +7,7 @@ description = "Deploy Kubermatic SecureGuard across managed, bring-your-own-prov
 
 Kubermatic SecureGuard is designed to be highly flexible, offering several deployment modes depending on your existing infrastructure and production requirements.
 
-SecureGuard ships with **OpenBao** (Vault-compatible secret engine), **Dex** (OIDC provider), **ESO**, and **Reloader** (automatic workload restarts on secret changes) as optional Helm sub-charts. Each component can be toggled independently via the Helm values file (`openbao.enabled`, `dex.enabled`, `eso.enabled`, `reloader.enabled`).
+SecureGuard ships with **OpenBao** (Vault-compatible secret engine), **Dex** (OIDC provider), **ESO**, and **Reloader** (event-driven rotation — trigger Deployment rollouts or ESO reconciles from Secret/ConfigMap changes, cloud events, or webhooks) as optional Helm sub-charts. Each component can be toggled independently via the Helm values file (`openbao.enabled`, `dex.enabled`, `eso.enabled`, `reloader.enabled`).
 
 {{% notice note %}}
 **OpenBao is optional and opinionated.** It's bundled so teams without a vault get a complete stack out of the box, but SecureGuard is **provider-agnostic** — it manages ESO, and ESO supports many backends (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and others). If you already have a secrets backend, disable OpenBao (`--set openbao.enabled=false`) and point your `SecretStore`s at your provider. Dex is similarly optional if you already run an OIDC provider.
@@ -90,7 +90,7 @@ Beyond installing the components, the chart performs several pieces of automatio
 | Dex OIDC provider | `dex.enabled` | `true` |
 | OpenBao | `openbao.enabled` | `true` |
 | External Secrets Operator | `eso.enabled` | `true` |
-| Reloader (workload restarts) | `reloader.enabled` | `false` |
+| Reloader (event-driven rotation) | `reloader.enabled` | `false` |
 | **SG Agent Controller** (multi-cluster ESO lifecycle, heartbeats) | `sgAgent.enabled` | **`false`** |
 | **Federation broker** (cross-cluster secret serving) | `federation.enabled` | **`false`** |
 

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -165,6 +165,40 @@ The **SG Agent** and **Federation** are opt-in. Without `sgAgent.enabled=true` t
 
 ---
 
+## Install Order (DNS & TLS)
+
+On a cloud cluster the ingress load-balancer address only exists **after** the
+chart is installed, and cert-manager can only issue a certificate once DNS
+resolves to that address. Follow this order for a first install with ingress +
+TLS enabled:
+
+1. **Install the chart** with ingress enabled and your hostname(s) set (see the
+   [Ingress & TLS](#ingress--tls) values). The dashboard, Dex, and OpenBao come
+   up, but TLS is not valid yet.
+2. **Read the load-balancer address** the ingress controller was assigned:
+   ```bash
+   kubectl get ingress -n secureguard-system
+   kubectl get svc -n <ingress-controller-namespace> \
+     -o jsonpath='{.items[*].status.loadBalancer.ingress[*].hostname}{"\n"}'
+   ```
+3. **Create the wildcard DNS record** (e.g. `*.secureguard.example.com`)
+   pointing at that hostname/IP. Wait for it to propagate.
+4. **cert-manager issues `secureguard-tls`.** Once DNS resolves, the ACME
+   HTTP-01/DNS-01 challenge completes and the certificate Secret becomes `Ready`:
+   ```bash
+   kubectl get certificate -n secureguard-system
+   ```
+5. **Log in** at `https://secureguard.example.com`.
+
+{{% notice info %}}
+No component restart is required between these steps. The proxy performs OIDC
+discovery against Dex with automatic retry/back-off, so it **self-heals** once
+the certificate is issued and Dex becomes reachable over HTTPS — you do not need
+to restart the proxy after `secureguard-tls` goes `Ready`.
+{{% /notice %}}
+
+---
+
 ## Dev Mode for Testing
 
 By default OpenBao runs as a 3-node Raft HA cluster that the chart initializes and unseals for you. For local development or testing you usually don't want three replicas or persistent state — enable `dev` mode instead, where OpenBao runs as a single in-memory node that is automatically unsealed but loses all data on restart:
@@ -189,6 +223,16 @@ helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
   --set openbao.server.standalone.enabled=true \
   --set openbao.server.ha.enabled=false
 ```
+
+{{% notice tip %}}
+**Node sizing.** Even the default (non-dev) install schedules a fair number of
+pods — dashboard + proxy, Dex, three OpenBao replicas, and the ESO
+controller/webhook/cert-controller — plus the init/config hook Jobs. For a
+local `kind`/minikube walkthrough, prefer dev mode (single in-memory OpenBao,
+no PVCs) on a node with at least ~4 vCPU / 8 GiB free; the full Raft HA default
+additionally needs a working `StorageClass` and enough headroom for three
+persistent OpenBao replicas.
+{{% /notice %}}
 
 ---
 

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -265,7 +265,13 @@ A freshly deployed OpenBao is **sealed** and must be initialized and unsealed be
 - The Shamir unseal **key shares** are stored in the `<release>-openbao-keys` Secret (`keyShares: 5`, `keyThreshold: 3` by default).
 
 {{% notice warning %}}
-**Back up the `<release>-openbao-keys` Secret.** Without the unseal keys you cannot unseal OpenBao and your secrets are unrecoverable. For break-glass admin access (the root token is gone), run `bao operator generate-root` using the stored key shares.
+**Back up the `<release>-openbao-keys` Secret — immediately after the first install, as a day-one step.** Without the unseal keys you cannot unseal OpenBao and your secrets are unrecoverable. Copy it out of the cluster to your organization's secrets manager / offline escrow (do **not** leave the only copy in the same cluster it protects), then verify you can read it back:
+
+```bash
+kubectl get secret <release>-openbao-keys -n secureguard-system -o yaml > openbao-keys.backup.yaml
+```
+
+For break-glass admin access (the root token is revoked after init and never persisted), run `bao operator generate-root` using the stored key shares.
 {{% /notice %}}
 
 ```yaml

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -10,7 +10,7 @@ private = true
 
 Kubermatic SecureGuard is designed to be highly flexible, offering several deployment modes depending on your existing infrastructure and production requirements.
 
-SecureGuard ships with **OpenBao** (Vault-compatible secret engine), **Dex** (OIDC provider), and **ESO** as optional Helm sub-charts. Each component can be toggled independently via the Helm values file.
+SecureGuard ships with **OpenBao** (Vault-compatible secret engine), **Dex** (OIDC provider), **ESO**, and **Reloader** (automatic workload restarts on secret changes) as optional Helm sub-charts. Each component can be toggled independently via the Helm values file (`openbao.enabled`, `dex.enabled`, `eso.enabled`, `reloader.enabled`).
 
 {{% notice note %}}
 **OpenBao is optional and opinionated.** It's bundled so teams without a vault get a complete stack out of the box, but SecureGuard is **provider-agnostic** — it manages ESO, and ESO supports many backends (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and others). If you already have a secrets backend, disable OpenBao (`--set openbao.enabled=false`) and point your `SecretStore`s at your provider. Dex is similarly optional if you already run an OIDC provider.
@@ -22,7 +22,7 @@ SecureGuard ships with **OpenBao** (Vault-compatible secret engine), **Dex** (OI
 
 ## Deployment Modes
 
-SecureGuard's Helm chart bundles all necessary Custom Resource Definitions (CRDs) and sub-chart dependencies (OpenBao, Dex, ESO).
+SecureGuard's Helm chart bundles all necessary Custom Resource Definitions (CRDs) and sub-chart dependencies (OpenBao, Dex, ESO, Reloader).
 
 ### 1. Managed (Default)
 In this mode, all components are installed automatically by the SecureGuard Helm chart. This is recommended for clusters that do not already have an established secret manager.
@@ -41,7 +41,7 @@ helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
 ### 2. Bring Your Own Provider (External Vault, AWS, GCP, Azure, …)
 
 You don't have to use the bundled OpenBao. SecureGuard manages ESO, and ESO can
-talk to any of its [supported providers](https://external-secrets.io/latest/provider/aws-secrets-manager/).
+talk to any of its [supported providers](https://external-secrets.io/latest/introduction/stability-support/).
 Disable the bundled OpenBao and point your `SecretStore`/`ClusterSecretStore`
 resources at your own backend.
 
@@ -70,7 +70,7 @@ for AWS, Workload Identity for GCP). The dashboard, proxy, and ESO behave
 identically regardless of which provider you choose.*
 
 ### 3. Bring Your Own ESO
-If your target clusters already have the External Secrets Operator installed and managed by another platform team, you can instruct SecureGuard to deploy only the UI and Proxy, skipping the ESO installation.
+If your target clusters already have the External Secrets Operator installed and managed by another platform team, disable the bundled ESO sub-chart. The dashboard and proxy still work with the existing ESO installation — SecureGuard simply skips installing its own.
 
 ```bash
 helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
@@ -78,6 +78,8 @@ helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
   --create-namespace \
   --set eso.enabled=false
 ```
+
+*Note: This only disables the ESO sub-chart. Dex and OpenBao still deploy according to their own toggles (`dex.enabled`, `openbao.enabled`) — combine flags as needed for your environment. The [SG Agent]({{< ref "../architecture/" >}}) also auto-discovers externally installed ESO instances on managed clusters and surfaces them read-only in the dashboard.*
 
 ---
 
@@ -164,12 +166,12 @@ The SecureGuard Helm chart includes templates for RBAC, network policies, and re
 
 ### RBAC
 
-The chart provisions a dedicated `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` (see [`k8s/rbac.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/rbac.yaml)). The ClusterRole grants the proxy read access to the Kubernetes resources it manages (ExternalSecrets, SecretStores, Secrets, Events, etc.) and nothing more. Review and restrict these permissions further if your deployment does not use all SecureGuard features.
+The chart provisions a dedicated `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` for each component. The proxy's ClusterRole deliberately grants **no standing read access** to ExternalSecrets, SecretStores, or Secrets: every Kubernetes API request is impersonated as the logged-in user, so what each user can see and do is governed by the RBAC bound to *their* user/groups — not by the proxy's own permissions. The proxy itself holds only the `impersonate` verb plus narrow bookkeeping permissions (SGAgent registration and per-cluster kubeconfig Secret access). See [User Authorization]({{< ref "../advanced-configuration/#user-authorization-rbac-via-impersonation" >}}) and [RBAC Configuration]({{< ref "../security-hardening/#rbac-configuration" >}}).
 
 ```yaml
-rbac:
+serviceAccount:
   create: true
-  # Set to false if you manage RBAC externally
+  # Set to false and provide `name` if you manage the ServiceAccount externally
 ```
 
 ### Network Policies

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -132,7 +132,7 @@ Dev mode is intended only for local testing. Secrets are stored in-memory and wi
 
 ## Production Hardening
 
-When moving to production, several configurations MUST be applied to ensure a secure, resilient platform.
+When moving to production, several configurations MUST be applied to ensure a secure, resilient platform. This section covers the availability-oriented settings; for the full security checklist (authentication, RBAC, container security, CSP), work through the [Security Hardening guide]({{< ref "../security-hardening/" >}}).
 
 ### High Availability (HA)
 
@@ -188,7 +188,16 @@ The chart ships a `values-production.yaml` with a production-oriented starting p
 {{% /notice %}}
 
 ### Tenant Isolation
-For multi-tenant environments, the recommendation is deploying distinct secrets management vaults to limit the blast radius. You can deploy multiple, namespace-scoped instances of OpenBao behind the SecureGuard dashboard, isolating teams at the infrastructure level.
+For multi-tenant environments, the recommendation is deploying distinct secrets management vaults to limit the blast radius. You can deploy multiple, namespace-scoped instances of OpenBao behind the SecureGuard dashboard, isolating teams at the infrastructure level. For lighter-weight, policy-level isolation within a single instance, OpenBao's namespace feature is an alternative — see [OpenBao Basics]({{< ref "../openbao-basics/" >}}).
+
+### OpenBao UI Exposure
+The bundled OpenBao ships with its web UI enabled. In production, either serve it only via an authenticated, TLS-terminated ingress (`openbaoIngress`) or disable it entirely:
+
+```yaml
+openbao:
+  ui:
+    enabled: false
+```
 
 ---
 
@@ -216,6 +225,8 @@ networkPolicy:
   # Restricts proxy ingress to the Ingress controller
   # Restricts proxy egress to the Kubernetes API server and OpenBao
 ```
+
+For the full policy details and a custom-policy example, see [Security Hardening → Network Policies]({{< ref "../security-hardening/#network-policies" >}}).
 
 ### Resource Limits
 

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -83,6 +83,34 @@ helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
 
 ---
 
+## What the Chart Deploys (and Wires Up)
+
+Beyond installing the components, the chart performs several pieces of automation worth knowing about:
+
+| Component / behaviour | Value | Default |
+|---|---|---|
+| Dashboard UI + backend proxy | (always deployed) | — |
+| Dex OIDC provider | `dex.enabled` | `true` |
+| OpenBao | `openbao.enabled` | `true` |
+| External Secrets Operator | `eso.enabled` | `true` |
+| Reloader (workload restarts) | `reloader.enabled` | `false` |
+| **SG Agent Controller** (multi-cluster ESO lifecycle, heartbeats) | `sgAgent.enabled` | **`false`** |
+| **Federation broker** (cross-cluster secret serving) | `federation.enabled` | **`false`** |
+
+{{% notice note %}}
+The **SG Agent** and **Federation** are opt-in. Without `sgAgent.enabled=true` there are no ESODeployment reconciliation, heartbeats, or ESO auto-discovery — the related dashboard pages stay empty. See [Multi-Cluster Deployments]({{< ref "../advanced-configuration/#multi-cluster-deployments" >}}) and the [Federation guide]({{< ref "../federation/" >}}).
+{{% /notice %}}
+
+**Automatic wiring** (each can be disabled):
+
+- **Session secret** — `auth.sessionSecret` is auto-generated on first install and kept stable across upgrades if left empty. Set it explicitly when running multiple releases that must share sessions.
+- **Dex → OpenBao login** (`openbao.oidc.enabled`, default `true`) — a post-install Job configures OpenBao's OIDC auth method so users can log in to the OpenBao UI with the same Dex identity.
+- **Kubernetes auth for ESO** (`openbao.kubernetesAuth.enabled`, default `true`) — a post-install Job enables OpenBao's `kubernetes` auth method and creates the `eso-role` bound to the ESO ServiceAccount.
+- **Default ClusterSecretStore** (`eso.vaultSecretStore.enabled`, default `true`) — when both ESO and OpenBao are enabled, the chart creates a ready-to-use `ClusterSecretStore` named `openbao-backend` pointing at the bundled OpenBao (KV v2).
+- **Projected SA tokens** — `serviceAccount.tokenExpirationSeconds` (default `3600`) controls the lifetime of the proxy/agent tokens; the kubelet rotates them automatically.
+
+---
+
 ## Dev Mode for Testing
 
 By default, OpenBao starts in `standalone` (production-oriented) mode, meaning it writes to persistent storage and requires manual initialization and unsealing.
@@ -136,7 +164,7 @@ openbao:
 ```
 
 ### Ingress & TLS
-Ensure that traffic to the SecureGuard dashboard, the proxy, and OpenBao is encrypted via TLS. Configure Ingress annotations to use a tool like cert-manager for automatic certificate provisioning.
+Ensure that traffic to the SecureGuard dashboard, the proxy, and OpenBao is encrypted via TLS. The chart provides **three independent ingress blocks**: `ingress` (dashboard + proxy), `dexIngress` (Dex, exposed at `/dex` on the dashboard host), and `openbaoIngress` (OpenBao UI/API on its own hostname). Configure Ingress annotations to use a tool like cert-manager for automatic certificate provisioning.
 
 ```yaml
 ingress:
@@ -154,6 +182,10 @@ ingress:
       hosts:
         - secureguard.yourdomain.com
 ```
+
+{{% notice tip %}}
+The chart ships a `values-production.yaml` with a production-oriented starting point: 2 replicas, ingress + TLS enabled, NetworkPolicies and PodDisruptionBudgets on, OpenBao with persistent data/audit storage, and required-secret placeholders (`auth.sessionSecret`, `auth.oidc.clientSecret`). Use it as the base for your own values file.
+{{% /notice %}}
 
 ### Tenant Isolation
 For multi-tenant environments, the recommendation is deploying distinct secrets management vaults to limit the blast radius. You can deploy multiple, namespace-scoped instances of OpenBao behind the SecureGuard dashboard, isolating teams at the infrastructure level.

--- a/content/secureguard/main/installation/_index.en.md
+++ b/content/secureguard/main/installation/_index.en.md
@@ -31,7 +31,7 @@ helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
 ```
 
 - **Dex** provides OIDC authentication.
-- **OpenBao** provides a Vault-compatible secret backend (standalone/production mode by default).
+- **OpenBao** provides a Vault-compatible secret backend. By default it deploys as a **3-node integrated-Raft HA cluster that is automatically initialized and unsealed** — no manual `operator init`/unseal step is required (see [Self-Initialization](#openbao-self-initialization--unsealing)).
 - **ESO** manages external secrets, connected to OpenBao via Kubernetes auth.
 - **OpenBao UI** will be available by default at `:30820/ui` (NodePort) or via Ingress.
 
@@ -101,8 +101,9 @@ The **SG Agent** and **Federation** are opt-in. Without `sgAgent.enabled=true` t
 **Automatic wiring** (each can be disabled):
 
 - **Session secret** — `auth.sessionSecret` is auto-generated on first install and kept stable across upgrades if left empty. Set it explicitly when running multiple releases that must share sessions.
-- **Dex → OpenBao login** (`openbao.oidc.enabled`, default `true`) — a post-install Job configures OpenBao's OIDC auth method so users can log in to the OpenBao UI with the same Dex identity.
-- **Kubernetes auth for ESO** (`openbao.kubernetesAuth.enabled`, default `true`) — a post-install Job enables OpenBao's `kubernetes` auth method and creates the `eso-role` bound to the ESO ServiceAccount.
+- **OpenBao self-initialization** (`openbao.init.enabled`, default `true`) — an ordered post-install/upgrade hook Job (weight 0) runs `operator init`, unseals every Raft node, enables the Kubernetes auth method, and creates a chart admin role — then **revokes the root token** (it is never persisted). The Shamir unseal key shares are stored in the `<release>-openbao-keys` Secret. See [Self-Initialization](#openbao-self-initialization--unsealing).
+- **Kubernetes auth for ESO** (`openbao.kubernetesAuth.enabled`, default `true`) — a post-install Job (weight 5) configures the KV v2 engine, the ESO read policy, and the `eso-role` bound to the ESO ServiceAccount. Under self-init it authenticates via the chart admin role (no root token exists).
+- **Dex → OpenBao login** (`openbao.oidc.enabled`, default `true`) — a post-install Job (weight 10) configures OpenBao's OIDC auth method so users can log in to the OpenBao UI with the same Dex identity, also via the chart admin role.
 - **Default ClusterSecretStore** (`eso.vaultSecretStore.enabled`, default `true`) — when both ESO and OpenBao are enabled, the chart creates a ready-to-use `ClusterSecretStore` named `openbao-backend` pointing at the bundled OpenBao (KV v2).
 - **Projected SA tokens** — `serviceAccount.tokenExpirationSeconds` (default `3600`) controls the lifetime of the proxy/agent tokens; the kubelet rotates them automatically.
 
@@ -110,9 +111,7 @@ The **SG Agent** and **Federation** are opt-in. Without `sgAgent.enabled=true` t
 
 ## Dev Mode for Testing
 
-By default, OpenBao starts in `standalone` (production-oriented) mode, meaning it writes to persistent storage and requires manual initialization and unsealing.
-
-For local development or testing, you can enable `dev` mode, where secrets are stored in-memory, automatically unsealed, but lost upon restart:
+By default OpenBao runs as a 3-node Raft HA cluster that the chart initializes and unseals for you. For local development or testing you usually don't want three replicas or persistent state — enable `dev` mode instead, where OpenBao runs as a single in-memory node that is automatically unsealed but loses all data on restart:
 
 ```bash
 helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
@@ -125,6 +124,16 @@ helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
 Dev mode is intended only for local testing. Secrets are stored in-memory and will be lost when the pod restarts. Do not use dev mode in production.
 {{% /notice %}}
 
+If you want persistent storage but only a single node (e.g. a small staging cluster), run the standalone `file` backend instead of Raft HA:
+
+```bash
+helm install secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
+  --namespace secureguard-system \
+  --create-namespace \
+  --set openbao.server.standalone.enabled=true \
+  --set openbao.server.ha.enabled=false
+```
+
 ---
 
 ## Production Hardening
@@ -133,32 +142,81 @@ When moving to production, several configurations MUST be applied to ensure a se
 
 ### High Availability (HA)
 
-Enable High Availability with Raft integrated storage and increase the replica count (typically 3 or 5).
-
-Example `values-production.yaml` snippet:
-```yaml
-openbao:
-  server:
-    ha:
-      enabled: true
-      replicas: 3
-```
-
-### Automatic Unsealing
-In production, you should not manually unseal the OpenBao cluster every time a pod restarts. Configure an auto-unseal mechanism such as AWS KMS, GCP KMS, Transit, or Azure Key Vault.
+High Availability with Raft integrated storage is the **chart default**: OpenBao runs as a 3-node cluster, each replica keeping its own copy of the data (no external Consul/etcd needed). Use an odd replica count (3 or 5) so leader elections always have a quorum, and size the data storage for your secret volume.
 
 ```yaml
 openbao:
   server:
     ha:
       enabled: true
-      replicas: 3
-    seal:
-      type: awskms
-      config:
-        region: eu-west-1
-        kms_key_id: "alias/openbao-unseal"
+      replicas: 3       # odd number for quorum
+      raft:
+        enabled: true
+    dataStorage:
+      enabled: true
+      size: 20Gi
 ```
+
+### OpenBao Self-Initialization & Unsealing
+
+A freshly deployed OpenBao is **sealed** and must be initialized and unsealed before it can serve secrets. The chart automates this so no manual `operator init`/unseal is required (`openbao.init.enabled`, default `true`):
+
+- A weight-0 post-install/upgrade hook Job runs `operator init` on the leader, unseals every Raft node, bootstraps Kubernetes auth + a chart admin role, and then **revokes the root token** — it is used once in memory and never persisted.
+- The Shamir unseal **key shares** are stored in the `<release>-openbao-keys` Secret (`keyShares: 5`, `keyThreshold: 3` by default).
+
+{{% notice warning %}}
+**Back up the `<release>-openbao-keys` Secret.** Without the unseal keys you cannot unseal OpenBao and your secrets are unrecoverable. For break-glass admin access (the root token is gone), run `bao operator generate-root` using the stored key shares.
+{{% /notice %}}
+
+```yaml
+openbao:
+  init:
+    enabled: true        # self-init + unseal (default)
+    keyShares: 5
+    keyThreshold: 3
+    # secretName: ""     # defaults to <release>-openbao-keys
+```
+
+**Restart behavior (Shamir seal).** With the default Shamir seal, a pod that restarts comes back **sealed**. The init hook re-unseals every node on each `helm upgrade`; to also re-unseal automatically between upgrades, enable the periodic sweep:
+
+```yaml
+openbao:
+  init:
+    unsealCronJob:
+      enabled: true
+      schedule: "*/5 * * * *"
+```
+
+### Automatic Unsealing with a KMS (higher security)
+
+For the strongest posture — survives restarts with no unseal key shares stored in a Secret — use **KMS auto-unseal** instead of Shamir self-init. Disable the init Job and add a `seal` stanza to the Raft config so OpenBao unseals itself against your cloud KMS on every start:
+
+```yaml
+openbao:
+  server:
+    ha:
+      enabled: true
+      replicas: 3
+      raft:
+        enabled: true
+        config: |
+          ui = true
+          listener "tcp" { tls_disable = 1
+            address = "[::]:8200" cluster_address = "[::]:8201" }
+          storage "raft" { path = "/openbao/data"
+            retry_join { leader_api_addr = "http://<rel>-openbao-0.<rel>-openbao-internal:8200" }
+            retry_join { leader_api_addr = "http://<rel>-openbao-1.<rel>-openbao-internal:8200" }
+            retry_join { leader_api_addr = "http://<rel>-openbao-2.<rel>-openbao-internal:8200" } }
+          seal "awskms" {
+            region     = "eu-west-1"
+            kms_key_id = "alias/openbao-unseal"
+          }
+          service_registration "kubernetes" {}
+  init:
+    enabled: false       # KMS unseals automatically; no self-init Job or key-shares Secret
+```
+
+OpenBao also supports `gcpckms`, `azurekeyvault`, and `transit` seal types — swap the `seal` stanza accordingly.
 
 ### Ingress & TLS
 Ensure that traffic to the SecureGuard dashboard, the proxy, and OpenBao is encrypted via TLS. The chart provides **three independent ingress blocks**: `ingress` (dashboard + proxy), `dexIngress` (Dex, exposed at `/dex` on the dashboard host), and `openbaoIngress` (OpenBao UI/API on its own hostname). Configure Ingress annotations to use a tool like cert-manager for automatic certificate provisioning.

--- a/content/secureguard/main/openbao-basics/_index.en.md
+++ b/content/secureguard/main/openbao-basics/_index.en.md
@@ -49,9 +49,10 @@ It handles:
 
 ## Understanding Unsealing & High Availability
 
-By default, an OpenBao server starts in a **Sealed** state. It knows where to find the encrypted data, but it does not know how to decrypt it because it lacks the master key.
+By default, an OpenBao server starts in a **Sealed** state. It knows where to find the encrypted data, but it does not know how to decrypt it because it lacks the master key. There are three ways to unseal it:
 
-*   **Manual Unsealing**: Requires multiple operators to independently enter shards of the master key. This is secure but impractical for cloud-native orchestration (e.g., if a pod simply restarts).
-*   **Auto-Unseal**: In production SecureGuard setups, OpenBao is configured with an Auto-Unseal mechanism (like AWS KMS or Azure Key Vault). When the pod starts, it automatically reaches out to the KMS to retrieve the key and decrypts itself, enabling seamless cluster scaling and recovery.
+*   **Automated Self-Initialization (SecureGuard default)**: The chart runs `operator init` for you, splits the master key into Shamir key shares, unseals every node, and stores the key shares in the `<release>-openbao-keys` Kubernetes Secret — so no manual bootstrap is needed after `helm install`. The one-time root token is revoked immediately after setup and never persisted. **Back up that Secret**: it is the only way to unseal the cluster (or, for break-glass admin, to run `bao operator generate-root`). With this Shamir seal, a restarted pod comes back sealed and is re-unsealed on the next `helm upgrade` (or by an optional periodic CronJob).
+*   **Manual Unsealing**: Requires multiple operators to independently enter shards of the master key. This is the most controlled but impractical for cloud-native orchestration (e.g., if a pod simply restarts).
+*   **KMS Auto-Unseal**: OpenBao is configured with a cloud KMS (AWS KMS, GCP KMS, Azure Key Vault, or Transit). When a pod starts it reaches out to the KMS to decrypt itself — so it survives restarts with **no key shares stored in a Secret**. This is the higher-security production option; see [Installation → Automatic Unsealing with a KMS]({{< ref "../installation/#automatic-unsealing-with-a-kms-higher-security" >}}).
 
-When clustered for **High Availability (HA)** using Integrated Raft Storage, only one OpenBao node is the "Active" node processing writes, while the others serve as "Standbys". If the active node fails, another node instantly takes over, guaranteeing virtually zero downtime for your secret synchronization.
+The bundled OpenBao runs as a **3-node cluster with Integrated Raft Storage** by default. Only one node is the "Active" node processing writes, while the others serve as "Standbys". If the active node fails, another node instantly takes over, guaranteeing virtually zero downtime for your secret synchronization. Raft keeps each node's data in its own storage with no external Consul/etcd dependency.

--- a/content/secureguard/main/openbao-basics/_index.en.md
+++ b/content/secureguard/main/openbao-basics/_index.en.md
@@ -17,7 +17,7 @@ Unfamiliar with a term below (KV engine, auth method, unsealing)? The [Glossary]
 {{% /notice %}}
 
 {{% notice note %}}
-**OpenBao is optional — it's an opinionated default, not a requirement.** SecureGuard bundles OpenBao so teams **without** an existing vault get a complete stack out of the box. If you already run a secrets backend, you don't need OpenBao at all: SecureGuard manages **ESO**, and ESO works with many providers — AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and [others](https://external-secrets.io/latest/provider/aws-secrets-manager/). Just point your `SecretStore`/`ClusterSecretStore` resources at your provider and disable the bundled OpenBao (`--set openbao.enabled=false`). The rest of this page applies only if you choose to use OpenBao as your backend.
+**OpenBao is optional — it's an opinionated default, not a requirement.** SecureGuard bundles OpenBao so teams **without** an existing vault get a complete stack out of the box. If you already run a secrets backend, you don't need OpenBao at all: SecureGuard manages **ESO**, and ESO works with many providers — AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, and [others](https://external-secrets.io/latest/introduction/stability-support/). Just point your `SecretStore`/`ClusterSecretStore` resources at your provider and disable the bundled OpenBao (`--set openbao.enabled=false`). The rest of this page applies only if you choose to use OpenBao as your backend.
 {{% /notice %}}
 
 ## What is OpenBao?

--- a/content/secureguard/main/openbao-basics/_index.en.md
+++ b/content/secureguard/main/openbao-basics/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "OpenBao Basics"
 date = 2026-06-13T09:00:00+02:00
-weight = 5
+weight = 4
 description = "Understand OpenBao — the open-source, production-grade secrets vault bundled with Kubermatic SecureGuard — including secret engines, auth methods, and unsealing."
 sitemapexclude = true
 searchexclude = true
@@ -48,7 +48,7 @@ Within the SecureGuard ecosystem, OpenBao acts purely as the **Central Vault**.
 It handles:
 1.  **Encryption**: Ensuring all secrets are encrypted both in transit and at rest using industry-standard encryption (AES-256-GCM for storage, TLS 1.2+ for transit).
 2.  **RBAC (Role-Based Access Control)**: Enforcing strict least-privilege policies. You define *who* (which OIDC group or which Kubernetes Service Account) can read *what* paths.
-3.  **Multi-Tenancy**: Through its namespace features, OpenBao allows large organizations to isolate teams. "Team A" vault paths are completely invisible to "Team B".
+3.  **Multi-Tenancy**: Through its namespace features, OpenBao allows large organizations to isolate teams. "Team A" vault paths are completely invisible to "Team B". For stronger, infrastructure-level isolation, you can instead run one OpenBao instance per tenant — see [Installation → Tenant Isolation]({{< ref "../installation/#tenant-isolation" >}}).
 
 ## Understanding Unsealing & High Availability
 

--- a/content/secureguard/main/openbao-basics/_index.en.md
+++ b/content/secureguard/main/openbao-basics/_index.en.md
@@ -3,9 +3,6 @@ title = "OpenBao Basics"
 date = 2026-06-13T09:00:00+02:00
 weight = 4
 description = "Understand OpenBao — the open-source, production-grade secrets vault bundled with Kubermatic SecureGuard — including secret engines, auth methods, and unsealing."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 [OpenBao](https://openbao.org/) is the open-source, production-grade secrets management backend at the heart of Kubermatic SecureGuard. It was forked from HashiCorp Vault to provide a completely open, community-driven cryptographic engine.

--- a/content/secureguard/main/security-hardening/_index.en.md
+++ b/content/secureguard/main/security-hardening/_index.en.md
@@ -3,9 +3,6 @@ title = "Security Hardening Guide"
 date = 2026-06-13T09:00:00+02:00
 weight = 9
 description = "Production security best practices for SecureGuard — TLS, OIDC/Dex hardening, RBAC via impersonation, network policies, container security, CSP, and supply-chain controls."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 This guide covers security best practices for deploying SecureGuard in production environments. SecureGuard manages Kubernetes Secrets and external secret provider credentials — a security lapse can expose API keys, database passwords, TLS certificates, and cloud provider credentials.

--- a/content/secureguard/main/security-hardening/_index.en.md
+++ b/content/secureguard/main/security-hardening/_index.en.md
@@ -23,26 +23,17 @@ SecureGuard operates on a **zero-knowledge** principle for secret values:
 
 ### Ingress TLS
 
-Always terminate TLS at the ingress layer. Use cert-manager for automatic certificate provisioning:
+Always terminate TLS at the ingress layer — base ingress configuration is covered in [Installation → Ingress & TLS]({{< ref "../installation/#ingress--tls" >}}). For hardening, additionally force HTTPS redirects so no session cookie ever travels over plaintext:
 
 ```yaml
 ingress:
-  enabled: true
-  className: "nginx"
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  hosts:
-    - host: secureguard.yourdomain.com
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls:
-    - secretName: secureguard-tls
-      hosts:
-        - secureguard.yourdomain.com
 ```
+
+Apply the same to `dexIngress` and `openbaoIngress` if you expose Dex or the OpenBao UI.
 
 ### Internal TLS
 
@@ -62,7 +53,7 @@ kubectl get secret <release>-dex-admin -n <namespace> -o jsonpath='{.data.passwo
 ```
 
 {{% notice warning %}}
-**Local development and CI only:** the raw dev manifest [`k8s/dex.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/dex.yaml) hardcodes static passwords for `admin@secureguard.local` and `viewer@secureguard.local` (bcrypt hash of `admin`). These credentials exist **solely for kind-based local development and CI** (`scripts/deploy-dev-dashboard.sh`) and are **never** used by the Helm chart. Do not deploy `k8s/dex.yaml` to any shared or production cluster.
+**Local development and CI only:** the raw dev manifests in the source repository (`k8s/dex.yaml`) hardcode static passwords for `admin@secureguard.local` and `viewer@secureguard.local` (bcrypt hash of `admin`). These credentials exist **solely for kind-based local development and CI** and are **never** used by the Helm chart. Do not deploy the raw dev manifests to any shared or production cluster.
 {{% /notice %}}
 
 For any non-local deployment, either set a strong `dex.staticAdmin.password` explicitly, or disable the static admin entirely (`dex.staticAdmin.enabled: false`) and federate to a production IDP (see below).
@@ -105,7 +96,7 @@ A user with no RBAC bindings can log in but gets `403 Forbidden` on every resour
 
 ### Least-privilege service accounts
 
-The proxy and the SG Agent run under **separate** service accounts (see [`k8s/rbac.yaml`](https://github.com/kubermatic/secureguard/blob/main/k8s/rbac.yaml) / [`charts/secureguard/templates/rbac.yaml`](https://github.com/kubermatic/secureguard/blob/main/charts/secureguard/templates/rbac.yaml)):
+The proxy and the SG Agent run under **separate** service accounts, provisioned by the Helm chart's RBAC templates:
 
 ```yaml
 # Proxy: only impersonation + SGAgent registration (per-cluster kubeconfig
@@ -198,17 +189,7 @@ securityContext:
 
 ### Resource Limits
 
-Always set resource requests and limits to prevent resource exhaustion:
-
-```yaml
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 256Mi
-```
+Always set resource requests and limits to prevent resource exhaustion — see [Installation → Resource Limits]({{< ref "../installation/#resource-limits" >}}) for the per-component values.
 
 ### Image Pinning
 
@@ -224,6 +205,10 @@ Configure CSP headers to prevent XSS and data exfiltration. When using nginx for
 ```nginx
 add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data:; frame-ancestors 'none';" always;
 ```
+
+{{% notice tip %}}
+The Google Fonts entries exist for the default typography. For air-gapped or maximally locked-down deployments, self-host the fonts and drop the external `fonts.googleapis.com` / `fonts.gstatic.com` sources from the policy.
+{{% /notice %}}
 
 ## Supply Chain Security
 

--- a/content/secureguard/main/troubleshooting/_index.en.md
+++ b/content/secureguard/main/troubleshooting/_index.en.md
@@ -58,7 +58,7 @@ Managing a distributed secret synchronization engine involves dealing with netwo
      kubectl exec -it secureguard-openbao-0 -n secureguard-system -- bao operator unseal <key_2>
      kubectl exec -it secureguard-openbao-0 -n secureguard-system -- bao operator unseal <key_3>
      ```
-  4. Once the threshold is met, the pod will become ready. It is strongly recommended to configure [Auto-Unseal]({{< ref "../installation/" >}}) for production.
+  4. Once the threshold is met, the pod will become ready. It is strongly recommended to configure [Auto-Unseal]({{< ref "../installation/#automatic-unsealing" >}}) for production.
 
 ## ESO Synchronization Issues
 
@@ -112,10 +112,10 @@ When an `ExternalSecret` fails to sync, ESO will update the `status` block of th
 - **Resolution**:
   1. Verify the upload response included the expected context names.
   2. Check proxy logs for errors during per-cluster Secret creation.
-  3. If using init container mode, the proxy pod may need a restart to pick up new Secrets.
+  3. Confirm the per-cluster Secret exists and carries the discovery label: `kubectl get secrets -n secureguard-system -l secureguard.io/cluster-kubeconfig=true`. In-cluster, the proxy watches these Secrets via an informer, so new registrations appear without a pod restart.
 
 ## Debugging Tips
 
 - **Event Stream**: Use the Event Stream page in the dashboard to see real-time Kubernetes events across all managed resources.
-- **Proxy Debug Logging**: Set the proxy's log level to debug for verbose output. The proxy uses Go's standard `log` package — check pod logs with `kubectl logs`.
+- **Proxy Debug Logging**: Set the `LOG_LEVEL=debug` environment variable on the proxy for verbose output (structured JSON logs) — see [Proxy Configuration]({{< ref "../advanced-configuration/#environment-variables" >}}). The agent and federation broker have equivalent `logLevel` Helm values. Check pod logs with `kubectl logs`.
 - **Sync Error Drawer**: Click on any failed ExternalSecret in the dashboard to open the Sync Error Drawer, which shows detailed error messages and remediation hints.

--- a/content/secureguard/main/troubleshooting/_index.en.md
+++ b/content/secureguard/main/troubleshooting/_index.en.md
@@ -3,9 +3,6 @@ title = "Troubleshooting & FAQ"
 date = 2026-06-13T09:00:00+02:00
 weight = 11
 description = "Common operational issues and resolutions for SecureGuard — dashboard access, authentication, OpenBao sealing, ESO sync errors, proxy 403s, and multi-cluster connectivity."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 Managing a distributed secret synchronization engine involves dealing with network connectivity, authentication tokens, and vault states. This guide covers common operational issues and how to resolve them.

--- a/content/secureguard/main/troubleshooting/_index.en.md
+++ b/content/secureguard/main/troubleshooting/_index.en.md
@@ -50,20 +50,25 @@ Managing a distributed secret synchronization engine involves dealing with netwo
 ## OpenBao Issues
 
 ### OpenBao Pods are Running but Not Ready
-- **Cause**: By default in production, OpenBao starts in a sealed state and cannot read or write data until unsealed.
+- **Cause**: OpenBao starts in a sealed state and cannot read or write data until unsealed. With the default Shamir seal, a restarted pod comes back sealed.
 - **Resolution**:
   1. Check the vault status:
      ```bash
      kubectl exec -it secureguard-openbao-0 -n secureguard-system -- bao status
      ```
   2. Look for `Sealed: true`.
-  3. If you do not have Auto-Unseal configured, you must manually provide the unseal keys generated during initialization:
+  3. **With self-initialization (default):** the key shares are in the `<release>-openbao-keys` Secret and the init hook re-unseals every node on the next `helm upgrade`. To re-unseal immediately without an upgrade, either enable the periodic sweep (`openbao.init.unsealCronJob.enabled=true`) or unseal manually with the stored shares:
      ```bash
+     # Retrieve the key shares (newline-separated) from the Secret
+     kubectl get secret secureguard-openbao-keys -n secureguard-system \
+       -o jsonpath='{.data.keys}' | base64 -d
+     # Then feed the threshold number of shares to the sealed pod
      kubectl exec -it secureguard-openbao-0 -n secureguard-system -- bao operator unseal <key_1>
      kubectl exec -it secureguard-openbao-0 -n secureguard-system -- bao operator unseal <key_2>
      kubectl exec -it secureguard-openbao-0 -n secureguard-system -- bao operator unseal <key_3>
      ```
-  4. Once the threshold is met, the pod will become ready. It is strongly recommended to configure [Auto-Unseal]({{< ref "../installation/#automatic-unsealing" >}}) for production.
+  4. **With KMS auto-unseal**, pods unseal themselves on start — a stuck `Sealed: true` points to a KMS connectivity/permission problem; check the pod logs and your cloud KMS access.
+  5. Once the threshold is met, the pod will become ready. For restart-resilient production, prefer [KMS auto-unseal]({{< ref "../installation/#automatic-unsealing-with-a-kms-higher-security" >}}).
 
 ## ESO Synchronization Issues
 

--- a/content/secureguard/main/troubleshooting/_index.en.md
+++ b/content/secureguard/main/troubleshooting/_index.en.md
@@ -26,6 +26,14 @@ Managing a distributed secret synchronization engine involves dealing with netwo
   2. Ensure the `redirect_uri` configured in your IDP (GitHub, Google, etc.) exactly matches the Dex callback URL.
   3. Verify that clock drift hasn't caused token validation failures (ensure NTP is synced across nodes).
 
+### Lost or Unknown Static Admin Password
+- **Cause**: The Helm chart auto-generates the static admin password — it is never `admin`.
+- **Resolution**: Retrieve it from the release Secret:
+  ```bash
+  kubectl get secret <release>-dex-admin -n secureguard-system \
+    -o jsonpath='{.data.password}' | base64 -d && echo
+  ```
+
 ### Proxy Pod Crash-Loops on Startup (`OIDC_ISSUER_URL is required`)
 - **Cause**: Authentication is mandatory — the proxy refuses to start without an OIDC issuer. There is no "auth disabled" mode (the old `AUTH_ENABLED` flag was removed).
 - **Resolution**: Set `OIDC_ISSUER_URL` (and the other `OIDC_*` / `SESSION_SECRET` env) on the proxy. With the bundled Dex, this is the in-cluster issuer, e.g. `http://<release>-dex.<namespace>.svc.cluster.local:5556/dex`.
@@ -113,6 +121,67 @@ When an `ExternalSecret` fails to sync, ESO will update the `status` block of th
   1. Verify the upload response included the expected context names.
   2. Check proxy logs for errors during per-cluster Secret creation.
   3. Confirm the per-cluster Secret exists and carries the discovery label: `kubectl get secrets -n secureguard-system -l secureguard.io/cluster-kubeconfig=true`. In-cluster, the proxy watches these Secrets via an informer, so new registrations appear without a pod restart.
+
+### Kubeconfig Upload Rejected at Registration
+- **Cause**: The proxy replaces the uploaded credential with a short-lived minted token. A credential that cannot provision the remote ServiceAccount (e.g. a narrowly scoped bearer token) is rejected — there is no "store as-is" mode.
+- **Resolution**: Upload a kubeconfig whose credential can create ServiceAccounts, ClusterRoles, and bindings on the target cluster (typically cluster-admin, used exactly once). Exec-plugin credentials (EKS/GKE/AKS) are stored unchanged. See [Short-Lived Remote-Cluster Tokens]({{< ref "../advanced-configuration/#short-lived-remote-cluster-tokens" >}}).
+
+## ESODeployment & SG Agent Issues
+
+### ESODeployment Pages Are Empty / Nothing Reconciles
+- **Cause**: The SG Agent Controller is **disabled by default** (`sgAgent.enabled: false`).
+- **Resolution**: Enable it: `helm upgrade ... --set sgAgent.enabled=true`, then confirm the agent pod is running.
+
+### ESODeployment Stuck in `Error` with a `Conflict` Condition
+- **Cause**: Two deployments claim the same effective cluster/namespaces (`NamespaceOverlap` or `MultipleClusterScope` are blocking).
+- **Resolution**: Inspect the condition (`kubectl describe esodeployment <name>`), then delete or re-scope one of the conflicting deployments. See [Conflict Detection]({{< ref "../advanced-configuration/#conflict-detection" >}}).
+
+### ESODeployment Stuck in `Deploying`
+- **Cause**: The agent cannot reach the target cluster, or the ESO version/image cannot be pulled there.
+- **Resolution**:
+  1. Check the cluster's health on the Clusters page (or `/api/clusters/{id}/health`).
+  2. Check agent logs: `kubectl logs -l app.kubernetes.io/component=sg-agent -n secureguard-system`.
+  3. On the target cluster, inspect the ESO pods/events in the deployment namespace (image pull errors, RBAC denials).
+
+### Unexpected Read-Only `eso-ext-*` Deployment Appeared
+- **Cause**: Not an error — the agent discovered an ESO installation it doesn't manage and represents it as an external, read-only ESODeployment.
+- **Resolution**: Nothing to fix. To bring the installation under SecureGuard management, remove the external install and create a managed ESODeployment.
+
+### SG Agent Badge Shows "Stale"
+- **Cause**: The agent's heartbeat for that cluster is older than expected — agent pod down, leader election stuck, or the cluster unreachable.
+- **Resolution**:
+  1. Check the agent pod and its logs.
+  2. Check `kubectl get sgagents` — `lastHeartbeat` shows when the cluster last reported.
+  3. Test the cluster connection from the Clusters page.
+
+## Federation Issues
+
+Federation errors are deterministic — the broker returns a distinct status per failure, and `fedclient` maps them to [exit codes]({{< ref "../federation/#cli-reliability-version-retries-exit-codes" >}}).
+
+### `401 Unauthenticated` (fedclient exit code `11`)
+- **Cause**: The workload token is invalid, expired, or carries the wrong audience; or the broker doesn't trust the token's issuer.
+- **Resolution**:
+  1. Verify the token's audience matches the broker's expected audiences (`federation.audiences`, default `secureguard-federation`) and the projected volume's `audience`.
+  2. Confirm the issuer is listed under `FederationServer.spec.trustedIssuers` with the correct `issuerURL`.
+  3. Off-cluster: a file-based token has no kubelet to rotate it and simply expires — switch to `--token-source=kube`.
+
+### `401` with OIDC Discovery Errors in Broker Logs
+- **Cause**: The broker cannot fetch the issuer's OIDC discovery document or JWKS — wrong CA or missing anonymous discovery access.
+- **Resolution**:
+  1. For private-CA / cluster-API-server issuers, set `trustedIssuers[].caBundle` (for an API server, its `kube-root-ca.crt`).
+  2. Grant the issuer cluster's `system:service-account-issuer-discovery` ClusterRole to `system:unauthenticated` so the broker's anonymous discovery requests succeed.
+
+### `403 Forbidden` (exit code `13`)
+- **Cause**: Authentication succeeded, but no `FederationAuthorization` allows this identity to read this store/key (deny-by-default).
+- **Resolution**: Create or extend a `FederationAuthorization` whose `identity.kubernetes.issuer`/`serviceAccount` match the caller and whose `allow[].store`/`keys` globs cover the requested key.
+
+### `404 Not Found` (exit code `14`)
+- **Cause**: The store name in the URL is not in `FederationServer.spec.exposedStores`, or the key doesn't exist in the backing store.
+- **Resolution**: Check `exposedStores[].name` spelling and, for the interim resolver, that the backing Kubernetes Secret exists in the `secretStoreRef.namespace`.
+
+### Broker Pod Not Starting
+- **Cause**: TLS is mandatory — the broker requires a server certificate Secret.
+- **Resolution**: Set `federation.tls.secretName` to an existing TLS Secret; check broker logs for certificate path errors.
 
 ## Debugging Tips
 

--- a/content/secureguard/main/troubleshooting/_index.en.md
+++ b/content/secureguard/main/troubleshooting/_index.en.md
@@ -48,7 +48,7 @@ Managing a distributed secret synchronization engine involves dealing with netwo
        --namespace <ns> --as <your-email> --as-group <your-group>
      ```
   3. Ensure Dex emits a `groups` claim if you bind to groups (group-based RBAC won't work otherwise).
-  4. Verify the proxy's own service account holds the `impersonate` verb on `users`/`groups` (included in `k8s/rbac.yaml` and the Helm chart); without it, impersonation itself returns `403`.
+  4. Verify the proxy's own service account holds the `impersonate` verb on `users`/`groups` (included in the Helm chart's RBAC templates); without it, impersonation itself returns `403`.
 
 ## OpenBao Issues
 
@@ -104,7 +104,7 @@ When an `ExternalSecret` fails to sync, ESO will update the `status` block of th
 - **Resolution**:
   1. Check proxy logs: `kubectl logs -l app.kubernetes.io/name=secureguard-proxy -n secureguard-system`
   2. Verify the `KUBECONFIG` environment variable points to a valid kubeconfig file.
-  3. For in-cluster deployments, ensure the ServiceAccount has the correct RBAC permissions (see `k8s/rbac.yaml`).
+  3. For in-cluster deployments, ensure the ServiceAccount has the correct RBAC permissions (provisioned by the Helm chart's RBAC templates).
 
 ## Multi-Cluster Issues
 

--- a/content/secureguard/main/upgrade-guides/_index.en.md
+++ b/content/secureguard/main/upgrade-guides/_index.en.md
@@ -18,13 +18,21 @@ Because SecureGuard is deployed via Helm, upgrades follow the standard Helm rele
 OCI-based Helm charts do not require `helm repo add` or `helm repo update`. Simply run `helm upgrade` with the registry URL.
 {{% /notice %}}
 
-1. **Review the Release Notes** in the SecureGuard repository for any breaking changes or manual migration steps.
-2. **Execute the Upgrade**, passing your custom `values-production.yaml` file to preserve your HA, ingress, and IDP configurations.
+1. **Review the Release Notes** published with each chart release on the [Kubermatic Quay.io registry](https://quay.io/repository/kubermatic/helm-charts) and in the SecureGuard changelog for any breaking changes or manual migration steps.
+2. **Take an OpenBao snapshot** (see below) — this is mandatory, not optional.
+3. **Execute the Upgrade**, passing your custom `values-production.yaml` file to preserve your HA, ingress, and IDP configurations.
    ```bash
    helm upgrade secureguard oci://quay.io/kubermatic/helm-charts/secureguard \
      -f values-production.yaml \
      --namespace secureguard-system
    ```
+4. **Verify**: all pods `Running`, dashboard reachable, OpenBao unsealed, a spot-check ExternalSecret still `Synced`.
+
+If the upgrade fails, roll back the release and — only if data was affected — restore the snapshot:
+
+```bash
+helm rollback secureguard --namespace secureguard-system
+```
 
 ## Pre-Upgrade Requirement: OpenBao Backups (Snapshots)
 
@@ -47,6 +55,27 @@ OCI-based Helm charts do not require `helm repo add` or `helm repo update`. Simp
     ```bash
     kubectl cp secureguard-system/secureguard-openbao-0:/tmp/backup.snap ./vault_backup_$(date +%F).snap
     ```
+
+### Restoring a Snapshot
+
+If an upgrade corrupts the OpenBao data or you need to recover to a known-good state:
+
+1.  Copy the snapshot back into the (unsealed) leader pod:
+    ```bash
+    kubectl cp ./vault_backup_2026-06-13.snap secureguard-system/secureguard-openbao-0:/tmp/restore.snap
+    ```
+2.  Authenticate and restore:
+    ```bash
+    kubectl exec -it secureguard-openbao-0 -n secureguard-system -- /bin/sh
+    bao login <root-or-admin-token>
+    bao operator raft snapshot restore /tmp/restore.snap
+    ```
+    Use `restore -force` when restoring into a **fresh** cluster whose auto-unseal keys or cluster identity differ from the snapshot's origin — and be aware you then need the *original* unseal/recovery keys to complete the restore.
+3.  Verify: `bao status` shows unsealed, and a known secret path reads back correctly.
+
+{{% notice tip %}}
+Test the restore procedure regularly on a scratch cluster — a backup that has never been restored is not a backup.
+{{% /notice %}}
 
 ## Component Specifics
 
@@ -81,3 +110,7 @@ The React UI and **Go proxy** are stateless applications deployed as standard Ku
 ### Upgrading the SG Agent Controller
 
 The SG Agent Controller (`agent/`) is a Go controller-runtime binary deployed as a Kubernetes Deployment. It follows the same rolling update pattern as the proxy — Helm will perform a standard rolling rollout of the new ReplicaSet. No special migration steps are required; the controller is stateless and will automatically resume reconciliation of SGAgent and ESODeployment resources after restart.
+
+## Version-Specific Notes
+
+Version-specific migration guides are published here as releases ship. Currently there are none — all `0.x` upgrades follow the general path above. Always check the release notes of the exact chart version you are moving to.

--- a/content/secureguard/main/upgrade-guides/_index.en.md
+++ b/content/secureguard/main/upgrade-guides/_index.en.md
@@ -37,7 +37,15 @@ helm rollback secureguard --namespace secureguard-system
 **CRITICAL:** Before performing any upgrade, especially one that bumps the OpenBao major/minor version, you MUST take a snapshot of the OpenBao integrated storage (Raft). Failure to do so risks catastrophic data loss if the upgrade fails.
 {{% /notice %}}
 
-1.  Authenticate to OpenBao with a privileged token:
+{{% notice info %}}
+**Also back up the unseal-keys Secret.** With the default self-initialization, the Shamir unseal key shares live in the `<release>-openbao-keys` Secret. A Raft snapshot is useless without the keys to unseal a restored cluster, so back up both together:
+
+```bash
+kubectl get secret secureguard-openbao-keys -n secureguard-system -o yaml > openbao-keys-backup.yaml
+```
+{{% /notice %}}
+
+1.  Authenticate to OpenBao with a privileged token. Under self-initialization the root token was revoked after bootstrap, so obtain a break-glass token via `bao operator generate-root` (using the stored unseal keys) or use a token from a configured auth method:
     ```bash
     kubectl exec -it secureguard-openbao-0 -n secureguard-system -- /bin/sh
     bao login <root-or-admin-token>
@@ -61,7 +69,7 @@ If an upgrade corrupts the OpenBao data or you need to recover to a known-good s
     ```bash
     kubectl cp ./vault_backup_2026-06-13.snap secureguard-system/secureguard-openbao-0:/tmp/restore.snap
     ```
-2.  Authenticate and restore:
+2.  Authenticate and restore (the self-init root token is revoked — use a break-glass token from `bao operator generate-root`, or a token from a configured auth method):
     ```bash
     kubectl exec -it secureguard-openbao-0 -n secureguard-system -- /bin/sh
     bao login <root-or-admin-token>
@@ -81,8 +89,9 @@ Test the restore procedure regularly on a scratch cluster — a backup that has 
 When Helm updates the OpenBao StatefulSet image version, Kubernetes will perform a rolling restart of the OpenBao pods.
 
 *   **HA Clusters (Raft)**: The rolling restart must be monitored carefully. When a pod restarts, it will trigger leader election. Ensure that the cluster remains quorate during the roll.
-*   **Auto-Unseal**: If you have configured Auto-Unseal (e.g., AWS KMS), the pods will automatically unseal and rejoin the cluster upon starting.
-*   **Manual Unseal**: If you are *not* using Auto-Unseal, the pods will restart into a `Sealed` state. You must manually execute the `bao operator unseal` commands on each newly started pod *before* the StatefulSet controller proceeds to restart the next pod. This requires active operator intervention during the `helm upgrade`.
+*   **Shamir self-init (default)**: A restarted pod comes back **sealed**. The self-initialization hook Job re-runs on every `helm upgrade` and re-unseals every node automatically, so a normal upgrade recovers on its own. Between upgrades, a crashed or rescheduled pod stays sealed until the next upgrade — enable `openbao.init.unsealCronJob.enabled=true` for automatic periodic re-unseal, or switch to KMS auto-unseal for full restart resilience.
+*   **KMS Auto-Unseal**: If you have configured KMS auto-unseal (`openbao.init.enabled=false` + a `seal` stanza), the pods will automatically unseal and rejoin the cluster upon starting — no operator intervention needed.
+*   **Fully manual unseal**: If you run without self-init or KMS, you must manually execute the `bao operator unseal` commands on each newly started pod *before* the StatefulSet controller proceeds to the next one.
 
 ### Upgrading the External Secrets Operator (ESO) CRDs
 
@@ -110,4 +119,21 @@ The SG Agent Controller (`agent/`) is a Go controller-runtime binary deployed as
 
 ## Version-Specific Notes
 
-Version-specific migration guides are published here as releases ship. Currently there are none — all `0.x` upgrades follow the general path above. Always check the release notes of the exact chart version you are moving to.
+Always check the release notes of the exact chart version you are moving to.
+
+### 0.3.0 — OpenBao Raft HA + self-initialization (breaking)
+
+The bundled OpenBao default changed from a single-node `file` backend to a **3-node integrated-Raft HA cluster** that is **automatically initialized and unsealed** by a post-install/upgrade hook Job.
+
+- **New installs** need no action — OpenBao initializes, unseals, and stores its Shamir key shares in the `<release>-openbao-keys` Secret automatically. **Back up that Secret.**
+- **To keep the previous single-node behavior**, pin it explicitly before upgrading:
+  ```yaml
+  openbao:
+    server:
+      standalone:
+        enabled: true
+      ha:
+        enabled: false
+  ```
+- **For restart-resilient production**, prefer KMS auto-unseal (`openbao.init.enabled=false` + a `seal` stanza) — no key shares are stored in a Secret. See [Installation → OpenBao Self-Initialization & Unsealing]({{< ref "../installation/#openbao-self-initialization--unsealing" >}}).
+- The root token is **revoked** after bootstrap and never persisted; use `bao operator generate-root` with the stored unseal keys for break-glass admin.

--- a/content/secureguard/main/upgrade-guides/_index.en.md
+++ b/content/secureguard/main/upgrade-guides/_index.en.md
@@ -3,9 +3,6 @@ title = "Upgrade Guides"
 date = 2026-06-13T09:00:00+02:00
 weight = 10
 description = "Best practices for upgrading SecureGuard components — OpenBao snapshots, ESO CRD upgrades, and rolling updates for the UI, proxy, and SG Agent."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 Keeping SecureGuard updated ensures you have the latest security patches for OpenBao, Dex, ESO, and the UI components. This guide outlines the best practices for upgrading a production deployment.

--- a/content/secureguard/main/user-guide/_index.en.md
+++ b/content/secureguard/main/user-guide/_index.en.md
@@ -167,13 +167,12 @@ your ExternalSecrets), not edited by hand in the dashboard.
 
 ## ReloaderConfigs
 
-ReloaderConfigs trigger automatic workload restarts when synced secrets change.
-On the **Reloaders** page you can **view** all ReloaderConfigs and their status,
-and **delete** one. They are created with `kubectl` / GitOps and specify:
+ReloaderConfigs make secret delivery **event-driven**: they wire notification **sources** to trigger **destinations**, so a change propagates the instant it happens instead of on ESO's next poll. On the **Reloaders** page you can **view** all ReloaderConfigs and their status, open a detail view (with **Notification Sources** and **Trigger Destinations** tabs), and **delete** one. They are created with `kubectl` / GitOps and specify:
 
-- **Target workload** (Deployment, StatefulSet, or DaemonSet)
-- **Secret references** to watch
-- **Reload strategy** (rolling restart vs. annotation bump)
+- **Notification sources** — what to listen to: a Kubernetes `Secret` or `ConfigMap` change, a cloud event (GCP Pub/Sub, AWS SQS, Azure Event Grid), a HashiCorp Vault audit-log event, a generic webhook, or a TCP socket.
+- **Trigger destinations** — what to act on: roll out a **Deployment**, or make an **ExternalSecret** / **PushSecret** reconcile immediately, or a **WorkflowRunTemplate**.
+
+Common patterns: restart a Deployment when its Secret rotates, or trigger ESO to re-fetch on a cloud event/webhook rather than waiting for `refreshInterval`. See the [External Secrets Reloader docs](https://external-secrets.github.io/reloader/) for the full source/destination catalog.
 
 ## ESODeployments
 
@@ -193,7 +192,7 @@ The guided form validates as you type and covers:
 - **Scope** — cluster-wide or restricted to specific target namespaces (with optional exclusions; system namespaces are filtered out)
 - **High availability** — replica count
 - **Image & update schedule** — custom image repository and an optional cron schedule for automated image updates
-- **Deploy Reloader** — optionally co-deploy the Reloader controller for automatic workload restarts
+- **Deploy Reloader** — optionally co-deploy the Reloader controller for event-driven rotation (see [ReloaderConfigs](#reloaderconfigs))
 
 A **Form ↔ YAML** toggle lets you switch to a full YAML editor at any point — the round-trip is lossless, so YAML keys the form doesn't know about are preserved.
 

--- a/content/secureguard/main/user-guide/_index.en.md
+++ b/content/secureguard/main/user-guide/_index.en.md
@@ -34,17 +34,19 @@ dashboard then lets you watch, troubleshoot, and run targeted actions on them.
 | **Federation (Server / Authorization)** | ✅ | — | — | — | — |
 
 {{% notice note %}}
-**Why so read-only?** Each thing the browser can do must be explicitly allowed by the proxy's [route allowlist](https://github.com/kubermatic/secureguard/blob/main/docs/api-reference.md#route-allowlist). Keeping the surface small is a deliberate security choice — see [Architecture → Security Model]({{< ref "../architecture/#the-security-model" >}}). To create the resources marked "—" above, use `kubectl apply` or GitOps.
+**Why so read-only?** Each thing the browser can do must be explicitly allowed by the proxy's [route allowlist]({{< ref "../api-reference/#route-allowlist" >}}). Keeping the surface small is a deliberate security choice — see [Architecture → Security Model]({{< ref "../architecture/#the-security-model" >}}). To create the resources marked "—" above, use `kubectl apply` or GitOps.
 {{% /notice %}}
 
 ## Dashboard Overview
 
 The Dashboard page provides an at-a-glance view of your secrets management posture:
 
-- **Sync Status Breakdown** — How many ExternalSecrets are synced, pending, or errored
+- **Sync Status Breakdown** — How many ExternalSecrets are synced, pending, errored, or **stale** (see [stale detection](#stale-detection) below)
+- **Infrastructure Metrics** — When the SG Agent is enabled: ESO Deployments running/errored and SG Agents healthy/unhealthy
 - **Provider Distribution** — Which external secret providers are in use across your stores
 - **Recent Sync Errors** — The latest failures with direct links to affected resources
-- **Namespace Breakdown** — Resource distribution across namespaces
+- **External Store Links** — Deep links to the admin consoles of the providers in use (OpenBao UI, AWS/GCP/Azure consoles)
+- **Cluster & Namespace Breakdown** — Resource distribution across clusters and namespaces
 
 ## Managing ExternalSecrets
 
@@ -53,17 +55,28 @@ The Dashboard page provides an at-a-glance view of your secrets management postu
 Navigate to **External Secrets** in the sidebar. The table shows all ExternalSecrets across your selected namespace(s) with:
 
 - **Name** and **Namespace**
-- **Sync Status** — `Synced` (green), `Pending` (amber), or `Error` (red)
+- **Sync Status** — `Synced` (green), `Pending` (amber), `Error` (red), or `Stale`
 - **Secret Store** — Which SecretStore or ClusterSecretStore the secret references
 - **Last Synced** — Timestamp of the most recent successful sync
 - **Refresh Interval** — How often ESO polls the external provider
+
+Use the search box and the **Status** / **SecretStore** filters to narrow the list.
+
+### Stale Detection
+
+An ExternalSecret is flagged **Stale** when its last successful sync is older than **twice its `refreshInterval`** — a sign that ESO is running but silently failing to refresh (provider unreachable, credentials expiring, controller wedged). Stale secrets get their own dashboard metric and list filter so they don't hide behind a green `Synced` condition.
 
 Click any row to open the detail view, which includes:
 - Full resource metadata
 - Status conditions with timestamps
 - Sync history timeline
+- Key mappings (`spec.data` / `spec.dataFrom`) and target template
 - The complete resource as **read-only YAML** (you can copy it, but not edit it here)
 - The target Kubernetes Secret (with values displayed as `••••••••`)
+
+### Debugging a Failed Sync (Sync Error Drawer)
+
+For an errored ExternalSecret, the detail view offers a **Debug** action that opens the **Sync Error Drawer**: a side panel combining the resource's condition timeline, related Kubernetes events, and **remediation hints** — pattern-matched suggestions for common failures (e.g. access denied → check the provider policy attached to the store's role). This is usually the fastest path from a red badge to a root cause without leaving the browser.
 
 ### Creating an ExternalSecret
 
@@ -167,12 +180,39 @@ and **delete** one. They are created with `kubectl` / GitOps and specify:
 
 ## ESODeployments
 
-ESODeployments manage the ESO operator lifecycle across clusters:
+ESODeployments manage the ESO operator lifecycle across clusters — the one resource with a full **create/edit form** in the dashboard:
 
 1. Navigate to **ESO Deployments**
 2. View the status of ESO installations across your connected clusters
 3. Create or update ESODeployments to install, upgrade, or remove ESO from target clusters
-4. Monitor deployment phases: `Deploying`, `Running`, `Upgrading`, `Error`
+4. Monitor deployment phases: `Deploying`, `Running`, `Upgrading`, `Deleting`, `Error`, and `Discovered` (see below)
+
+### The Create/Edit Form
+
+The guided form validates as you type and covers:
+
+- **Target cluster** and installation **namespace**
+- **ESO version** — picked from the operator-curated [ESO Version Catalog]({{< ref "../advanced-configuration/#eso-version-catalog-esoversion-crd" >}}), newest first, with the `latest`-flagged release preselected
+- **Scope** — cluster-wide or restricted to specific target namespaces (with optional exclusions; system namespaces are filtered out)
+- **High availability** — replica count
+- **Image & update schedule** — custom image repository and an optional cron schedule for automated image updates
+- **Deploy Reloader** — optionally co-deploy the Reloader controller for automatic workload restarts
+
+A **Form ↔ YAML** toggle lets you switch to a full YAML editor at any point — the round-trip is lossless, so YAML keys the form doesn't know about are preserved.
+
+### Conflict Pre-Validation
+
+Before you submit, the form checks the new deployment against existing ESODeployments on the same effective cluster and warns about:
+
+- **Namespace overlap** — two namespaced deployments targeting the same namespace
+- **Multiple cluster-scoped deployments** on one cluster
+- **Cluster scope covering a namespaced deployment**
+
+The SG Agent performs the same checks server-side and surfaces violations as a `Conflict` condition on the resource — blocking (`Error`) or advisory (`Warning`) depending on severity.
+
+### Externally Installed ESO (Discovered)
+
+The SG Agent periodically scans connected clusters for ESO installations **it didn't deploy** (e.g. installed by another platform team). These appear as read-only `eso-ext-*` ESODeployments in the `Discovered` phase with `managementMode: external`, showing the discovered image and replica count. SecureGuard never modifies them — they exist so the dashboard shows the complete picture. To adopt such a cluster, remove the external installation and create a managed ESODeployment for it.
 
 ## Federation
 
@@ -192,38 +232,47 @@ proxy. Federation is opt-in and disabled by default. For setup, the broker, the
 
 ## Event Stream
 
-The **Event Stream** page shows real-time Kubernetes events related to ESO resources. Use it for:
+The **Event Stream** page shows a live feed of Kubernetes events related to ESO resources, aggregated across all selected clusters. Use it for:
 
 - Monitoring sync activity across all ExternalSecrets
 - Spotting error patterns in real-time
 - Debugging failed syncs without needing `kubectl`
 
+Controls: filter by **Type** (Normal/Warning) and **Reason**, **Pause/Resume** the feed, and **Clear** the buffer. Each event links to its involved object's detail page. The feed polls every 10 seconds and keeps the most recent 500 events.
+
 ## Relationship Visualization
 
-The **Visualization** page renders an interactive graph showing relationships between:
+The **Visualization** page renders your secret-syncing topology in two views:
 
-- ExternalSecrets → SecretStores / ClusterSecretStores
-- ExternalSecrets → target Kubernetes Secrets
-- PushSecrets → source Kubernetes Secrets
+- **Graph view** — an interactive, auto-laid-out graph of clusters, SecretStores/ClusterSecretStores, ExternalSecrets, target Kubernetes Secrets, and ESODeployments. Zoom, pan, rotate the layout, auto-arrange, and use the minimap for orientation.
+- **List view** — the same relationships as expandable per-cluster trees: each store expands to show its referencing ExternalSecrets and their target Secrets.
 
-Click any node to navigate to its detail page. Use the controls to zoom, pan, and re-layout the graph.
+Click any node to navigate to its detail page. Both views respect the global cluster and namespace selectors.
 
 ## Multi-Cluster Management
 
 ### Cluster Selector
 
-The **cluster selector** in the top bar lets you scope the view to a specific cluster or view resources across all clusters.
+The **cluster selector** in the top bar lets you scope the view to a specific cluster or view resources across all clusters. In "All Clusters" mode the dashboard queries every registered cluster in parallel and tags each row with its origin cluster. The selection is persisted in the URL (`?cluster=...`), so filtered views are shareable and bookmarkable.
 
 ### Adding Clusters
 
-1. Navigate to **Clusters** (the Cluster Management page)
-2. Click **Upload Kubeconfig** and select a kubeconfig file
-3. Each context in the kubeconfig becomes a new cluster
-4. Optionally register an SGAgent for the cluster
+Navigate to **Clusters** (the Cluster Management page) and click **Add Cluster**. A three-step wizard walks you through registration:
 
-### Cluster Health
+1. **Configure** — Choose a cluster name (lowercase RFC 1123), an environment label, and whether to register an **SG Agent** for the cluster. Registering an agent enables heartbeat health reporting and ESO lifecycle management (ESODeployments) on that cluster; without it, the cluster is view-only through the proxy.
+2. **Setup** — The wizard generates the exact `kubectl` commands to run against the target cluster: they create a dedicated least-privilege, read-only ServiceAccount for SecureGuard. Use **Copy All Commands** and run them with cluster-admin rights on the target.
+3. **Upload** — Drag-and-drop or select the kubeconfig. Each context becomes a registered cluster.
 
-The Cluster Management page shows the health status of all connected clusters. Unhealthy clusters are flagged with the reason (unreachable, auth expired, etc.).
+On upload, the proxy immediately replaces the kubeconfig's credential with a **short-lived, self-renewing token** — the uploaded credential is never persisted. See [Short-Lived Remote-Cluster Tokens]({{< ref "../advanced-configuration/#short-lived-remote-cluster-tokens" >}}).
+
+### Cluster Health & Day-2 Actions
+
+The Cluster Management page shows the health of all connected clusters, their environment, an **SG Agent badge** (active / stale / none) with the last heartbeat, and per-cluster actions:
+
+- **Test Connection** — Run an on-demand connectivity check against the cluster's API server.
+- **Delete Cluster** — Deregister a cluster (with confirmation). This removes the per-cluster kubeconfig Secret from the management cluster; the **management cluster itself cannot be deleted**. Resources on the remote cluster are not touched — clean up the remote ServiceAccount manually if you're decommissioning the integration.
+
+Unhealthy clusters are flagged with the reason (unreachable, auth expired, etc.). The cluster detail page additionally shows the SG Agent's status conditions and the ESODeployments targeting that cluster.
 
 ## Namespace Filtering
 

--- a/content/secureguard/main/user-guide/_index.en.md
+++ b/content/secureguard/main/user-guide/_index.en.md
@@ -3,9 +3,6 @@ title = "User Guide"
 date = 2026-06-13T09:00:00+02:00
 weight = 6
 description = "A feature-by-feature tour of the SecureGuard dashboard — managing ExternalSecrets, stores, push secrets, clusters, and federation from a read-mostly control room."
-sitemapexclude = true
-searchexclude = true
-private = true
 +++
 
 This guide walks you through the key features of the SecureGuard dashboard. It assumes you have a running deployment (see [Getting Started]({{< ref "../getting-started/" >}})) and are logged in.


### PR DESCRIPTION
This PR does a broad accuracy + coverage pass on the SecureGuard user docs ahead of launch.

1. **Fix factual errors** — auto-generated Dex admin password (chart never uses a hardcoded one) + the missing RBAC-binding step needed before the dashboard shows anything; impersonation-model RBAC rewrite; real Prometheus metrics replacing the "no metrics" section; complete proxy env-var table; correct `ReloaderConfig` ownership; pinned fedclient/ESO versions; provider links → ESO support matrix.
2. **Document missing features + in-site API Reference** — new API Reference page (endpoints, CSRF contract, method-aware allowlist, redaction, errors); stale detection, Sync Error Drawer, event-stream controls, visualization views, cluster wizard/Test Connection/Delete Cluster, ESODeployment form, conflict detection, external-ESO discovery, chart auto-wiring, opt-in `sgAgent`/`federation` defaults, `values-production.yaml`, ingress trio.
3. **Expand troubleshooting & upgrades** — federation failure modes (broker 401/403/404 ↔ fedclient exit codes, OIDC discovery), ESODeployment/SG Agent issues, admin-password recovery; OpenBao snapshot **restore**, rollback, verification checklist, version-specific notes.
4. **Restructure & polish** — replace all links into the source repo with in-site content/refs; swap ESO/OpenBao Basics weights to match the recommended reading order; de-duplicate ingress/limits/netpol blocks; reconcile the two multi-tenancy stories; glossary fixes.
5. **Unhide for launch** — remove the `private`/`sitemapexclude`/`searchexclude` front-matter flags and the preview banners.
6. **OpenBao Raft HA + self-init (chart 0.3.0)** — Raft HA default, self-initialization/unsealing (key-shares Secret, restart-reseal caveat, `unsealCronJob`), KMS auto-unseal opt-out, `bao operator generate-root` break-glass, and a 0.3.0 breaking-change upgrade note. 
7. **Real-world install/day-2 operations pass** — closes the gaps surfaced during a from-scratch cloud install:
   - **Installation prerequisites** beyond "Kubernetes + helm": private-registry pull credentials (images live in a private Quay repo → `ImagePullBackOff`/`401` until `imagePullSecrets`/`global.imagePullSecrets` is set), an ingress controller + `IngressClass`, cert-manager + a `ClusterIssuer`, wildcard DNS → ingress LB, and a default `StorageClass` with a sizing note (EBS `gp2`/`gp3` may not support online volume expansion).
   - **DNS & TLS install-order runbook** — install → read the LB address → create wildcard DNS → cert-manager issues `secureguard-tls` → log in, with a note that the proxy retries OIDC discovery and self-heals (no restart needed). Plus a node-sizing tip (dev-mode vs full Raft HA).
   - **Multi-cluster RBAC made explicit** — the impersonated user needs Role/ClusterRole bindings on **every** cluster they touch, including targets; the management-cluster binding does not carry over.
   - **Cluster registration mechanism & credentials** — labeled Secret (`secureguard.io/cluster-kubeconfig=true`) + informer discovery, the management/local cluster must be registered too, and credential constraints (bearer/exec supported; OIDC `auth-provider` kubeconfigs rejected).
   - **Nice-to-haves** — `dex.config.oauth2.skipApprovalScreen` for the first-party dashboard client, and a reinforced day-one `<release>-openbao-keys` backup + `generate-root` break-glass step.

