### PR TITLE
Add Kubermatic-virtualization version 1.2.0 to the list

### DIFF
--- a/data/products.yaml
+++ b/data/products.yaml
@@ -60,6 +60,8 @@ kubermatic-virtualization:
   versions:
     - release: main
       name: main
+    - release: v1.2.0
+      name: v1.2.0
     - release: v1.1.0
       name: v1.1.0
     - release: v1.0.0


### PR DESCRIPTION
Seems the Kubermatic-virtualization version 1.2 was accidentally dropped as part of https://github.com/kubermatic/docs/pull/2193 PR. 
Putting it back to the list