### PR TITLE
docs(kubev): document top-level imagePullSecret in declarative installation

### DIFF
--- a/content/kubermatic-virtualization/main/installation/declarative-installation/_index.en.md
+++ b/content/kubermatic-virtualization/main/installation/declarative-installation/_index.en.md
@@ -129,7 +129,7 @@ kubevirt:
 
 The KubeV web dashboard is optional and disabled by default. Enable it by adding a `dashboard` section to your configuration file.
 
-The dashboard images are hosted on a private registry — credentials are required before `kubev apply` will proceed. Provide them either inline in the config file or via environment variables before running the command:
+KubeV images are hosted on a private registry — credentials are required for every installation, as the controller-manager is always deployed. Provide them either as the top-level `imagePullSecret` field in the config file or via environment variables before running the command:
 
 ```bash
 # Option A — environment variables
@@ -137,23 +137,22 @@ export KUBEV_USERNAME=myuser
 export KUBEV_PASSWORD=mypassword
 kubev apply -f cluster.yaml
 
-# Option B — inline in cluster.yaml
-dashboard:
-  enabled: true
-  imagePullSecret: |
-    {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+# Option B — top-level field in cluster.yaml
+imagePullSecret: |
+  {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
 ```
 
-If neither is provided and the dashboard is enabled, `kubev apply` fails the pre-flight check before making any cluster changes.
+Setting `dashboard.imagePullSecret` is still supported and overrides the top-level field for the dashboard components only.
 
 The dashboard supports three authentication modes: `none`, `basic`, and `oidc`. The simplest way to get started is `none` — the dashboard is accessible without a login, suitable for private networks during initial setup:
 
 ```yaml
+imagePullSecret: |
+  {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+
 dashboard:
   enabled: true
   dashboardURL: "https://dashboard.example.com"
-  imagePullSecret: |
-    {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
   auth:
     none: {}
 ```

--- a/content/kubermatic-virtualization/v1.2.0/installation/declarative-installation/_index.en.md
+++ b/content/kubermatic-virtualization/v1.2.0/installation/declarative-installation/_index.en.md
@@ -129,7 +129,7 @@ kubevirt:
 
 The KubeV web dashboard is optional and disabled by default. Enable it by adding a `dashboard` section to your configuration file.
 
-The dashboard images are hosted on a private registry — credentials are required before `kubev apply` will proceed. Provide them either inline in the config file or via environment variables before running the command:
+KubeV images are hosted on a private registry — credentials are required for every installation, as the controller-manager is always deployed. Provide them either as the top-level `imagePullSecret` field in the config file or via environment variables before running the command:
 
 ```bash
 # Option A — environment variables
@@ -137,23 +137,22 @@ export KUBEV_USERNAME=myuser
 export KUBEV_PASSWORD=mypassword
 kubev apply -f cluster.yaml
 
-# Option B — inline in cluster.yaml
-dashboard:
-  enabled: true
-  imagePullSecret: |
-    {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+# Option B — top-level field in cluster.yaml
+imagePullSecret: |
+  {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
 ```
 
-If neither is provided and the dashboard is enabled, `kubev apply` fails the pre-flight check before making any cluster changes.
+Setting `dashboard.imagePullSecret` is still supported and overrides the top-level field for the dashboard components only.
 
 The dashboard supports three authentication modes: `none`, `basic`, and `oidc`. The simplest way to get started is `none` — the dashboard is accessible without a login, suitable for private networks during initial setup:
 
 ```yaml
+imagePullSecret: |
+  {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+
 dashboard:
   enabled: true
   dashboardURL: "https://dashboard.example.com"
-  imagePullSecret: |
-    {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
   auth:
     none: {}
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Since KubeV v1.2.0 the controller-manager is always deployed and reads registry credentials from the top-level `imagePullSecret` field, but the declarative-installation page (v1.2.0 and main) still showed `dashboard.imagePullSecret` as the only inline option — users upgrading v1.1.x configs end up with the controller-manager in `ImagePullBackOff`. Updates both examples to the top-level field and notes the dashboard-level field as a components-only override.

**Which issue(s) this PR fixes**:
Refs kubermatic/kubermatic-virtualization#340

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:
Same two edits applied identically to `v1.2.0` and `main` content dirs. No other pages touched.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)