### PR TITLE
Add Known Issues page: Flatcar Ignition failure on KubeVirt 1.6.x

### DIFF
--- a/content/kubermatic-virtualization/main/known-issues/_index.en.md
+++ b/content/kubermatic-virtualization/main/known-issues/_index.en.md
@@ -1,0 +1,91 @@
++++
+title = "Known Issues"
+date = 2026-07-23T00:00:00+00:00
+weight = 7
++++
+
+## Overview
+
+This page lists known issues in Kubermatic Virtualization together with their
+current status and any available workarounds. Each entry states the versions it
+applies to, so you can quickly tell whether your environment is affected.
+
+## Flatcar worker nodes fail to bootstrap on KubeVirt 1.6.x (Ignition not applied)
+
+**Applies to:** Kubermatic Virtualization v1.2.0 and newer (ships KubeVirt
+v1.6.5). The underlying defect is present in KubeVirt v1.6.4 and newer.
+**Scope:** Flatcar Linux worker nodes only. Ubuntu and other cloud-init based
+operating systems are **not** affected.
+**Status:** Upstream fix open, not yet released. Workaround available (see below).
+
+### Problem
+
+Flatcar-based user-cluster worker VMs start and receive an IP address, but they
+never receive their Ignition configuration. As a result `kubeadm` is never
+installed, no `bootstrap.service` runs, and the node never joins the user
+cluster. Ubuntu worker pools on the same infrastructure provision normally.
+
+### Root Cause
+
+Flatcar receives its provisioning config through a QEMU firmware-config argument
+(`-fw_cfg name=opt/com.coreos/config`), which lives in the `qemu:commandline`
+section of the VM's libvirt domain. Ubuntu instead uses cloud-init / `noCloud`,
+delivered as a disk.
+
+Starting with KubeVirt v1.6.4, the PCIe-hotplug port reservation writes the
+libvirt domain definition a second time. That code path performs an XML
+round-trip that cannot preserve the `qemu` XML namespace, so the second write
+drops the `qemu:commandline` block — and with it the `-fw_cfg` argument that
+carries Flatcar's Ignition payload. The VM therefore boots from a definition
+that no longer points at its Ignition config. This is an upstream KubeVirt
+defect, not a Kubermatic Virtualization or machine-controller bug — the Ignition
+data itself is generated and written to disk correctly.
+
+### Workaround
+
+KubeVirt exposes a per-VM annotation, `kubevirt.io/placePCIDevicesOnRootComplex`,
+that disables the extra hotplug-port reservation and therefore skips the second
+domain write, so the `-fw_cfg` argument is preserved.
+
+machine-controller sets this annotation automatically for Flatcar machines as of
+[kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057).
+Deploy a machine-controller version that includes this change and recreate the
+affected Flatcar nodes.
+
+If you cannot update machine-controller yet, add the annotation manually to the
+Flatcar worker pool's `MachineDeployment` in the user cluster (namespace
+`kube-system`) and roll the nodes:
+
+```yaml
+apiVersion: cluster.k8s.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: <flatcar-worker-pool>
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      annotations:
+        kubevirt.io/placePCIDevicesOnRootComplex: "true"
+```
+
+Note: the annotation must sit on `spec.template.metadata.annotations` (this is
+what reaches the VM). It only takes effect on newly created machines, so
+existing Flatcar nodes must be recreated for the fix to apply.
+
+### Limitations and trade-offs
+
+- **The workaround is Flatcar-specific.** It is applied only to Flatcar machines
+  and does not change behaviour for any other operating system.
+- **Drawback:** setting `placePCIDevicesOnRootComplex` places all PCI devices on
+  the root complex and disables PCIe hotplug for those VMs. This has no practical
+  impact on worker nodes, which do not hotplug PCI devices.
+- **Temporary.** This is a workaround, not a permanent fix. It should be removed
+  once the upstream KubeVirt fix is available in the KubeVirt version shipped
+  with Kubermatic Virtualization.
+
+### References
+
+- KubeVirt root-cause issue: [kubevirt/kubevirt#16901](https://github.com/kubevirt/kubevirt/issues/16901)
+- KubeVirt fix (open): [kubevirt/kubevirt#18460](https://github.com/kubevirt/kubevirt/pull/18460)
+- machine-controller workaround: [kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057)

--- a/content/kubermatic-virtualization/main/known-issues/_index.en.md
+++ b/content/kubermatic-virtualization/main/known-issues/_index.en.md
@@ -16,7 +16,9 @@ applies to, so you can quickly tell whether your environment is affected.
 v1.6.5). The underlying defect is present in KubeVirt v1.6.4 and newer.
 **Scope:** Flatcar Linux worker nodes only. Ubuntu and other cloud-init based
 operating systems are **not** affected.
-**Status:** Upstream fix open, not yet released. Workaround available (see below).
+**Status:** Upstream KubeVirt fix open, not yet released. The machine-controller
+workaround is released (v1.66.1, backported to v1.65.5) and bundled in KKP
+v2.30.6 and newer (see below).
 
 ### Problem
 
@@ -45,16 +47,62 @@ data itself is generated and written to disk correctly.
 
 KubeVirt exposes a per-VM annotation, `kubevirt.io/placePCIDevicesOnRootComplex`,
 that disables the extra hotplug-port reservation and therefore skips the second
-domain write, so the `-fw_cfg` argument is preserved.
+domain write, so the `-fw_cfg` argument is preserved on Flatcar nodes.
 
 machine-controller sets this annotation automatically for Flatcar machines as of
-[kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057).
-Deploy a machine-controller version that includes this change and recreate the
-affected Flatcar nodes.
+[kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057),
+released in machine-controller v1.66.1 and backported to v1.65.5.
 
-If you cannot update machine-controller yet, add the annotation manually to the
-Flatcar worker pool's `MachineDeployment` in the user cluster (namespace
-`kube-system`) and roll the nodes:
+#### Upgrade KKP to a release that bundles the fix (recommended)
+
+Kubermatic Kubernetes Platform (KKP) v2.30.6 and newer ship machine-controller
+v1.65.5, which sets the annotation for you. Upgrade KKP and recreate the affected
+Flatcar nodes.
+
+#### Pin the machine-controller image
+
+If you run a KKP v2.30.x release older than v2.30.6 and cannot upgrade yet, pin
+machine-controller to the release containing the fix in your
+`KubermaticConfiguration`:
+
+```yaml
+spec:
+  userCluster:
+    machineController:
+      imageTag: v1.65.5
+```
+
+Remove this override once you upgrade to a KKP release that already bundles the
+fix.
+
+On KKP v2.29.x and v2.28.x the fix is not part of the bundled machine-controller
+line (v1.64.x and v1.62.x respectively). Set the annotation manually instead, as
+described below.
+
+#### Set the annotation manually
+
+If you can neither upgrade nor pin machine-controller, set the annotation
+`kubevirt.io/placePCIDevicesOnRootComplex` to `"true"` yourself, using one of the
+options below.
+
+**Existing user cluster (affected MachineDeployment)**
+
+Patch the `MachineDeployment` in the user cluster (namespace `kube-system`), then
+recreate the Flatcar nodes:
+
+```bash
+kubectl -n kube-system patch machinedeployment <flatcar-worker-pool> --type merge \
+  -p '{"spec":{"template":{"metadata":{"annotations":{"kubevirt.io/placePCIDevicesOnRootComplex":"true"}}}}}'
+```
+
+The annotation only takes effect on newly created machines, so existing Flatcar
+nodes must be recreated for the fix to apply.
+
+**New user cluster / MachineDeployment**
+
+Add the annotation under `spec.template.metadata.annotations` at creation time,
+either in the `MachineDeployment` YAML, or directly from the KKP dashboard during
+user cluster or MachineDeployment creation:
 
 ```yaml
 apiVersion: cluster.k8s.io/v1alpha1
@@ -69,9 +117,8 @@ spec:
         kubevirt.io/placePCIDevicesOnRootComplex: "true"
 ```
 
-Note: the annotation must sit on `spec.template.metadata.annotations` (this is
-what reaches the VM). It only takes effect on newly created machines, so
-existing Flatcar nodes must be recreated for the fix to apply.
+**Note:** The annotation must sit on `spec.template.metadata.annotations`, not the
+MD's top-level metadata. This is what reaches the VM.
 
 ### Limitations and trade-offs
 

--- a/content/kubermatic-virtualization/v1.2.0/known-issues/_index.en.md
+++ b/content/kubermatic-virtualization/v1.2.0/known-issues/_index.en.md
@@ -1,0 +1,91 @@
++++
+title = "Known Issues"
+date = 2026-07-23T00:00:00+00:00
+weight = 7
++++
+
+## Overview
+
+This page lists known issues in Kubermatic Virtualization together with their
+current status and any available workarounds. Each entry states the versions it
+applies to, so you can quickly tell whether your environment is affected.
+
+## Flatcar worker nodes fail to bootstrap on KubeVirt 1.6.x (Ignition not applied)
+
+**Applies to:** Kubermatic Virtualization v1.2.0 (ships KubeVirt v1.6.5). The
+underlying defect is present in KubeVirt v1.6.4 and newer.
+**Scope:** Flatcar Linux worker nodes only. Ubuntu and other cloud-init based
+operating systems are **not** affected.
+**Status:** Upstream fix open, not yet released. Workaround available (see below).
+
+### Problem
+
+Flatcar-based user-cluster worker VMs start and receive an IP address, but they
+never receive their Ignition configuration. As a result `kubeadm` is never
+installed, no `bootstrap.service` runs, and the node never joins the user
+cluster. Ubuntu worker pools on the same infrastructure provision normally.
+
+### Root Cause
+
+Flatcar receives its provisioning config through a QEMU firmware-config argument
+(`-fw_cfg name=opt/com.coreos/config`), which lives in the `qemu:commandline`
+section of the VM's libvirt domain. Ubuntu instead uses cloud-init / `noCloud`,
+delivered as a disk.
+
+Starting with KubeVirt v1.6.4, the PCIe-hotplug port reservation writes the
+libvirt domain definition a second time. That code path performs an XML
+round-trip that cannot preserve the `qemu` XML namespace, so the second write
+drops the `qemu:commandline` block — and with it the `-fw_cfg` argument that
+carries Flatcar's Ignition payload. The VM therefore boots from a definition
+that no longer points at its Ignition config. This is an upstream KubeVirt
+defect, not a Kubermatic Virtualization or machine-controller bug — the Ignition
+data itself is generated and written to disk correctly.
+
+### Workaround
+
+KubeVirt exposes a per-VM annotation, `kubevirt.io/placePCIDevicesOnRootComplex`,
+that disables the extra hotplug-port reservation and therefore skips the second
+domain write, so the `-fw_cfg` argument is preserved.
+
+machine-controller sets this annotation automatically for Flatcar machines as of
+[kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057).
+Deploy a machine-controller version that includes this change and recreate the
+affected Flatcar nodes.
+
+If you cannot update machine-controller yet, add the annotation manually to the
+Flatcar worker pool's `MachineDeployment` in the user cluster (namespace
+`kube-system`) and roll the nodes:
+
+```yaml
+apiVersion: cluster.k8s.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: <flatcar-worker-pool>
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      annotations:
+        kubevirt.io/placePCIDevicesOnRootComplex: "true"
+```
+
+Note: the annotation must sit on `spec.template.metadata.annotations` (this is
+what reaches the VM). It only takes effect on newly created machines, so
+existing Flatcar nodes must be recreated for the fix to apply.
+
+### Limitations and trade-offs
+
+- **The workaround is Flatcar-specific.** It is applied only to Flatcar machines
+  and does not change behaviour for any other operating system.
+- **Drawback:** setting `placePCIDevicesOnRootComplex` places all PCI devices on
+  the root complex and disables PCIe hotplug for those VMs. This has no practical
+  impact on worker nodes, which do not hotplug PCI devices.
+- **Temporary.** This is a workaround, not a permanent fix. It should be removed
+  once the upstream KubeVirt fix is available in the KubeVirt version shipped
+  with Kubermatic Virtualization.
+
+### References
+
+- KubeVirt root-cause issue: [kubevirt/kubevirt#16901](https://github.com/kubevirt/kubevirt/issues/16901)
+- KubeVirt fix (open): [kubevirt/kubevirt#18460](https://github.com/kubevirt/kubevirt/pull/18460)
+- machine-controller workaround: [kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057)

--- a/content/kubermatic-virtualization/v1.2.0/known-issues/_index.en.md
+++ b/content/kubermatic-virtualization/v1.2.0/known-issues/_index.en.md
@@ -16,7 +16,9 @@ applies to, so you can quickly tell whether your environment is affected.
 underlying defect is present in KubeVirt v1.6.4 and newer.
 **Scope:** Flatcar Linux worker nodes only. Ubuntu and other cloud-init based
 operating systems are **not** affected.
-**Status:** Upstream fix open, not yet released. Workaround available (see below).
+**Status:** Upstream KubeVirt fix open, not yet released. The machine-controller
+workaround is released (v1.66.1, backported to v1.65.5) and bundled in KKP
+v2.30.6 and newer (see below).
 
 ### Problem
 
@@ -45,16 +47,62 @@ data itself is generated and written to disk correctly.
 
 KubeVirt exposes a per-VM annotation, `kubevirt.io/placePCIDevicesOnRootComplex`,
 that disables the extra hotplug-port reservation and therefore skips the second
-domain write, so the `-fw_cfg` argument is preserved.
+domain write, so the `-fw_cfg` argument is preserved on Flatcar nodes.
 
 machine-controller sets this annotation automatically for Flatcar machines as of
-[kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057).
-Deploy a machine-controller version that includes this change and recreate the
-affected Flatcar nodes.
+[kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057),
+released in machine-controller v1.66.1 and backported to v1.65.5.
 
-If you cannot update machine-controller yet, add the annotation manually to the
-Flatcar worker pool's `MachineDeployment` in the user cluster (namespace
-`kube-system`) and roll the nodes:
+#### Upgrade KKP to a release that bundles the fix (recommended)
+
+Kubermatic Kubernetes Platform (KKP) v2.30.6 and newer ship machine-controller
+v1.65.5, which sets the annotation for you. Upgrade KKP and recreate the affected
+Flatcar nodes.
+
+#### Pin the machine-controller image
+
+If you run a KKP v2.30.x release older than v2.30.6 and cannot upgrade yet, pin
+machine-controller to the release containing the fix in your
+`KubermaticConfiguration`:
+
+```yaml
+spec:
+  userCluster:
+    machineController:
+      imageTag: v1.65.5
+```
+
+Remove this override once you upgrade to a KKP release that already bundles the
+fix.
+
+On KKP v2.29.x and v2.28.x the fix is not part of the bundled machine-controller
+line (v1.64.x and v1.62.x respectively). Set the annotation manually instead, as
+described below.
+
+#### Set the annotation manually
+
+If you can neither upgrade nor pin machine-controller, set the annotation
+`kubevirt.io/placePCIDevicesOnRootComplex` to `"true"` yourself, using one of the
+options below.
+
+**Existing user cluster (affected MachineDeployment)**
+
+Patch the `MachineDeployment` in the user cluster (namespace `kube-system`), then
+recreate the Flatcar nodes:
+
+```bash
+kubectl -n kube-system patch machinedeployment <flatcar-worker-pool> --type merge \
+  -p '{"spec":{"template":{"metadata":{"annotations":{"kubevirt.io/placePCIDevicesOnRootComplex":"true"}}}}}'
+```
+
+The annotation only takes effect on newly created machines, so existing Flatcar
+nodes must be recreated for the fix to apply.
+
+**New user cluster / MachineDeployment**
+
+Add the annotation under `spec.template.metadata.annotations` at creation time,
+either in the `MachineDeployment` YAML, or directly from the KKP dashboard during
+user cluster or MachineDeployment creation:
 
 ```yaml
 apiVersion: cluster.k8s.io/v1alpha1
@@ -69,9 +117,8 @@ spec:
         kubevirt.io/placePCIDevicesOnRootComplex: "true"
 ```
 
-Note: the annotation must sit on `spec.template.metadata.annotations` (this is
-what reaches the VM). It only takes effect on newly created machines, so
-existing Flatcar nodes must be recreated for the fix to apply.
+**Note:** The annotation must sit on `spec.template.metadata.annotations`, not the
+MD's top-level metadata. This is what reaches the VM.
 
 ### Limitations and trade-offs
 

--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -217,3 +217,40 @@ As long as there are PersistentVolumes and Services of type LoadBalancer within 
 1. Make sure the user cluster has a MachineDeployment, Machines and corresponding healthy nodes before deleting it.
 2. Download the user cluster's kubeconfig before deleting the user cluster and add a new MachineDeployment (e.g. by copying it from another cluster that was created using the same settings). Please be aware that you can neither download the kubeconfig nor create a new MachineDeployment via the KKP Dashboard anymore once user cluster deletion was started!
 3. Ask your platform administrator to remove the `kubermatic.k8c.io/cleanup-in-cluster-pv` and `kubermatic.k8c.io/cleanup-in-cluster-lb` finalizers from your `Cluster` resource within the seed cluster and clean up the corresponding cloud provider resources (e.g. AWS EBS volume) manually.
+
+## Flatcar worker nodes fail to bootstrap on KubeVirt infrastructure (Ignition not applied)
+
+_**Affected Components**_: Machine Controller, KubeVirt provider (Kubermatic Virtualization)
+
+_**Affected OS Image**_: Flatcar Linux worker nodes provisioned on KubeVirt v1.6.4 and newer (shipped with Kubermatic Virtualization v1.2.0). Ubuntu and other cloud-init based operating systems are **not** affected.
+
+Issue: [kubevirt/kubevirt#16901](https://github.com/kubevirt/kubevirt/issues/16901)
+
+### Problem
+
+Flatcar-based user-cluster worker VMs start and receive an IP address, but they never receive their Ignition configuration. As a result the node never joins the user cluster. Ubuntu worker pools on the same infrastructure provision normally.
+
+### Root Cause
+
+Flatcar receives its provisioning config through a QEMU firmware-config argument (`-fw_cfg name=opt/com.coreos/config`) in the `qemu:commandline` section of the VM's libvirt domain. Starting with KubeVirt v1.6.4, the PCIe-hotplug port reservation rewrites the libvirt domain a second time; that XML round-trip drops the `qemu:commandline` block, and with it the `-fw_cfg` argument that carries Flatcar's Ignition payload. This is an upstream KubeVirt defect, not a Kubermatic or machine-controller bug — the Ignition data itself is generated correctly.
+
+### Workaround
+
+Set the KubeVirt annotation `kubevirt.io/placePCIDevicesOnRootComplex: "true"` on the Flatcar worker pool. machine-controller sets it automatically for Flatcar machines as of [kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057), released in machine-controller v1.66.1 and backported to v1.65.5. machine-controller v1.66.1 is the version bundled with this KKP release, so no extra configuration is required — recreate the affected Flatcar nodes so they are created with the annotation.
+
+If your installation still runs a machine-controller version that predates the fix, pin it in your `KubermaticConfiguration`, staying within the machine-controller minor your KKP release bundles (v1.65.5 for KKP v2.30.x):
+
+```yaml
+spec:
+  userCluster:
+    machineController:
+      imageTag: v1.65.5
+```
+
+Remove the override once you run a KKP release that already bundles the fix.
+
+Alternatively, set the annotation manually on the Flatcar worker pool's `MachineDeployment` under `spec.template.metadata.annotations` (namespace `kube-system`) and recreate the nodes. The annotation only takes effect on newly created machines. See the [Kubermatic Virtualization known issues](https://docs.kubermatic.com/kubermatic-virtualization/main/known-issues/) page for the full steps, the patch command, and trade-offs.
+
+### Planned resolution
+
+Tracked upstream in [kubevirt/kubevirt#18460](https://github.com/kubevirt/kubevirt/pull/18460). The workaround can be removed once the fix ships in the KubeVirt version bundled with Kubermatic Virtualization.

--- a/content/kubermatic/v2.28/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.28/architecture/known-issues/_index.en.md
@@ -158,3 +158,29 @@ Workaround in detail:
   ```
 
 2. Re-run the mla installation process in accordance with the [official documentation](../../tutorials-howtos//monitoring-logging-alerting//user-cluster/admin-guide/#installing-mla-stack-in-a-seed-cluster) with a kubermatic installer matching your current KKP version.
+
+## Flatcar worker nodes fail to bootstrap on KubeVirt infrastructure (Ignition not applied)
+
+_**Affected Components**_: Machine Controller, KubeVirt provider (Kubermatic Virtualization)
+
+_**Affected OS Image**_: Flatcar Linux worker nodes provisioned on KubeVirt v1.6.4 and newer (shipped with Kubermatic Virtualization v1.2.0). Ubuntu and other cloud-init based operating systems are **not** affected.
+
+Issue: [kubevirt/kubevirt#16901](https://github.com/kubevirt/kubevirt/issues/16901)
+
+### Problem
+
+Flatcar-based user-cluster worker VMs start and receive an IP address, but they never receive their Ignition configuration. As a result the node never joins the user cluster. Ubuntu worker pools on the same infrastructure provision normally.
+
+### Root Cause
+
+Flatcar receives its provisioning config through a QEMU firmware-config argument (`-fw_cfg name=opt/com.coreos/config`) in the `qemu:commandline` section of the VM's libvirt domain. Starting with KubeVirt v1.6.4, the PCIe-hotplug port reservation rewrites the libvirt domain a second time; that XML round-trip drops the `qemu:commandline` block, and with it the `-fw_cfg` argument that carries Flatcar's Ignition payload. This is an upstream KubeVirt defect, not a Kubermatic or machine-controller bug — the Ignition data itself is generated correctly.
+
+### Workaround
+
+Set the KubeVirt annotation `kubevirt.io/placePCIDevicesOnRootComplex: "true"` on the Flatcar worker pool. machine-controller sets it automatically for Flatcar machines as of [kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057), released in machine-controller v1.66.1 and backported to v1.65.5. Neither release is part of the machine-controller v1.62.x line that KKP v2.28.x bundles, and pinning `spec.userCluster.machineController.imageTag` to a different machine-controller minor than your KKP release ships is not tested. On v2.28.x, set the annotation manually on the Flatcar worker pool's `MachineDeployment` under `spec.template.metadata.annotations` (namespace `kube-system`) and recreate the nodes. The annotation only takes effect on newly created machines. See the [Kubermatic Virtualization known issues](https://docs.kubermatic.com/kubermatic-virtualization/main/known-issues/) page for the full steps, the patch command, and trade-offs.
+
+To have machine-controller set the annotation for you, upgrade to KKP v2.30.6 or newer, which bundles machine-controller v1.65.5.
+
+### Planned resolution
+
+Tracked upstream in [kubevirt/kubevirt#18460](https://github.com/kubevirt/kubevirt/pull/18460). The workaround can be removed once the fix ships in the KubeVirt version bundled with Kubermatic Virtualization.

--- a/content/kubermatic/v2.29/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.29/architecture/known-issues/_index.en.md
@@ -217,3 +217,29 @@ As long as there are PersistentVolumes and Services of type LoadBalancer within 
 1. Make sure the user cluster has a MachineDeployment, Machines and corresponding healthy nodes before deleting it.
 2. Download the user cluster's kubeconfig before deleting the user cluster and add a new MachineDeployment (e.g. by copying it from another cluster that was created using the same settings). Please be aware that you can neither download the kubeconfig nor create a new MachineDeployment via the KKP Dashboard anymore once user cluster deletion was started!
 3. Ask your platform administrator to remove the `kubermatic.k8c.io/cleanup-in-cluster-pv` and `kubermatic.k8c.io/cleanup-in-cluster-lb` finalizers from your `Cluster` resource within the seed cluster and clean up the corresponding cloud provider resources (e.g. AWS EBS volume) manually.
+
+## Flatcar worker nodes fail to bootstrap on KubeVirt infrastructure (Ignition not applied)
+
+_**Affected Components**_: Machine Controller, KubeVirt provider (Kubermatic Virtualization)
+
+_**Affected OS Image**_: Flatcar Linux worker nodes provisioned on KubeVirt v1.6.4 and newer (shipped with Kubermatic Virtualization v1.2.0). Ubuntu and other cloud-init based operating systems are **not** affected.
+
+Issue: [kubevirt/kubevirt#16901](https://github.com/kubevirt/kubevirt/issues/16901)
+
+### Problem
+
+Flatcar-based user-cluster worker VMs start and receive an IP address, but they never receive their Ignition configuration. As a result the node never joins the user cluster. Ubuntu worker pools on the same infrastructure provision normally.
+
+### Root Cause
+
+Flatcar receives its provisioning config through a QEMU firmware-config argument (`-fw_cfg name=opt/com.coreos/config`) in the `qemu:commandline` section of the VM's libvirt domain. Starting with KubeVirt v1.6.4, the PCIe-hotplug port reservation rewrites the libvirt domain a second time; that XML round-trip drops the `qemu:commandline` block, and with it the `-fw_cfg` argument that carries Flatcar's Ignition payload. This is an upstream KubeVirt defect, not a Kubermatic or machine-controller bug — the Ignition data itself is generated correctly.
+
+### Workaround
+
+Set the KubeVirt annotation `kubevirt.io/placePCIDevicesOnRootComplex: "true"` on the Flatcar worker pool. machine-controller sets it automatically for Flatcar machines as of [kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057), released in machine-controller v1.66.1 and backported to v1.65.5. Neither release is part of the machine-controller v1.64.x line that KKP v2.29.x bundles, and pinning `spec.userCluster.machineController.imageTag` to a different machine-controller minor than your KKP release ships is not tested. On v2.29.x, set the annotation manually on the Flatcar worker pool's `MachineDeployment` under `spec.template.metadata.annotations` (namespace `kube-system`) and recreate the nodes. The annotation only takes effect on newly created machines. See the [Kubermatic Virtualization known issues](https://docs.kubermatic.com/kubermatic-virtualization/main/known-issues/) page for the full steps, the patch command, and trade-offs.
+
+To have machine-controller set the annotation for you, upgrade to KKP v2.30.6 or newer, which bundles machine-controller v1.65.5.
+
+### Planned resolution
+
+Tracked upstream in [kubevirt/kubevirt#18460](https://github.com/kubevirt/kubevirt/pull/18460). The workaround can be removed once the fix ships in the KubeVirt version bundled with Kubermatic Virtualization.

--- a/content/kubermatic/v2.30/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.30/architecture/known-issues/_index.en.md
@@ -217,3 +217,40 @@ As long as there are PersistentVolumes and Services of type LoadBalancer within 
 1. Make sure the user cluster has a MachineDeployment, Machines and corresponding healthy nodes before deleting it.
 2. Download the user cluster's kubeconfig before deleting the user cluster and add a new MachineDeployment (e.g. by copying it from another cluster that was created using the same settings). Please be aware that you can neither download the kubeconfig nor create a new MachineDeployment via the KKP Dashboard anymore once user cluster deletion was started!
 3. Ask your platform administrator to remove the `kubermatic.k8c.io/cleanup-in-cluster-pv` and `kubermatic.k8c.io/cleanup-in-cluster-lb` finalizers from your `Cluster` resource within the seed cluster and clean up the corresponding cloud provider resources (e.g. AWS EBS volume) manually.
+
+## Flatcar worker nodes fail to bootstrap on KubeVirt infrastructure (Ignition not applied)
+
+_**Affected Components**_: Machine Controller, KubeVirt provider (Kubermatic Virtualization)
+
+_**Affected OS Image**_: Flatcar Linux worker nodes provisioned on KubeVirt v1.6.4 and newer (shipped with Kubermatic Virtualization v1.2.0). Ubuntu and other cloud-init based operating systems are **not** affected.
+
+Issue: [kubevirt/kubevirt#16901](https://github.com/kubevirt/kubevirt/issues/16901)
+
+### Problem
+
+Flatcar-based user-cluster worker VMs start and receive an IP address, but they never receive their Ignition configuration. As a result the node never joins the user cluster. Ubuntu worker pools on the same infrastructure provision normally.
+
+### Root Cause
+
+Flatcar receives its provisioning config through a QEMU firmware-config argument (`-fw_cfg name=opt/com.coreos/config`) in the `qemu:commandline` section of the VM's libvirt domain. Starting with KubeVirt v1.6.4, the PCIe-hotplug port reservation rewrites the libvirt domain a second time; that XML round-trip drops the `qemu:commandline` block, and with it the `-fw_cfg` argument that carries Flatcar's Ignition payload. This is an upstream KubeVirt defect, not a Kubermatic or machine-controller bug — the Ignition data itself is generated correctly.
+
+### Workaround
+
+Set the KubeVirt annotation `kubevirt.io/placePCIDevicesOnRootComplex: "true"` on the Flatcar worker pool. machine-controller sets it automatically for Flatcar machines as of [kubermatic/machine-controller#2057](https://github.com/kubermatic/machine-controller/pull/2057), released in machine-controller v1.66.1 and backported to v1.65.5. machine-controller v1.65.5 is bundled in KKP v2.30.6 and newer, so upgrading to v2.30.6 or newer and recreating the affected Flatcar nodes is enough.
+
+On a v2.30.x patch release older than v2.30.6, pin machine-controller in your `KubermaticConfiguration`:
+
+```yaml
+spec:
+  userCluster:
+    machineController:
+      imageTag: v1.65.5
+```
+
+Remove the override once you upgrade to KKP v2.30.6 or newer.
+
+Alternatively, set the annotation manually on the Flatcar worker pool's `MachineDeployment` under `spec.template.metadata.annotations` (namespace `kube-system`) and recreate the nodes. The annotation only takes effect on newly created machines. See the [Kubermatic Virtualization known issues](https://docs.kubermatic.com/kubermatic-virtualization/main/known-issues/) page for the full steps, the patch command, and trade-offs.
+
+### Planned resolution
+
+Tracked upstream in [kubevirt/kubevirt#18460](https://github.com/kubevirt/kubevirt/pull/18460). The workaround can be removed once the fix ships in the KubeVirt version bundled with Kubermatic Virtualization.


### PR DESCRIPTION
### What this PR does / why we need it

Adds a **Known Issues** page to the Kubermatic Virtualization docs, documenting
the KubeVirt 1.6.x defect that breaks Flatcar worker-node provisioning.

On KubeVirt v1.6.4 and newer, Flatcar worker VMs boot and get an IP but never
receive their Ignition configuration, so the node never joins the user cluster.
KubeVirt's PCIe-hotplug port reservation re-defines the libvirt domain a second
time, and that XML round-trip drops the `qemu:commandline` `-fw_cfg
opt/com.coreos/config` argument that carries Flatcar's Ignition. Ubuntu
(cloud-init / noCloud) is unaffected. This is an upstream KubeVirt bug, not a
Kubermatic Virtualization or machine-controller defect.

The page documents the problem, root cause, the workaround (the
`kubevirt.io/placePCIDevicesOnRootComplex` annotation — set automatically for
Flatcar by kubermatic/machine-controller#2057, with a manual `MachineDeployment`
fallback), the Flatcar-only scope, the trade-off (disables unused PCIe hotplug),
and upstream references.


### Related

- Workaround: kubermatic/machine-controller#2057
- Upstream root cause: kubevirt/kubevirt#16901
- Upstream fix (open): kubevirt/kubevirt#18460
