### PR TITLE
Add Kubermatic Virtualization upgrading guide (v1.1.x → v1.2.0 imagePullSecret migration)

### DIFF
--- a/content/kubermatic-virtualization/main/installation/upgrading/_index.en.md
+++ b/content/kubermatic-virtualization/main/installation/upgrading/_index.en.md
@@ -1,0 +1,92 @@
++++
+title = "Upgrading"
+date = 2026-07-24T09:00:00+02:00
+weight = 17
++++
+
+This section contains important upgrade notes you should read **before** upgrading a
+Kubermatic Virtualization (KubeV) installation to a new version. Read the version-specific
+guide for the release you are moving to, then follow the general guidelines below.
+
+## Version-Specific Upgrade Notes
+
+{{% children %}}
+{{% /children %}}
+
+## General Guidelines
+
+The following steps apply to every KubeV upgrade.
+
+### How Upgrades Work
+
+KubeV installations are declarative, and `kubev apply` is idempotent: the same command that
+installs a cluster also upgrades it. To upgrade, update the KubeV version (and any changed
+settings) in your configuration file and re-run `kubev apply` against it — the installer
+reconciles the live system to the desired state, handling installation, upgrades, and repairs.
+
+```bash
+kubev apply -f cluster.yaml
+```
+
+Keep your `cluster.yaml` under version control and treat it as the single source of truth. See
+[Declarative Installation]({{< ref "../declarative-installation/" >}}) for the full
+configuration reference.
+
+### Upgrade One Minor Version at a Time
+
+Upgrade sequentially through minor versions (for example `v1.1.x` → `v1.2.x`) and read the
+version-specific guide for each hop. Do not skip minor versions.
+
+### Create Backups
+
+Even though regular backups should already be in place, ensure fresh backups exist before you
+start an upgrade:
+
+* **Your configuration** — keep the exact `cluster.yaml` used for the running installation, plus
+  the generated cluster kubeconfig.
+* **Cluster state** — back up etcd, or dump the Kubernetes resources you care about:
+
+```bash
+export KUBECONFIG=...
+
+while IFS= read -r crd; do
+  echo "Dumping $crd ..."
+  kubectl get "$crd" -A -o yaml > "$crd.yaml"
+done <<< "$(kubectl get crd -o name)"
+```
+
+* **Workload data** — snapshot persistent VM and application data through your storage layer (for
+  example, Longhorn volume snapshots/backups) according to your disaster-recovery process.
+
+### Repair Before You Upgrade
+
+`kubev apply` does not perform a repair and an upgrade in the same run. If nodes are unhealthy,
+first run `kubev apply` with the **current** version to repair the cluster, and only then change
+the version and re-run to upgrade.
+
+### Offline / Air-Gapped Installations
+
+In offline mode (`offlineSettings.enabled: true`) KubeV does not reach the public internet during
+upgrades. Every container image, Helm chart, and OS package for the target version must be
+pre-loaded into your internal mirrors before you upgrade.
+
+### Run the Pre-Flight Check
+
+`kubev apply` runs pre-flight checks and fails fast with a descriptive message if the
+configuration is incomplete (for example, missing image-registry credentials) **before** making
+any cluster changes. A failed pre-flight leaves the existing installation untouched — resolve the
+reported issue and re-run.
+
+### Verify the Upgrade
+
+After `kubev apply` completes, confirm the platform is healthy:
+
+```bash
+export KUBECONFIG=kubev-cluster-kubeconfig
+kubectl get nodes
+kubectl get pods -A
+```
+
+All platform components — including `kubev-controller-manager`, the api-server, and (if enabled)
+the dashboard — should reach `Running`. Investigate any pod stuck in `ImagePullBackOff`,
+`CrashLoopBackOff`, or `Pending`.

--- a/content/kubermatic-virtualization/main/installation/upgrading/upgrade-from-1.1-to-1.2/_index.en.md
+++ b/content/kubermatic-virtualization/main/installation/upgrading/upgrade-from-1.1-to-1.2/_index.en.md
@@ -1,0 +1,113 @@
++++
+title = "Upgrading to KubeV v1.2.0"
+date = 2026-07-24T09:00:00+02:00
+weight = 10
++++
+
+{{% notice note %}}
+Upgrading to KubeV v1.2.0 is supported from v1.1.x. If you are on an older release, upgrade step
+by step over minor versions first. It is also advised to be on the latest v1.1.x patch release
+before upgrading to v1.2.0.
+{{% /notice %}}
+
+This guide walks you through upgrading a Kubermatic Virtualization (KubeV) installation from
+v1.1.x to v1.2.0. Read the full document before starting, then follow the
+[general guidelines]({{< ref "../" >}}) (backups, minor-by-minor, repair-before-upgrade).
+
+## Pre-Upgrade Considerations
+
+### Image Pull Secret Moved to the Top Level
+
+In v1.1.x the registry pull secret was configured under `dashboard.imagePullSecret`. In v1.2.0
+the pull secret is a **top-level `imagePullSecret`** field that is applied to all platform
+components. This matters because the `kubev-controller-manager` is always deployed — even when the
+dashboard is disabled — and it reads its pull secret **only** from the top-level field.
+
+{{% notice warning %}}
+**Action required.** If your v1.1.x configuration sets the pull secret only under
+`dashboard.imagePullSecret`, move that value to the top-level `imagePullSecret` before upgrading.
+If you do not, `kubev-controller-manager` fails to pull its image and enters `ImagePullBackOff`
+(`401 UNAUTHORIZED`). In v1.2.0 the `kubev apply` pre-flight check detects the missing top-level
+field and stops with a descriptive error before making any cluster changes.
+{{% /notice %}}
+
+#### Migration Procedure
+
+Move the pull secret to the top level of your configuration file. The value is unchanged — only
+its location moves.
+
+**v1.1.x (old) — pull secret under `dashboard`:**
+
+```yaml
+apiVersion: virtualization.k8c.io/v1alpha1
+kind: KubeVCluster
+
+dashboard:
+  enabled: true
+  imagePullSecret: |
+    {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+```
+
+**v1.2.0 (new) — top-level `imagePullSecret`:**
+
+```yaml
+apiVersion: virtualization.k8c.io/v1alpha1
+kind: KubeVCluster
+
+# required for every installation — applied to all platform components
+imagePullSecret: |
+  {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+
+dashboard:
+  enabled: true
+```
+
+Alternatively, export the credentials as environment variables before running `kubev apply`, so
+nothing is stored in the file:
+
+```bash
+export KUBEV_USERNAME=myuser
+export KUBEV_PASSWORD=mypassword
+kubev apply -f cluster.yaml
+```
+
+Not sure where the field belongs? Generate an annotated example and search for `imagePullSecret`:
+
+```bash
+kubev config print --full
+```
+
+{{% notice note %}}
+Air-gapped installations that pull every image from a mirror configured under `offlineSettings`
+do not need a top-level `imagePullSecret`; in that case the pre-flight check does not require it.
+{{% /notice %}}
+
+## Upgrade Procedure
+
+1. Apply the [Migration Procedure](#migration-procedure) above to your `cluster.yaml`.
+2. Set the KubeV version in `cluster.yaml` to v1.2.0.
+3. Ensure all nodes are healthy (repair first if needed — see the
+   [general guidelines]({{< ref "../" >}})).
+4. Re-run apply:
+
+```bash
+kubev apply -f cluster.yaml
+```
+
+The pre-flight check runs first. If the top-level `imagePullSecret` (or `KUBEV_USERNAME`/
+`KUBEV_PASSWORD`) is missing on a non-air-gapped install, apply stops before changing anything —
+add the field and re-run.
+
+## Verify the Upgrade
+
+```bash
+export KUBECONFIG=kubev-cluster-kubeconfig
+kubectl get pods -A
+```
+
+Confirm `kubev-controller-manager` (and, if enabled, the api-server and dashboard) is `Running`
+and not `ImagePullBackOff`. To inspect a failing controller-manager:
+
+```bash
+kubectl -n kubermatic-virtualization describe pod -l app.kubernetes.io/name=kubev-controller-manager
+```

--- a/content/kubermatic-virtualization/v1.2.0/installation/upgrading/_index.en.md
+++ b/content/kubermatic-virtualization/v1.2.0/installation/upgrading/_index.en.md
@@ -1,0 +1,92 @@
++++
+title = "Upgrading"
+date = 2026-07-24T09:00:00+02:00
+weight = 17
++++
+
+This section contains important upgrade notes you should read **before** upgrading a
+Kubermatic Virtualization (KubeV) installation to a new version. Read the version-specific
+guide for the release you are moving to, then follow the general guidelines below.
+
+## Version-Specific Upgrade Notes
+
+{{% children %}}
+{{% /children %}}
+
+## General Guidelines
+
+The following steps apply to every KubeV upgrade.
+
+### How Upgrades Work
+
+KubeV installations are declarative, and `kubev apply` is idempotent: the same command that
+installs a cluster also upgrades it. To upgrade, update the KubeV version (and any changed
+settings) in your configuration file and re-run `kubev apply` against it — the installer
+reconciles the live system to the desired state, handling installation, upgrades, and repairs.
+
+```bash
+kubev apply -f cluster.yaml
+```
+
+Keep your `cluster.yaml` under version control and treat it as the single source of truth. See
+[Declarative Installation]({{< ref "../declarative-installation/" >}}) for the full
+configuration reference.
+
+### Upgrade One Minor Version at a Time
+
+Upgrade sequentially through minor versions (for example `v1.1.x` → `v1.2.x`) and read the
+version-specific guide for each hop. Do not skip minor versions.
+
+### Create Backups
+
+Even though regular backups should already be in place, ensure fresh backups exist before you
+start an upgrade:
+
+* **Your configuration** — keep the exact `cluster.yaml` used for the running installation, plus
+  the generated cluster kubeconfig.
+* **Cluster state** — back up etcd, or dump the Kubernetes resources you care about:
+
+```bash
+export KUBECONFIG=...
+
+while IFS= read -r crd; do
+  echo "Dumping $crd ..."
+  kubectl get "$crd" -A -o yaml > "$crd.yaml"
+done <<< "$(kubectl get crd -o name)"
+```
+
+* **Workload data** — snapshot persistent VM and application data through your storage layer (for
+  example, Longhorn volume snapshots/backups) according to your disaster-recovery process.
+
+### Repair Before You Upgrade
+
+`kubev apply` does not perform a repair and an upgrade in the same run. If nodes are unhealthy,
+first run `kubev apply` with the **current** version to repair the cluster, and only then change
+the version and re-run to upgrade.
+
+### Offline / Air-Gapped Installations
+
+In offline mode (`offlineSettings.enabled: true`) KubeV does not reach the public internet during
+upgrades. Every container image, Helm chart, and OS package for the target version must be
+pre-loaded into your internal mirrors before you upgrade.
+
+### Run the Pre-Flight Check
+
+`kubev apply` runs pre-flight checks and fails fast with a descriptive message if the
+configuration is incomplete (for example, missing image-registry credentials) **before** making
+any cluster changes. A failed pre-flight leaves the existing installation untouched — resolve the
+reported issue and re-run.
+
+### Verify the Upgrade
+
+After `kubev apply` completes, confirm the platform is healthy:
+
+```bash
+export KUBECONFIG=kubev-cluster-kubeconfig
+kubectl get nodes
+kubectl get pods -A
+```
+
+All platform components — including `kubev-controller-manager`, the api-server, and (if enabled)
+the dashboard — should reach `Running`. Investigate any pod stuck in `ImagePullBackOff`,
+`CrashLoopBackOff`, or `Pending`.

--- a/content/kubermatic-virtualization/v1.2.0/installation/upgrading/upgrade-from-1.1-to-1.2/_index.en.md
+++ b/content/kubermatic-virtualization/v1.2.0/installation/upgrading/upgrade-from-1.1-to-1.2/_index.en.md
@@ -1,0 +1,113 @@
++++
+title = "Upgrading to KubeV v1.2.0"
+date = 2026-07-24T09:00:00+02:00
+weight = 10
++++
+
+{{% notice note %}}
+Upgrading to KubeV v1.2.0 is supported from v1.1.x. If you are on an older release, upgrade step
+by step over minor versions first. It is also advised to be on the latest v1.1.x patch release
+before upgrading to v1.2.0.
+{{% /notice %}}
+
+This guide walks you through upgrading a Kubermatic Virtualization (KubeV) installation from
+v1.1.x to v1.2.0. Read the full document before starting, then follow the
+[general guidelines]({{< ref "../" >}}) (backups, minor-by-minor, repair-before-upgrade).
+
+## Pre-Upgrade Considerations
+
+### Image Pull Secret Moved to the Top Level
+
+In v1.1.x the registry pull secret was configured under `dashboard.imagePullSecret`. In v1.2.0
+the pull secret is a **top-level `imagePullSecret`** field that is applied to all platform
+components. This matters because the `kubev-controller-manager` is always deployed — even when the
+dashboard is disabled — and it reads its pull secret **only** from the top-level field.
+
+{{% notice warning %}}
+**Action required.** If your v1.1.x configuration sets the pull secret only under
+`dashboard.imagePullSecret`, move that value to the top-level `imagePullSecret` before upgrading.
+If you do not, `kubev-controller-manager` fails to pull its image and enters `ImagePullBackOff`
+(`401 UNAUTHORIZED`). In v1.2.0 the `kubev apply` pre-flight check detects the missing top-level
+field and stops with a descriptive error before making any cluster changes.
+{{% /notice %}}
+
+#### Migration Procedure
+
+Move the pull secret to the top level of your configuration file. The value is unchanged — only
+its location moves.
+
+**v1.1.x (old) — pull secret under `dashboard`:**
+
+```yaml
+apiVersion: virtualization.k8c.io/v1alpha1
+kind: KubeVCluster
+
+dashboard:
+  enabled: true
+  imagePullSecret: |
+    {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+```
+
+**v1.2.0 (new) — top-level `imagePullSecret`:**
+
+```yaml
+apiVersion: virtualization.k8c.io/v1alpha1
+kind: KubeVCluster
+
+# required for every installation — applied to all platform components
+imagePullSecret: |
+  {"auths":{"quay.io":{"auth":"<base64 of username:password>"}}}
+
+dashboard:
+  enabled: true
+```
+
+Alternatively, export the credentials as environment variables before running `kubev apply`, so
+nothing is stored in the file:
+
+```bash
+export KUBEV_USERNAME=myuser
+export KUBEV_PASSWORD=mypassword
+kubev apply -f cluster.yaml
+```
+
+Not sure where the field belongs? Generate an annotated example and search for `imagePullSecret`:
+
+```bash
+kubev config print --full
+```
+
+{{% notice note %}}
+Air-gapped installations that pull every image from a mirror configured under `offlineSettings`
+do not need a top-level `imagePullSecret`; in that case the pre-flight check does not require it.
+{{% /notice %}}
+
+## Upgrade Procedure
+
+1. Apply the [Migration Procedure](#migration-procedure) above to your `cluster.yaml`.
+2. Set the KubeV version in `cluster.yaml` to v1.2.0.
+3. Ensure all nodes are healthy (repair first if needed — see the
+   [general guidelines]({{< ref "../" >}})).
+4. Re-run apply:
+
+```bash
+kubev apply -f cluster.yaml
+```
+
+The pre-flight check runs first. If the top-level `imagePullSecret` (or `KUBEV_USERNAME`/
+`KUBEV_PASSWORD`) is missing on a non-air-gapped install, apply stops before changing anything —
+add the field and re-run.
+
+## Verify the Upgrade
+
+```bash
+export KUBECONFIG=kubev-cluster-kubeconfig
+kubectl get pods -A
+```
+
+Confirm `kubev-controller-manager` (and, if enabled, the api-server and dashboard) is `Running`
+and not `ImagePullBackOff`. To inspect a failing controller-manager:
+
+```bash
+kubectl -n kubermatic-virtualization describe pod -l app.kubernetes.io/name=kubev-controller-manager
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an Upgrading section to the Kubermatic Virtualization docs (v1.2.0 and main),
modeled on the KKP upgrading guide. Includes general upgrade guidelines (declarative
`kubev apply` reconcile model, backups, minor-by-minor, repair-before-upgrade, offline,
pre-flight, verification) and a v1.1.x→v1.2.0 guide covering the `imagePullSecret` move
to the top level. 
