### PR TITLE
Document customSecrets in the KubeOne credentials file guide

### DIFF
--- a/content/kubeone/main/guides/credentials/_index.md
+++ b/content/kubeone/main/guides/credentials/_index.md
@@ -294,6 +294,32 @@ For Docker Hub you need to name the registry key `registry-1.docker.io`. Just
 `docker.io` will not work.
 {{% /notice %}}
 
+### customSecrets
+
+Besides the provider credentials known to KubeOne, you can provide arbitrary,
+user-defined secrets under the `customSecrets` key. Values placed here are
+made available to [addon]({{< ref "../addons/" >}}) templates -- both
+built-in and custom addons -- as `.CustomCredentials.<<KEY>>`, so you no
+longer have to pass secrets through `kubeone.yaml`'s `Addon.Params`, which is
+typically committed to version control and not meant for secrets.
+
+Example:
+```yaml
+customSecrets: |
+  MY_APP_TOKEN: "<<MY_APP_TOKEN>>"
+  ANOTHER_KEY: "<<ANOTHER_VALUE>>"
+```
+
+The values can then be referenced in an addon manifest, for example:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-app-secret
+stringData:
+  token: "{{ .CustomCredentials.MY_APP_TOKEN }}"
+```
+
 ## Environment Variables in the Configuration Manifest
 
 KubeOne can source values for supported fields in the configuration manifest


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents the `customSecrets` key that was added to the KubeOne credentials file in [kubermatic/kubeone#4156](https://github.com/kubermatic/kubeone/pull/4156) (fixing [kubermatic/kubeone#3927](https://github.com/kubermatic/kubeone/issues/3927)). The new section is added to `content/kubeone/main/guides/credentials/_index.md`, right after the existing `registriesAuth` section, following the same style/format as the existing `cloudConfig` / `csiConfig` / `registriesAuth` subsections on that page.

Related: kubermatic/kubeone#3927 (already closed by the linked kubeone PR)
