### PR TITLE
kubelb: document Insights

### DIFF
--- a/content/kubelb/main/insights/_index.en.md
+++ b/content/kubelb/main/insights/_index.en.md
@@ -1,0 +1,174 @@
++++
+title = "Insights"
+linkTitle = "Insights"
+date = 2026-07-29T10:00:00+02:00
+weight = 27
++++
+
+The management cluster sees every tenant's effective configuration, every route, every policy and every budget. Insights is the part of KubeLB that reads all of it and tells you what is wrong.
+
+Findings are `Insight` objects. One per problem, in the namespace of the tenant it concerns, readable with `kubectl` and manageable through GitOps like anything else in the cluster.
+
+```bash
+kubectl get insights -A
+```
+
+```
+NAMESPACE     NAME              CHECK    SEVERITY   STATE   AGE
+kubelb        klb002-9f31ab04   KLB002   high       Open    4m
+tenant-acme   klb014-3fa2c81b   KLB014   high       Open    4m
+```
+
+Every check is a plain function of cluster state. The same configuration always produces the same findings, and no finding means the check ran and passed. Nothing is sampled, and no model is involved.
+
+Insights are for the platform operator. They live in tenant namespaces but are not part of the tenant RBAC allowlist, so tenants never see fleet-relative judgements about their configuration.
+
+## What it catches
+
+Most checks look at one tenant. The interesting ones need the whole fleet, which is why they can only run here:
+
+- Two tenants claiming the same hostname. Both believe they own it, and neither cluster can see the other.
+- A tenant whose certificate request was silently dropped because the hostname sits outside its allowed domains. From inside that tenant cluster it looks like cert-manager is broken.
+- A tenant that does not enforce ReferenceGrants, or runs without network policies, while the rest of the fleet does.
+- A quota about to refuse the next resource, with nothing but a controller log to explain the refusal.
+
+The [check catalog]({{% relref "./checks/" %}}) lists all of them.
+
+## Turning it off
+
+The engine runs by default. To disable it:
+
+```yaml
+kubelb:
+  enableInsights: false
+```
+
+Leaving it on is quiet. Checks declare the features they need, so an installation without the WAF or the AI gateway skips those checks rather than reporting everything they cover as broken. Several other checks compare tenants against each other and stay silent unless one differs from its peers. The rest wait out an age or usage threshold. A healthy installation reports nothing.
+
+## Reading a finding
+
+```yaml
+apiVersion: kubelb.k8c.io/v1alpha1
+kind: Insight
+metadata:
+  name: klb014-3fa2c81b
+  namespace: tenant-acme
+  labels:
+    kubelb.k8c.io/insight-check: KLB014
+    kubelb.k8c.io/insight-severity: high
+    kubelb.k8c.io/insight-category: reliability
+spec:
+  check: KLB014
+  slug: hostname-collision
+  severity: high
+  message: Ingress shop claims api.example.com, also claimed by globex. Traffic for it resolves to whichever claim the dataplane programmed last.
+  targetRefs:
+    - apiVersion: kubelb.k8c.io/v1alpha1
+      kind: Route
+      name: 4f2c1a90-...
+      namespace: tenant-acme
+  remediation:
+    summary: Decide which tenant owns the hostname and change the other, or scope the hostname per tenant with spec.allowedDomains so the conflict cannot recur.
+  docsURL: https://docs.kubermatic.com/kubelb/main/insights/checks/#klb014
+status:
+  state: Open
+  firstSeen: "2026-07-29T09:12:04Z"
+  lastEvaluated: "2026-07-29T09:24:07Z"
+```
+
+`evidence` points at the live objects behind the finding rather than copying them, so an insight cannot disagree with the state it describes. `remediation` is text: KubeLB never applies it.
+
+Findings are labelled, so you can list by check, severity or category:
+
+```bash
+kubectl get insights -A -l kubelb.k8c.io/insight-severity=high
+```
+
+## Triage
+
+`spec.triage` is yours. The engine reads it and never writes it, so your decision survives sweeps, manager restarts and a GitOps re-apply.
+
+```yaml
+spec:
+  triage:
+    state: Dismissed
+    reason: working_as_intended
+```
+
+| State | Meaning |
+|-------|---------|
+| unset | The finding is open. |
+| `Acknowledged` | You have seen it and intend to fix it. It stays visible and keeps counting. |
+| `Snoozed` | Hidden until `snoozeUntil`, then it reopens by itself. `snoozeUntil` is required. |
+| `Dismissed` | Closed for good. `reason` is required: `working_as_intended`, `accepted_risk`, `false_positive`, `low_priority` or `other`. |
+
+Dismissal survives re-detection. A dismissed finding that keeps reproducing stays dismissed, which is what dismissal means in a fleet where an unusual tenant configuration is often deliberate.
+
+`status.state` combines your triage with what the checks currently see. When a check stops detecting a finding, the engine sets `Fixed` with a timestamp and deletes the object a day later. `Fixed` is always machine-observed. If the problem returns, the same object reopens with its original `firstSeen`, so a flapping configuration reads as one long-lived issue rather than a series of new ones.
+
+## Suppressing a check
+
+A check that does not suit your installation can be switched off for the whole fleet:
+
+```yaml
+apiVersion: kubelb.k8c.io/v1alpha1
+kind: Config
+metadata:
+  name: default
+  namespace: kubelb
+spec:
+  insights:
+    disabledChecks:
+      - KLB010
+```
+
+Its findings are deleted rather than marked fixed, because a check that did not run has concluded nothing. The same applies to a check whose feature is unavailable, such as the WAF checks on an installation running without `--enable-waf`. Those are skipped and counted, never reported as passing.
+
+Prefer dismissing individual findings. A dismissal keeps the check working for everything else it covers.
+
+## Posture score
+
+Alongside the findings, KubeLB scores what it examined:
+
+```
+kubelb_manager_posture_score{tenant="acme", category="security"}  0.83
+kubelb_manager_posture_score{tenant="acme", category=""}          0.91
+```
+
+The empty category is the tenant's overall score, so you can rank tenants without adding up categories. The formula is the share of examined objects with no problem, counting high-severity findings in full and lower-severity ones at half:
+
+```
+passing / (passing + high + 0.5 * low)
+```
+
+Informational findings are observations rather than problems and do not count. Dismissed and snoozed findings leave both sides of the calculation, so triage cannot move a score in either direction. A tenant with nothing applicable to measure exports no score rather than a perfect one.
+
+## Metrics and alerts
+
+| Metric | Description |
+|--------|-------------|
+| `kubelb_manager_insights` | Open or acknowledged findings by `tenant`, `severity`, `category` and `check_id`. |
+| `kubelb_manager_posture_score` | Posture between 0 and 1 by `tenant` and `category`. |
+| `kubelb_manager_insights_sweep_duration_seconds` | Duration of a full sweep. |
+| `kubelb_manager_insights_checks_skipped_total` | Checks that did not run, by reason. |
+| `kubelb_manager_insights_checks_failed_total` | Checks that failed to evaluate. |
+
+`kubelb_manager_insight_info` emits one series per finding, naming the affected object for alerts that need it. Object names are unbounded label values, so it is off by default:
+
+```yaml
+kubelb:
+  insights:
+    perFindingMetrics: true
+```
+
+With `prometheusRule.enabled`, the chart ships four alerts: a critical finding that survives several sweeps, a tenant posture below 60% for an hour, a check that panicked, and a sweep loop that stopped. The `KubeLB / Insights` Grafana dashboard covers fleet posture, a tenant league table ordered worst first, and a table ranking checks by how many findings they account for.
+
+Events are emitted when a finding opens, is fixed, or reopens. Never on every sweep.
+
+## How the sweep works
+
+The engine evaluates the whole registry every three minutes, and immediately when the `Config`, a `Tenant`, or a finding's triage changes. It reads the caches the manager already maintains, so a sweep costs no extra API traffic. A check that panics loses its own findings for that round and nothing else.
+
+Because the sweep is idempotent, a manager restart changes nothing. Triage lives on the objects, `firstSeen` is preserved, and the next sweep re-derives the rest.
+
+One limit worth knowing: the engine reads the xDS cache in its own process, and the control plane runs on every manager replica while the sweep runs only on the leader. Findings about the dataplane therefore describe the replica that observed them, and say so.

--- a/content/kubelb/main/insights/checks/_index.en.md
+++ b/content/kubelb/main/insights/checks/_index.en.md
@@ -1,0 +1,173 @@
++++
+title = "Check Catalog"
+linkTitle = "Check Catalog"
+date = 2026-07-29T10:00:00+02:00
+weight = 10
++++
+
+Every check the insights engine runs. Check IDs are permanent: findings, the `kubelb.k8c.io/insight-check` label, `Config.spec.insights.disabledChecks` and these links all use them.
+
+Some checks need a feature to be meaningful. A WAF check on an installation without the WAF would report every route as unprotected, so instead it is skipped and counted in `kubelb_manager_insights_checks_skipped_total`.
+
+| Capability | Comes from |
+|------------|------------|
+| WAF | The `--enable-waf` manager flag |
+| AI | `Config.spec.ai.enabled` |
+| SpendData | `Config.spec.prometheus`, without which no key reports its spend |
+| EnvoyCache | The manager's own xDS snapshot cache |
+
+## KLB001
+
+`waf-detection-only` · security · medium · needs WAF
+
+A WAF policy has run with `SecRuleEngine DetectionOnly` or `Off` for more than two weeks. It inspects and logs, and blocks nothing. SecLang has no separate audit-mode field, so this state is easy to leave behind after tuning and hard to notice afterwards.
+
+Set `SecRuleEngine On` in the policy directives, or delete the policy if it is no longer wanted. Dismiss with `working_as_intended` if you deliberately run a logging-only ruleset.
+
+## KLB002
+
+`waf-validation-disabled` · security · high · needs WAF
+
+`spec.waf.skipValidation` is set while WAF policies exist. Every policy is reported as valid without its directives being parsed, so a malformed rule set is only discovered by Envoy at request time.
+
+Unset the field and fix whichever policy then fails validation.
+
+## KLB003
+
+`xds-endpoint-truncation` · reliability · high
+
+A workload resolves to more upstream addresses than `spec.envoyProxy.maxEndpointsPerCluster` allows. The surplus never reaches Envoy and those backends receive no traffic. Nothing else reports this.
+
+Raise the limit above the largest endpoint count, or reduce the number of endpoints behind the service.
+
+## KLB004
+
+`ai-budget-unenforceable` · cost · medium · needs AI
+
+A tenant has a Day-window budget, but no rate-limit service is configured, so nothing caps traffic inside the day. Set `spec.ai.rateLimitService` on the `Config`.
+
+## KLB005
+
+`ai-spend-metering-disabled` · cost · low · needs AI
+
+The tenant uses the AI gateway and no Prometheus is configured, so no key reports its spend and Week and Month budgets are not enforced. Set `spec.prometheus` on the `Config`.
+
+## KLB006
+
+`ai-throttle-unenforced` · cost · low · needs AI
+
+A budget asks for `onExceed: Throttle`, which this release does not enforce inline. Matching traffic is not throttled once the budget is exhausted, though usage is still metered. Use `onExceed: Block` if the cap has to hold.
+
+## KLB007
+
+`ai-unbudgeted-tenant` · cost · high · needs AI
+
+A tenant can use the AI gateway with no budget at all. Its token and dollar spend is unlimited, and you find out when the provider bill arrives.
+
+Set budgets on the `Tenant`, or `spec.ai.defaultBudgets` on the `Config` to cover every tenant that does not set its own.
+
+## KLB008
+
+`ai-key-never-expires` · security · medium · needs AI
+
+A provisioned key has no expiry, because neither the key nor the tenant policy sets one. It stays valid on the gateway until somebody deletes it.
+
+Set `spec.ai.virtualKeys.maxTTL` on the `Tenant` or `Config` so keys expire by default.
+
+## KLB009
+
+`ai-key-rejected` · hygiene · low · needs AI
+
+A tenant's key has been stuck in `Rejected` for more than a day, usually because the tenant key quota is full or the key's budgets exceed the tenant's. The tenant is waiting for a key that will never provision itself.
+
+Read the key's `Accepted` condition, then raise the tenant's `virtualKeys.limit`, fix the budgets, or delete the key.
+
+## KLB010
+
+`deprecated-proxy-topology` · hygiene · info
+
+`spec.envoyProxy.topology` is `dedicated` or `global`. Both are deprecated and already behave as `shared`, so nothing is wrong with your traffic today. The field only accepts a change back to `shared`, so leaving it will fail a future upgrade.
+
+## KLB011
+
+`reference-grants-disabled` · security · medium
+
+This tenant accepts cross-namespace backend and TLS certificate references without a `ReferenceGrant`, while other tenants in the fleet require one. The finding is comparative on purpose: a fleet that uniformly does not enforce grants has made a choice, and one tenant differing from its peers is usually an oversight.
+
+Set `spec.gatewayAPI.enforceReferenceGrants` on the `Tenant`, or on the `Config` for everyone.
+
+## KLB012
+
+`backend-transport-change-pending` · hygiene · info
+
+A `backendTransport` mode change is configured but was never confirmed, so the tenant still runs the old topology and the `Config` disagrees with the running dataplane. Annotate the `Config` with `kubelb.k8c.io/confirm-backend-transport-change` set to the target mode, or revert the change.
+
+## KLB013
+
+`ingress-conversion-stuck` · migration · medium
+
+An Ingress did not finish converting to Gateway API and is stuck as pending, partial or failed. Read `kubelb.k8c.io/conversion-warnings` on the source Ingress and fix what the converter could not translate, or annotate it with `kubelb.k8c.io/skip-conversion` to leave it as an Ingress.
+
+## KLB014
+
+`hostname-collision` · reliability · high
+
+Two tenants claim the same hostname. Both believe they own it, and traffic resolves to whichever claim the dataplane programmed last. Neither tenant cluster can see the other, so this is invisible from both sides and only the management cluster can detect it.
+
+Decide which tenant owns the hostname and change the other. To prevent it recurring, scope hostnames per tenant with `spec.allowedDomains`.
+
+## KLB015
+
+`cert-annotations-stripped` · security · high
+
+A tenant asked for a certificate and KubeLB removed the cert-manager annotations, because certificate automation is disabled for the tenant or the hostname falls outside `spec.certificates.allowedDomains`. No certificate is issued and nothing says why. From inside the tenant cluster this looks like cert-manager is broken.
+
+Add the hostname to the tenant's certificate `allowedDomains`, clear `spec.certificates.disable`, or tell the tenant the hostname is not permitted. Dismiss with `working_as_intended` when the refusal is deliberate and the tenant knows.
+
+## KLB016
+
+`waf-unprotected-route` · security · high · needs WAF
+
+An HTTP route serves traffic with no WAF policy while other tenants' routes are protected. Coverage is resolved with the same resolvers the dataplane uses, so a route counted as protected here is one Envoy actually filters.
+
+Attach a `WAFPolicy` to the route, or set one with `spec.global` to cover everything without a policy of its own.
+
+## KLB017
+
+`waf-failure-mode-asymmetry` · security · low · needs WAF
+
+This tenant lets its own policies decide what happens when the WAF filter fails to load, while its peers are forced closed. A tenant policy that fails to load passes traffic here and blocks it elsewhere.
+
+Set `spec.waf.enforceFailureMode` on the `Tenant`, or on the `Config` for the fleet.
+
+## KLB018
+
+`quota-headroom` · reliability · medium or high
+
+A tenant is at 80% of a limit, or 95% for the higher severity. Past the limit, new resources are refused with nothing but a controller log to explain it, and the tenant sees no error in its own cluster.
+
+Raise the limit on the `Tenant` or `Config`, or have the tenant remove what it no longer uses.
+
+## KLB019
+
+`ai-budget-threshold-crossed` · cost · high · needs AI and SpendData
+
+A key has spent past the `alertThresholdPercent` its budget asks for. Depending on `onExceed`, the next step is a hard stop mid-window.
+
+Raise the budget, or tell the tenant before the cap trips.
+
+## KLB020
+
+`netpol-asymmetry` · security · low
+
+This tenant's namespace has no managed network policies while its peers do, so it accepts traffic inside the management cluster that the others refuse. Set `spec.networkPolicy.enable` on the `Tenant`, or on the `Config`.
+
+## KLB021
+
+`xds-snapshot-missing` · reliability · critical · needs EnvoyCache
+
+The tenant has admitted traffic configuration that never reached the Envoy control plane, so its dataplane is serving nothing. Configuration younger than five minutes is treated as still in flight, and rejected routes are ignored because they are meant to be absent.
+
+Check the manager logs for the Envoy control plane controller and this tenant's namespace. The configuration exists and was admitted, so the gap sits between admission and the snapshot.
+
+This check reads the cache in the manager replica that ran the sweep. The control plane runs on every replica, so a clean result means that replica's view is complete rather than the whole fleet's.


### PR DESCRIPTION
Documents KubeLB Insights: what the engine reports, how to triage a finding, how to suppress a check, and the posture score.

Two pages under a new `insights` chapter: the guide, and a check catalog with one section per check. Findings link into the catalog by anchor.