### PR TITLE
docs: clarify KubeLB mTLS and WAF flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules
 
 # vscode related files
 .vscode/
+.worktrees/

--- a/content/kubelb/main/installation/management-cluster/_index.en.md
+++ b/content/kubelb/main/installation/management-cluster/_index.en.md
@@ -69,7 +69,7 @@ helm upgrade --install kubelb-manager kubelb-manager-ee --namespace kubelb -f ku
 | kubelb.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables Envoy Gateway support for BackendTrafficPolicy and ClientTrafficPolicy. Use this if you're using a Gateway API implementation other than Envoy Gateway. |
 | kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
 | kubelb.enableLeaderElection | bool | `true` |  |
-| kubelb.enableWAF | bool | `false` | [Alpha Feature] enableWAF enables the WAF controller for Web Application Firewall policy validation. WAF is an alpha feature and is disabled by default. |
+| kubelb.enableWAF | bool | `false` | [Beta feature] Enables Web Application Firewall policy validation and reconciliation. WAF is disabled by default. |
 | kubelb.envoyProxy.affinity | object | `{}` |  |
 | kubelb.envoyProxy.gracefulShutdown.disabled | bool | `false` | Disable graceful shutdown (default: false) |
 | kubelb.envoyProxy.nodeSelector | object | `{}` |  |

--- a/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "mTLS Backend Transport"
 linkTitle = "mTLS Backend Transport"
+description = "Encrypt KubeLB backend traffic between management and tenant clusters with mutual TLS."
 date = 2026-05-07T10:00:00+02:00
 weight = 45
 enterprise = true
@@ -14,18 +15,23 @@ mTLS backend transport is a **Beta / Technical Preview** feature (see [Kubermati
 
 KubeLB can encrypt backend traffic between the management cluster and tenant clusters with mutual TLS (mTLS). When enabled, KubeLB deploys a tenant-local Envoy Proxy and routes management-to-tenant backend traffic through it.
 
-Default `Direct` mode:
+```mermaid
+flowchart TB
+  subgraph direct["Direct mode"]
+    direction LR
+    DC["Client"] --> DM["KubeLB Envoy<br/>management cluster"]
+    DM -->|"Plain backend connection"| DN["Tenant node<br/>NodePort"]
+    DN --> DB["Backend Service + pod"]
+  end
 
-```text
-Client -> KubeLB Envoy -> tenant node:NodePort -> backend pod
-```
+  subgraph mtls["mTLS mode"]
+    direction LR
+    MC["Client"] --> MM["KubeLB Envoy<br/>management cluster"]
+    MM -->|"TLS 1.3 + mutual authentication"| TP["Tenant Envoy<br/>tenant cluster"]
+    TP --> MB["Backend Service + pod"]
+  end
 
-`MTLS` mode:
-
-```text
-Client -> KubeLB Envoy
-       -> [TLS 1.3 with mutual authentication]
-       -> kubelb-tenant-envoy -> backend Service -> backend pod
+  DB ~~~ MC
 ```
 
 Application teams keep using the same Kubernetes resources: `LoadBalancer` Services, `Ingress`, and Gateway API routes. The backend transport change is handled by KubeLB.
@@ -39,7 +45,10 @@ UDPRoute uses a CONNECT-UDP tunnel over the same mTLS tenant proxy port; see [UD
 ## Prerequisites
 
 - A KubeLB Enterprise Edition license; the feature ships in the `kubelb-manager-ee` chart.
-- The management cluster must be able to reach tenant cluster nodes on Kubernetes NodePort ranges. In `MTLS` mode with the default `NodePort` Service type, the tenant cluster exposes `kubelb-tenant-envoy` as a `NodePort` Service in the tenant `kubelb` namespace, and management Envoy connects to tenant node addresses on the assigned NodePort. TCP backends and UDPRoute tunnels share the same tenant proxy port. With `tenantProxy.serviceType: LoadBalancer` (see [Tenant proxy and UDP configuration](#tenant-proxy-and-udp-configuration)), the management cluster must instead reach the tenant proxy's load balancer address on the fixed port 15443. With static addresses configured on the CCM (see [Tenant-side exposure overrides](#tenant-side-exposure-overrides)), the management cluster must reach those addresses on the configured port.
+- The management cluster must be able to reach the tenant proxy. The required destination depends on how the proxy is exposed:
+  - **NodePort (default):** tenant node addresses on the assigned NodePort. TCP backends and UDPRoute tunnels share this port.
+  - **LoadBalancer:** the tenant proxy load balancer address on TCP port `15443`. See [Tenant proxy and UDP configuration](#tenant-proxy-and-udp-configuration).
+  - **Static addresses:** every address configured on the CCM, using its configured port. See [Tenant-side exposure overrides](#tenant-side-exposure-overrides).
 
 Check the tenant proxy Service:
 

--- a/content/kubelb/main/tutorials/web-application-firewall/_index.en.md
+++ b/content/kubelb/main/tutorials/web-application-firewall/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "Web Application Firewall (Beta)"
 linkTitle = "Web Application Firewall"
+description = "Protect KubeLB Layer 7 routes with centrally managed Coraza and OWASP Core Rule Set policies."
 date = 2026-01-23T10:00:00+02:00
 weight = 30
 enterprise = true
@@ -19,9 +20,9 @@ Unlike a WAF deployed per cluster, KubeLB manages WAF policies for the whole fle
 - KubeLB Enterprise Edition.
 - Gateway API support enabled in the manager (`kubelb.enableGatewayAPI: true`). WAF applies to Layer 7 Gateway API routes (`HTTPRoute`, `GRPCRoute`) served by Envoy Proxy.
 
-## Supported Routes
+## Supported routes
 
-| Route Type | Supported |
+| Resource or route type | Supported |
 |-----------|-----------|
 | HTTPRoute | Yes |
 | GRPCRoute | Yes |
@@ -45,7 +46,7 @@ kubelb:
 
 ## WAFPolicy CRD
 
-To manage WAF policies, you can use the `WAFPolicy` CRD which is a **cluster-scoped** resource. The following is an example of a `WAFPolicy` CRD:
+Manage fleet-wide WAF policies with the cluster-scoped `WAFPolicy` CRD:
 
 ```yaml
 apiVersion: kubelb.k8c.io/v1alpha1
@@ -64,7 +65,7 @@ spec:
 
 ## Targeting
 
-Three mutually exclusive targeting modes:
+Each `WAFPolicy` uses one of three mutually exclusive targeting modes:
 
 1. **`targetRef`**: Target a specific route by name/namespace/kind
 2. **`targetSelector`**: Match routes by label selector (checks both Route CR labels and embedded source route labels; Route CR labels win on conflict)
@@ -186,6 +187,27 @@ Tenant input is untrusted, so directives run through a strict allowlist before t
 ### How admin and tenant policies combine
 
 Admin and tenant policies are two independent layers. A route can pick up one of each, and when it does, both run as separate WAF engines chained back to back: admin first, tenant second. A request is blocked if either engine blocks it, so a tenant can only add protection on top of the operator's baseline, never weaken it.
+
+```mermaid
+flowchart TB
+  subgraph selection["Policy resolution"]
+    direction LR
+    AdminPolicy["Admin WAFPolicy<br/>global · selector · targetRef"] --> AdminMatch["Resolve matching<br/>admin policy"]
+    TenantPolicy["TenantWAFPolicy<br/>default · selector · targetRef"] --> TenantMatch["Validate guardrails<br/>and resolve"]
+  end
+
+  subgraph traffic["Request path"]
+    direction LR
+    Request["Layer 7 request"] --> AdminEngine["Admin Coraza engine<br/>when matched"]
+    AdminEngine -->|"allow"| TenantEngine["Tenant Coraza engine<br/>when matched"]
+    TenantEngine -->|"allow"| Upstream["Upstream Service"]
+    AdminEngine -->|"block"| Block["Blocked response"]
+    TenantEngine -->|"block"| Block
+  end
+
+  AdminMatch -.->|"configure"| AdminEngine
+  TenantMatch -.->|"configure"| TenantEngine
+```
 
 | Admin policy | Tenant policy | Result |
 |---|---|---|


### PR DESCRIPTION
## What changed

- add focused Mermaid request flows to the mTLS backend transport and WAF tutorials
- clarify direct versus mTLS backend routing and WAF policy resolution
- correct adjacent prerequisites, terminology, and feature-stage copy
- persist `.worktrees/` in `.gitignore`

## Why

The tutorials described multi-cluster request paths in prose and large media, making the control and data flow difficult to scan. The new diagrams explain only the flows that benefit from a sequence view while retaining the existing high-level visuals.

## Impact

Readers can distinguish direct and mTLS routing and understand where WAF policies are resolved and enforced without changing any product behavior.

## Validation

- full Hugo build: 6,086 pages
- Chrome visual review of both tutorials and Mermaid rendering

