### PR TITLE
docs: improve KubeLB architecture clarity

### DIFF
--- a/content/kubelb/main/architecture/_index.en.md
+++ b/content/kubelb/main/architecture/_index.en.md
@@ -14,17 +14,22 @@ This chapter uses the following KubeLB-specific terms:
 1. **Management Cluster** (also called the load balancing cluster): A Kubernetes cluster responsible for managing all tenants and their data plane components. Requests for Layer 4 and Layer 7 load balancing are handled by the management cluster.
 2. **Tenant Cluster**: A Kubernetes cluster that consumes the load balancer services. Workloads that need Layer 4 or Layer 7 load balancing are created in the tenant cluster. The tenant cluster hosts the KubeLB Cloud Controller Manager (CCM), which propagates the load balancer configurations to the management cluster. Each Kubernetes cluster where the KubeLB CCM runs is a unique tenant, because its endpoints (the node IPs and node ports) are unique to that cluster.
 
-## Design and Architecture
+## Design and architecture
 
-KubeLB follows the **hub and spoke** model: the management cluster is the hub and the tenant clusters are the spokes. Information flows from the tenant clusters to the management cluster. The agent running in the tenant cluster watches nodes, services, ingresses, and Gateway API resources and propagates the configuration to the management cluster. The management cluster deploys the load balancer, configures it according to the desired specification, and uses Envoy Proxy to route traffic to the appropriate endpoints, the node ports open on the nodes of the tenant cluster.
+KubeLB follows a **hub-and-spoke** model: the management cluster is the hub and tenant clusters are the spokes.
+
+1. The KubeLB CCM in each tenant cluster watches nodes, Services, Ingresses, Secrets, and Gateway API resources.
+2. The CCM validates relevant resources and synchronizes the desired state to the tenant's namespace in the management cluster.
+3. The KubeLB manager reconciles that state into load balancer infrastructure and Envoy configuration.
+4. Envoy routes external traffic to NodePort endpoints in the tenant cluster.
 
 For security and isolation, tenants have no access to native Kubernetes resources in the management cluster. They interact with it only through the KubeLB CRDs, which limits them to controlled operations within their access level.
 
-![KubeLB Architecture](/img/kubelb/v1.1/kubelb-high-level-architecture.png?classes=shadow,border "KubeLB Architecture")
+![A management cluster runs KubeLB Manager and Envoy for multiple tenant clusters, while a KubeLB CCM in each tenant cluster synchronizes desired state and status.](/img/kubelb/v1.1/kubelb-high-level-architecture.png?classes=shadow,border "KubeLB management and tenant cluster architecture")
 
 ## Components
 
-KubeLB consists of two components:
+KubeLB has two control-plane components:
 
 ### Cloud Controller Manager
 
@@ -38,21 +43,21 @@ The **KubeLB manager** is responsible for managing the data plane of its tenants
 
 At its core, the KubeLB manager relies on [Envoy Proxy][1] to load balance the traffic. The manager is responsible for deploying Envoy Proxy and configuring it for each load balancer service per tenant, based on the Envoy Proxy deployment topology.
 
-## Personas
+## Personas and responsibilities
 
-KubeLB targets the following personas:
+KubeLB uses the following personas, based on the [Gateway API persona model](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/):
 
-1. Platform Provider: The Platform Provider is responsible for the overall environment that the cluster runs in, i.e. the cloud provider. The Platform Provider will interact with GatewayClass resources.
-2. Platform Operator: The Platform Operator is responsible for overall cluster administration. They manage policies, network access, application permissions and will interact with Gateway resources.
-3. Service Operator: The Service Operator is responsible for defining application configuration and service composition. They will interact with HTTPRoute and TLSRoute resources and other typical Kubernetes resources.
+| Persona | Scope | Primary responsibilities | Typical resources |
+| --- | --- | --- | --- |
+| Platform Provider | Management cluster and underlying infrastructure | Operates KubeLB, provides load balancing infrastructure, and defines available implementations | `GatewayClass`, KubeLB `Config`, `Tenant` |
+| Platform Operator | Tenant-cluster platform | Manages shared networking, policies, permissions, and application entry points | `Gateway`, policy resources, namespaces |
+| Service Operator | Application workloads | Defines how application traffic is matched, secured, and routed to Services | `HTTPRoute`, `GRPCRoute`, `TCPRoute`, `TLSRoute`, `Service` |
 
-Inspired by [Gateway API Personas](https://gateway-api.sigs.k8s.io/#personas).
-
-Service Operator and Platform Operator are more or less the same persona in KubeLB and they are responsible for defining the load balancer configurations in tenant cluster. Platform Provider is the "KubeLB provider" and manages the management cluster.
+One team may perform both the Platform Operator and Service Operator roles, but the responsibilities and permissions remain distinct. The Platform Provider operates the management cluster; the other roles work primarily in tenant clusters.
 
 ## Concepts
 
-### Envoy Proxy Deployment Topology
+### Envoy Proxy deployment topology
 
 KubeLB manager deploys Envoy Proxy using the **shared** topology: a single Envoy Proxy is deployed per tenant cluster, and all load balancer services in that tenant cluster are routed through it.
 
@@ -64,11 +69,11 @@ The `global` Envoy Proxy topology available in KubeLB v1.3 and earlier has been 
 
 Existing workflows for managing Layer 4 and Layer 7 workloads should keep working with as little change as possible. Once the CCM is configured, the only difference for end users is to use the class **kubelb** for their resources instead of a provider-specific class.
 
-### Kubernetes Class
+### Kubernetes classes
 
-Class is a concept in Kubernetes that is used to mark the ownership of a resource. For example, an Ingress with `class: nginx` will be owned by a controller that implements the IngressClass named `nginx`. The same concept exists for services and Gateway API resources. By default, KubeLB only processes resources that carry its class; this behavior can be changed by overriding the CCM configuration.
+A Kubernetes class identifies the controller responsible for a resource. For example, an Ingress that references the `nginx` IngressClass is handled by the controller that implements that class. Equivalent class-selection mechanisms exist for Services and Gateway API resources. By default, KubeLB processes only resources that select its class; CCM configuration can change this behavior.
 
-## Table of Contents
+## Related architecture pages
 
 {{% children depth=5 %}}
 {{% /children %}}

--- a/content/kubelb/main/architecture/application-load-balancing/_index.en.md
+++ b/content/kubelb/main/architecture/application-load-balancing/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "Application Load Balancing"
 date = 2023-10-27T10:07:15+02:00
+description = "How KubeLB provides centralized Layer 7 routing, DNS, and TLS for tenant-cluster applications."
 weight = 10
 +++
 
@@ -8,7 +9,7 @@ This document explains the architecture for Layer 7 (application layer) load bal
 
 ## Background
 
-KubeLB manages the data plane of a fleet of tenant clusters from a central management cluster, providing Layer 4 and Layer 7 load balancing through a single platform. Layer 7 support, introduced in v1.1, covers application-level load balancing including DNS management and TLS management and termination.
+KubeLB manages the data plane for a fleet of tenant clusters from a central management cluster. Layer 7 capabilities include application routing, DNS management, and TLS certificate management and termination.
 
 ### Challenges
 
@@ -26,11 +27,11 @@ For Layer 7 requests, KubeLB automatically creates a `NodePort` service against 
 
 ### Lifecycle of a request
 
-1. Developer creates a deployment, service, and Ingress.
-2. KubeLB evaluates if the service is of type ClusterIP and generates a NodePort service against it.
-3. After validation, the KubeLB CCM propagates these resources from the tenant to the management cluster using the `Route` CRD.
-4. The KubeLB manager copies/creates the corresponding resources in the tenant namespace in the management cluster.
-5. The KubeLB CCM polls for the updated status of the Ingress and updates the status when available.
-6. The KubeLB manager starts routing the traffic for your resource.
+1. A Service Operator creates a workload, a `ClusterIP` Service, and an Ingress or Gateway API route in a tenant cluster.
+2. The KubeLB CCM validates the resources and ensures that a NodePort Service exposes the backend to the management cluster.
+3. The CCM synchronizes a `Route` resource and its dependencies to the tenant's namespace in the management cluster.
+4. The KubeLB manager reconciles the required Envoy, DNS, and certificate configuration.
+5. The CCM mirrors the assigned address and readiness status back to the original tenant resource.
+6. Envoy accepts external traffic and forwards it to the tenant cluster's NodePort endpoints.
 
-![KubeLB Architecture](/img/kubelb/v1.1/layer7-architecture.png?classes=shadow,border "KubeLB Architecture")
+![An Ingress or Gateway API route is synchronized from a tenant cluster to the management cluster, where KubeLB configures Envoy, DNS, and TLS before routing traffic back to tenant NodePorts.](/img/kubelb/v1.1/layer7-architecture.png?classes=shadow,border "KubeLB Layer 7 request lifecycle")

--- a/content/kubelb/main/architecture/layer-4-load-balancing/_index.en.md
+++ b/content/kubelb/main/architecture/layer-4-load-balancing/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "Layer 4 Load Balancing"
 date = 2023-10-27T10:07:15+02:00
+description = "How KubeLB provisions centralized TCP and UDP load balancing for tenant-cluster Services."
 weight = 5
 +++
 
@@ -18,10 +19,10 @@ KubeLB manages load balancers from a centralized point instead of running applia
 
 ### Lifecycle of a request
 
-1. Developer creates a service of type LoadBalancer.
-2. After validation, the KubeLB CCM propagates these resources from the tenant to the management cluster using the `LoadBalancer` CRD.
-3. The KubeLB manager copies/creates the corresponding resources in the tenant namespace in the management cluster.
-4. The KubeLB CCM polls for the updated status of the service and updates the status when available.
-5. The KubeLB manager starts routing the traffic for your resource.
+1. A Service Operator creates a Service of type `LoadBalancer` in a tenant cluster.
+2. The KubeLB CCM validates the Service and synchronizes a `LoadBalancer` resource to the tenant's namespace in the management cluster.
+3. The KubeLB manager reconciles the required infrastructure and Envoy configuration.
+4. The CCM mirrors the assigned address and readiness status back to the original Service.
+5. Traffic enters through the assigned address and is forwarded to NodePort endpoints in the tenant cluster.
 
-![KubeLB Architecture](/img/kubelb/common/architecture.png "KubeLB Architecture")
+![A LoadBalancer Service is synchronized by KubeLB CCM to the management cluster, where KubeLB Manager configures Envoy while the CCM mirrors assigned status to the tenant cluster.](/img/kubelb/common/architecture.png "KubeLB Layer 4 request lifecycle")

--- a/content/kubelb/main/compatibility-matrix/_index.en.md
+++ b/content/kubelb/main/compatibility-matrix/_index.en.md
@@ -5,11 +5,9 @@ description = "Tested version combinations of KubeLB, KKP, Gateway API, Envoy Ga
 weight = 10
 +++
 
-Currently, we don't have any hard dependencies on certain components and their versions. This matrix is here to reflect any changes in the compatibility matrix of the components we are using.
+This matrix lists the component versions that Kubermatic tests together. Listed combinations are covered by compatibility testing; versions outside the matrix may work, but Kubermatic does not make compatibility claims for them.
 
-We are only testing our software with specific versions of the components, we are not enforcing these versions but these are the ones tested. It should work with other versions of Kubernetes, Gateway API, and Envoy Gateway as well, but we can't guarantee it.
-
-**KubeLB support [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) for Ingress resources. [Envoy Gateway](https://gateway.envoyproxy.io/) is supported for Gateway API resources. While other products might work for Ingress and Gateway API resources, we are not testing them and can't guarantee the compatibility.**
+KubeLB supports [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) for Ingress resources and [Envoy Gateway](https://gateway.envoyproxy.io/) for Gateway API resources. Other implementations may work through standard Kubernetes APIs, but they are not part of the tested compatibility matrix.
 
 | KubeLB | Kubermatic Kubernetes Platform | Gateway API | Envoy Gateway | NGINX Ingress | Kubernetes |
 |--------|-------------------------------|-------------|---------------|-------------------------|------------|
@@ -17,8 +15,8 @@ We are only testing our software with specific versions of the components, we ar
 | v1.3   | v2.27, v2.28, v2.29, v2.30               | v1.4.0+      | v1.5.0+       | v1.10.0+                  | v1.27+     |
 | v1.2   | v2.27, v2.28, v2.29                | v1.3.0      | v1.3.0+       | v1.10.0+                  | v1.27+     |
 
-The Kubernetes version requirement is informational; the KubeLB Helm charts do not enforce a `kubeVersion` constraint.
+The Kubernetes version column records the versions covered by testing. KubeLB Helm charts do not enforce a `kubeVersion` constraint.
 
 ## Support Policy
 
-For the support policy, see the [KubeLB Support Policy](../support-policy/)
+See the [KubeLB Support Policy]({{< relref "../support-policy/" >}}) for the scope of Enterprise Edition support.


### PR DESCRIPTION
## What changed

- restructure the KubeLB architecture overview into a concise request flow
- clarify management-cluster and tenant-cluster responsibilities
- improve the L4 and L7 lifecycle descriptions and image alternative text
- distinguish tested compatibility combinations from unsupported claims

## Why

The architecture pages mixed responsibilities, lifecycle details, and support statements in dense prose. The revised structure makes the existing diagrams and operational boundaries easier to interpret without replacing the approved high-level images.

## Impact

Platform providers and application owners can find their responsibilities and understand the L4/L7 resource lifecycle more quickly.

## Validation

- full Hugo build: 6,086 pages
- Chrome visual review of architecture, compatibility, L4, and L7 pages
- confirmed no horizontal overflow in the responsibility table

