### PR TITLE
docs: clarify KubeLB installation instructions

### DIFF
--- a/content/kubelb/main/installation/management-cluster/_index.en.md
+++ b/content/kubelb/main/installation/management-cluster/_index.en.md
@@ -41,15 +41,101 @@ kubectl apply -f kubelb-manager-ee/crds/
 helm upgrade --install kubelb-manager kubelb-manager-ee --namespace kubelb -f kubelb-manager-ee/values.yaml --create-namespace
 ```
 
-### Review KubeLB Manager EE values
+### KubeLB Manager EE Values
 
 <!-- helm-values-kubelb-manager-ee start -->
-The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
-
-```sh
-helm show values oci://quay.io/kubermatic/helm-charts/kubelb-manager-ee --version=v1.4.3
-helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-manager-ee --version=v1.4.3
-```
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `10` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| cert-manager.enabled | bool | `false` | Enable cert-manager. |
+| external-dns.enabled | bool | `false` | Enable External-DNS. |
+| fullnameOverride | string | `""` |  |
+| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
+| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"quay.io/kubermatic/kubelb-manager-ee"` |  |
+| image.tag | string | `"v1.3.9"` |  |
+| imagePullSecrets[0].name | string | `"kubermatic-quay.io"` |  |
+| kkpintegration.rbac | bool | `false` | Create RBAC for KKP integration. |
+| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
+| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
+| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
+| kubelb.debug | bool | `true` |  |
+| kubelb.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables Envoy Gateway support for BackendTrafficPolicy and ClientTrafficPolicy. Use this if you're using a Gateway API implementation other than Envoy Gateway. |
+| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
+| kubelb.enableLeaderElection | bool | `true` |  |
+| kubelb.enableWAF | bool | `false` | [Alpha Feature] enableWAF enables the WAF controller for Web Application Firewall policy validation. WAF is an alpha feature and is disabled by default. |
+| kubelb.envoyProxy.affinity | object | `{}` |  |
+| kubelb.envoyProxy.gracefulShutdown.disabled | bool | `false` | Disable graceful shutdown (default: false) |
+| kubelb.envoyProxy.nodeSelector | object | `{}` |  |
+| kubelb.envoyProxy.replicas | int | `2` | The number of replicas for the Envoy Proxy deployment. |
+| kubelb.envoyProxy.resources | object | `{}` |  |
+| kubelb.envoyProxy.singlePodPerNode | bool | `true` | Deploy single pod per node. |
+| kubelb.envoyProxy.tolerations | list | `[]` |  |
+| kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Valid values are: shared and global. |
+| kubelb.envoyProxy.useDaemonset | bool | `false` | Use DaemonSet for Envoy Proxy deployment instead of Deployment. |
+| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
+| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
+| kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
+| kubelb.skipConfigGeneration | bool | `false` | Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
+| kubelb.tunnel.connectionManager.affinity | object | `{}` |  |
+| kubelb.tunnel.connectionManager.healthCheck.enabled | bool | `true` |  |
+| kubelb.tunnel.connectionManager.healthCheck.livenessInitialDelay | int | `30` |  |
+| kubelb.tunnel.connectionManager.healthCheck.readinessInitialDelay | int | `10` |  |
+| kubelb.tunnel.connectionManager.httpAddr | string | `":8080"` | Server addresses |
+| kubelb.tunnel.connectionManager.httpRoute.annotations | object | `{"cert-manager.io/cluster-issuer":"letsencrypt-prod","external-dns.alpha.kubernetes.io/hostname":"connection-manager.${DOMAIN}"}` | Annotations for HTTPRoute |
+| kubelb.tunnel.connectionManager.httpRoute.domain | string | `"connection-manager.${DOMAIN}"` | Domain for the HTTPRoute NOTE: Replace ${DOMAIN} with your domain name. |
+| kubelb.tunnel.connectionManager.httpRoute.enabled | bool | `false` |  |
+| kubelb.tunnel.connectionManager.httpRoute.gatewayName | string | `"gateway"` | Gateway name to attach to |
+| kubelb.tunnel.connectionManager.httpRoute.gatewayNamespace | string | `""` | Gateway namespace |
+| kubelb.tunnel.connectionManager.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/kubermatic/kubelb-connection-manager-ee","tag":""}` | Connection manager image configuration |
+| kubelb.tunnel.connectionManager.ingress | object | `{"annotations":{"cert-manager.io/cluster-issuer":"letsencrypt-prod","external-dns.alpha.kubernetes.io/hostname":"connection-manager.${DOMAIN}","nginx.ingress.kubernetes.io/backend-protocol":"HTTP","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"},"className":"nginx","enabled":false,"hosts":[{"host":"connection-manager.${DOMAIN}","paths":[{"path":"/tunnel","pathType":"Prefix"},{"path":"/health","pathType":"Prefix"}]}],"tls":[{"hosts":["connection-manager.${DOMAIN}"],"secretName":"connection-manager-tls"}]}` | Ingress configuration for external HTTP/2 access |
+| kubelb.tunnel.connectionManager.nodeSelector | object | `{}` |  |
+| kubelb.tunnel.connectionManager.podAnnotations | object | `{}` | Pod configuration |
+| kubelb.tunnel.connectionManager.podLabels | object | `{}` |  |
+| kubelb.tunnel.connectionManager.podSecurityContext.fsGroup | int | `65534` |  |
+| kubelb.tunnel.connectionManager.podSecurityContext.runAsNonRoot | bool | `true` |  |
+| kubelb.tunnel.connectionManager.podSecurityContext.runAsUser | int | `65534` |  |
+| kubelb.tunnel.connectionManager.replicaCount | int | `1` | Number of connection manager replicas |
+| kubelb.tunnel.connectionManager.requestTimeout | string | `"30s"` |  |
+| kubelb.tunnel.connectionManager.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"250m","memory":"128Mi"}}` | Resource limits |
+| kubelb.tunnel.connectionManager.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | Security context |
+| kubelb.tunnel.connectionManager.service | object | `{"httpPort":8080,"type":"ClusterIP"}` | Service configuration |
+| kubelb.tunnel.connectionManager.tolerations | list | `[]` |  |
+| kubelb.tunnel.enabled | bool | `false` | Enable tunnel functionality |
+| metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| priorityClassName | string | `""` | PriorityClassName for the manager pod (e.g., "system-cluster-critical") |
+| rbac.allowLeaderElectionRole | bool | `true` |  |
+| rbac.allowMetricsReaderRole | bool | `true` |  |
+| rbac.allowProxyRole | bool | `true` |  |
+| rbac.enabled | bool | `true` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"128Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.runAsUser | int | `65532` |  |
+| service.port | int | `8001` |  |
+| service.protocol | string | `"TCP"` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| tolerations | list | `[]` |  |
 <!-- helm-values-kubelb-manager-ee end -->
 
 {{% /tab %}}
@@ -65,17 +151,71 @@ kubectl apply -f kubelb-manager/crds/
 helm upgrade --install kubelb-manager kubelb-manager --namespace kubelb -f kubelb-manager/values.yaml --create-namespace
 ```
 
-### Review KubeLB Manager CE values
+### KubeLB Manager CE Values
 
 <!-- helm-values-kubelb-manager start -->
-The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
-
-```sh
-helm show values oci://quay.io/kubermatic/helm-charts/kubelb-manager --version=v1.4.3
-helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-manager --version=v1.4.3
-```
-
-You can also browse the [v1.4.3 Community Edition chart reference](https://github.com/kubermatic/kubelb/blob/v1.4.3/charts/kubelb-manager/README.md#values).
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `10` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| fullnameOverride | string | `""` |  |
+| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
+| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"quay.io/kubermatic/kubelb-manager"` |  |
+| image.tag | string | `"v1.3.9"` |  |
+| imagePullSecrets | list | `[]` |  |
+| kkpintegration.rbac | bool | `false` | Create RBAC for KKP integration. |
+| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
+| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
+| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
+| kubelb.debug | bool | `true` |  |
+| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
+| kubelb.enableLeaderElection | bool | `true` |  |
+| kubelb.envoyProxy.affinity | object | `{}` |  |
+| kubelb.envoyProxy.gracefulShutdown.disabled | bool | `false` | Disable graceful shutdown (default: false) |
+| kubelb.envoyProxy.nodeSelector | object | `{}` |  |
+| kubelb.envoyProxy.replicas | int | `2` | The number of replicas for the Envoy Proxy deployment. |
+| kubelb.envoyProxy.resources | object | `{}` |  |
+| kubelb.envoyProxy.singlePodPerNode | bool | `true` | Deploy single pod per node. |
+| kubelb.envoyProxy.tolerations | list | `[]` |  |
+| kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Valid values are: shared and global. |
+| kubelb.envoyProxy.useDaemonset | bool | `false` | Use DaemonSet for Envoy Proxy deployment instead of Deployment. |
+| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
+| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
+| kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
+| kubelb.skipConfigGeneration | bool | `false` | Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
+| metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| rbac.allowLeaderElectionRole | bool | `true` |  |
+| rbac.allowMetricsReaderRole | bool | `true` |  |
+| rbac.allowProxyRole | bool | `true` |  |
+| rbac.enabled | bool | `true` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"128Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.runAsUser | int | `65532` |  |
+| service.port | int | `8001` |  |
+| service.protocol | string | `"TCP"` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| tolerations | list | `[]` |  |
 <!-- helm-values-kubelb-manager end -->
 
 {{% /tab %}}

--- a/content/kubelb/main/installation/management-cluster/_index.en.md
+++ b/content/kubelb/main/installation/management-cluster/_index.en.md
@@ -1,6 +1,6 @@
 +++
-title = "Install KubeLB Manager and setup Management Cluster"
-linkTitle = "Setup Management Cluster"
+title = "Install KubeLB Manager and set up the management cluster"
+linkTitle = "Set Up Management Cluster"
 date = 2023-10-27T10:07:15+02:00
 weight = 10
 +++
@@ -12,26 +12,26 @@ weight = 10
 
 See [Requirements]({{< relref "../requirements" >}}) for the full port and resource sizing reference.
 
-## Installation for KubeLB manager
+## Install KubeLB Manager
 
-{{% notice warning %}} In case if Gateway API needs to be enabled for the cluster. Please set `kubelb.enableGatewayAPI` to `true` in the `values.yaml`. This is required otherwise due to missing CRDs, kubelb will not be able to start. {{% /notice %}}
+{{% notice warning %}} If you enable Gateway API support, install its CRDs first and set `kubelb.enableGatewayAPI` to `true` in `values.yaml`. Without the CRDs, KubeLB Manager cannot start. {{% /notice %}}
 
 {{< tabs name="KubeLB Manager" >}}
 {{% tab name="Enterprise Edition" %}}
 
 ### Prerequisites
 
-* Create a namespace **kubelb** for the CCM to be deployed in.
-* Create **imagePullSecrets** for the chart to pull the image from the registry in kubelb namespace.
+* Create a `kubelb` namespace for KubeLB Manager.
+* Create the required `imagePullSecrets` in that namespace so the chart can pull Enterprise Edition images.
 
-At this point a minimal values.yaml should look like this:
+A minimal `values.yaml` looks like this:
 
 ```yaml
 imagePullSecrets:
   - name: <imagePullSecretName>
 ```
 
-### Install the helm chart
+### Install the Helm chart
 
 ```sh
 helm pull oci://quay.io/kubermatic/helm-charts/kubelb-manager-ee --version=v1.4.3 --untardir "." --untar
@@ -41,107 +41,21 @@ kubectl apply -f kubelb-manager-ee/crds/
 helm upgrade --install kubelb-manager kubelb-manager-ee --namespace kubelb -f kubelb-manager-ee/values.yaml --create-namespace
 ```
 
-### KubeLB Manager EE Values
+### Review KubeLB Manager EE values
 
 <!-- helm-values-kubelb-manager-ee start -->
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `10` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
-| cert-manager.enabled | bool | `false` | Enable cert-manager. |
-| external-dns.enabled | bool | `false` | Enable External-DNS. |
-| fullnameOverride | string | `""` |  |
-| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
-| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"quay.io/kubermatic/kubelb-manager-ee"` |  |
-| image.tag | string | `"v1.3.9"` |  |
-| imagePullSecrets[0].name | string | `"kubermatic-quay.io"` |  |
-| kkpintegration.rbac | bool | `false` | Create RBAC for KKP integration. |
-| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
-| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
-| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
-| kubelb.debug | bool | `true` |  |
-| kubelb.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables Envoy Gateway support for BackendTrafficPolicy and ClientTrafficPolicy. Use this if you're using a Gateway API implementation other than Envoy Gateway. |
-| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
-| kubelb.enableLeaderElection | bool | `true` |  |
-| kubelb.enableWAF | bool | `false` | [Alpha Feature] enableWAF enables the WAF controller for Web Application Firewall policy validation. WAF is an alpha feature and is disabled by default. |
-| kubelb.envoyProxy.affinity | object | `{}` |  |
-| kubelb.envoyProxy.gracefulShutdown.disabled | bool | `false` | Disable graceful shutdown (default: false) |
-| kubelb.envoyProxy.nodeSelector | object | `{}` |  |
-| kubelb.envoyProxy.replicas | int | `2` | The number of replicas for the Envoy Proxy deployment. |
-| kubelb.envoyProxy.resources | object | `{}` |  |
-| kubelb.envoyProxy.singlePodPerNode | bool | `true` | Deploy single pod per node. |
-| kubelb.envoyProxy.tolerations | list | `[]` |  |
-| kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Valid values are: shared and global. |
-| kubelb.envoyProxy.useDaemonset | bool | `false` | Use DaemonSet for Envoy Proxy deployment instead of Deployment. |
-| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
-| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
-| kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
-| kubelb.skipConfigGeneration | bool | `false` | Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
-| kubelb.tunnel.connectionManager.affinity | object | `{}` |  |
-| kubelb.tunnel.connectionManager.healthCheck.enabled | bool | `true` |  |
-| kubelb.tunnel.connectionManager.healthCheck.livenessInitialDelay | int | `30` |  |
-| kubelb.tunnel.connectionManager.healthCheck.readinessInitialDelay | int | `10` |  |
-| kubelb.tunnel.connectionManager.httpAddr | string | `":8080"` | Server addresses |
-| kubelb.tunnel.connectionManager.httpRoute.annotations | object | `{"cert-manager.io/cluster-issuer":"letsencrypt-prod","external-dns.alpha.kubernetes.io/hostname":"connection-manager.${DOMAIN}"}` | Annotations for HTTPRoute |
-| kubelb.tunnel.connectionManager.httpRoute.domain | string | `"connection-manager.${DOMAIN}"` | Domain for the HTTPRoute NOTE: Replace ${DOMAIN} with your domain name. |
-| kubelb.tunnel.connectionManager.httpRoute.enabled | bool | `false` |  |
-| kubelb.tunnel.connectionManager.httpRoute.gatewayName | string | `"gateway"` | Gateway name to attach to |
-| kubelb.tunnel.connectionManager.httpRoute.gatewayNamespace | string | `""` | Gateway namespace |
-| kubelb.tunnel.connectionManager.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/kubermatic/kubelb-connection-manager-ee","tag":""}` | Connection manager image configuration |
-| kubelb.tunnel.connectionManager.ingress | object | `{"annotations":{"cert-manager.io/cluster-issuer":"letsencrypt-prod","external-dns.alpha.kubernetes.io/hostname":"connection-manager.${DOMAIN}","nginx.ingress.kubernetes.io/backend-protocol":"HTTP","nginx.ingress.kubernetes.io/proxy-read-timeout":"3600","nginx.ingress.kubernetes.io/proxy-send-timeout":"3600"},"className":"nginx","enabled":false,"hosts":[{"host":"connection-manager.${DOMAIN}","paths":[{"path":"/tunnel","pathType":"Prefix"},{"path":"/health","pathType":"Prefix"}]}],"tls":[{"hosts":["connection-manager.${DOMAIN}"],"secretName":"connection-manager-tls"}]}` | Ingress configuration for external HTTP/2 access |
-| kubelb.tunnel.connectionManager.nodeSelector | object | `{}` |  |
-| kubelb.tunnel.connectionManager.podAnnotations | object | `{}` | Pod configuration |
-| kubelb.tunnel.connectionManager.podLabels | object | `{}` |  |
-| kubelb.tunnel.connectionManager.podSecurityContext.fsGroup | int | `65534` |  |
-| kubelb.tunnel.connectionManager.podSecurityContext.runAsNonRoot | bool | `true` |  |
-| kubelb.tunnel.connectionManager.podSecurityContext.runAsUser | int | `65534` |  |
-| kubelb.tunnel.connectionManager.replicaCount | int | `1` | Number of connection manager replicas |
-| kubelb.tunnel.connectionManager.requestTimeout | string | `"30s"` |  |
-| kubelb.tunnel.connectionManager.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"250m","memory":"128Mi"}}` | Resource limits |
-| kubelb.tunnel.connectionManager.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | Security context |
-| kubelb.tunnel.connectionManager.service | object | `{"httpPort":8080,"type":"ClusterIP"}` | Service configuration |
-| kubelb.tunnel.connectionManager.tolerations | list | `[]` |  |
-| kubelb.tunnel.enabled | bool | `false` | Enable tunnel functionality |
-| metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext.runAsNonRoot | bool | `true` |  |
-| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| priorityClassName | string | `""` | PriorityClassName for the manager pod (e.g., "system-cluster-critical") |
-| rbac.allowLeaderElectionRole | bool | `true` |  |
-| rbac.allowMetricsReaderRole | bool | `true` |  |
-| rbac.allowProxyRole | bool | `true` |  |
-| rbac.enabled | bool | `true` |  |
-| replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"500m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"128Mi"` |  |
-| securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.runAsUser | int | `65532` |  |
-| service.port | int | `8001` |  |
-| service.protocol | string | `"TCP"` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| serviceMonitor.enabled | bool | `false` |  |
-| tolerations | list | `[]` |  |
+The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
+
+```sh
+helm show values oci://quay.io/kubermatic/helm-charts/kubelb-manager-ee --version=v1.4.3
+helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-manager-ee --version=v1.4.3
+```
 <!-- helm-values-kubelb-manager-ee end -->
 
 {{% /tab %}}
 {{% tab name="Community Edition" %}}
 
-### Install the helm chart
+### Install the Helm chart
 
 ```sh
 helm pull oci://quay.io/kubermatic/helm-charts/kubelb-manager --version=v1.4.3 --untardir "." --untar
@@ -151,71 +65,17 @@ kubectl apply -f kubelb-manager/crds/
 helm upgrade --install kubelb-manager kubelb-manager --namespace kubelb -f kubelb-manager/values.yaml --create-namespace
 ```
 
-### KubeLB Manager CE Values
+### Review KubeLB Manager CE values
 
 <!-- helm-values-kubelb-manager start -->
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `10` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
-| fullnameOverride | string | `""` |  |
-| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
-| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"quay.io/kubermatic/kubelb-manager"` |  |
-| image.tag | string | `"v1.3.9"` |  |
-| imagePullSecrets | list | `[]` |  |
-| kkpintegration.rbac | bool | `false` | Create RBAC for KKP integration. |
-| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
-| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
-| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
-| kubelb.debug | bool | `true` |  |
-| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
-| kubelb.enableLeaderElection | bool | `true` |  |
-| kubelb.envoyProxy.affinity | object | `{}` |  |
-| kubelb.envoyProxy.gracefulShutdown.disabled | bool | `false` | Disable graceful shutdown (default: false) |
-| kubelb.envoyProxy.nodeSelector | object | `{}` |  |
-| kubelb.envoyProxy.replicas | int | `2` | The number of replicas for the Envoy Proxy deployment. |
-| kubelb.envoyProxy.resources | object | `{}` |  |
-| kubelb.envoyProxy.singlePodPerNode | bool | `true` | Deploy single pod per node. |
-| kubelb.envoyProxy.tolerations | list | `[]` |  |
-| kubelb.envoyProxy.topology | string | `"shared"` | Topology defines the deployment topology for Envoy Proxy. Valid values are: shared and global. |
-| kubelb.envoyProxy.useDaemonset | bool | `false` | Use DaemonSet for Envoy Proxy deployment instead of Deployment. |
-| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
-| kubelb.propagateAllAnnotations | bool | `false` | Propagate all annotations from the LB resource to the LB service. |
-| kubelb.propagatedAnnotations | object | `{}` | Allowed annotations that will be propagated from the LB resource to the LB service. |
-| kubelb.skipConfigGeneration | bool | `false` | Set to true to skip the generation of the Config CR. Useful when the config CR needs to be managed manually. |
-| metrics.port | int | `9443` | Port where the manager exposes metrics (includes both manager and envoycp metrics) |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext.runAsNonRoot | bool | `true` |  |
-| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| rbac.allowLeaderElectionRole | bool | `true` |  |
-| rbac.allowMetricsReaderRole | bool | `true` |  |
-| rbac.allowProxyRole | bool | `true` |  |
-| rbac.enabled | bool | `true` |  |
-| replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"500m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"128Mi"` |  |
-| securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.runAsUser | int | `65532` |  |
-| service.port | int | `8001` |  |
-| service.protocol | string | `"TCP"` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| serviceMonitor.enabled | bool | `false` |  |
-| tolerations | list | `[]` |  |
+The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
+
+```sh
+helm show values oci://quay.io/kubermatic/helm-charts/kubelb-manager --version=v1.4.3
+helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-manager --version=v1.4.3
+```
+
+You can also browse the [v1.4.3 Community Edition chart reference](https://github.com/kubermatic/kubelb/blob/v1.4.3/charts/kubelb-manager/README.md#values).
 <!-- helm-values-kubelb-manager end -->
 
 {{% /tab %}}
@@ -236,7 +96,7 @@ kubelb-manager-6d95d7f45d-xz2lp   2/2     Running   0          1m
 
 The `kubelb-manager` pod must be in `Running` state. Envoy proxy pods appear in the tenant namespaces later, once tenants are registered and load balancers are created.
 
-## Setup the management cluster
+## Set up the management cluster
 
 {{% notice note %}}
 The examples and tools shared below are for demonstration purposes, you can use any other tools or configurations as per your requirements.

--- a/content/kubelb/main/installation/tenant-cluster/_index.en.md
+++ b/content/kubelb/main/installation/tenant-cluster/_index.en.md
@@ -119,15 +119,91 @@ kubectl apply -f kubelb-ccm-ee/crds/
 helm upgrade --install kubelb-ccm kubelb-ccm-ee --namespace kubelb -f kubelb-ccm-ee/values.yaml --create-namespace
 ```
 
-### Review KubeLB CCM EE values
+### KubeLB CCM EE Values
 
 <!-- helm-values-kubelb-ccm-ee start -->
-The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
-
-```sh
-helm show values oci://quay.io/kubermatic/helm-charts/kubelb-ccm-ee --version=v1.4.3
-helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-ccm-ee --version=v1.4.3
-```
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `10` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
+| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"quay.io/kubermatic/kubelb-ccm-ee"` |  |
+| image.tag | string | `"v1.3.9"` |  |
+| imagePullSecrets[0].name | string | `"kubermatic-quay.io"` |  |
+| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
+| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
+| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
+| kubelb.clusterSecretName | string | `"kubelb-cluster"` | Name of the secret that contains kubeconfig for the loadbalancer cluster |
+| kubelb.disableBackendTrafficPolicyController | bool | `false` | disableBackendTrafficPolicyController specifies whether to disable the BackendTrafficPolicy Controller. |
+| kubelb.disableClientTrafficPolicyController | bool | `false` | disableClientTrafficPolicyController specifies whether to disable the ClientTrafficPolicy Controller. |
+| kubelb.disableGRPCRouteController | bool | `false` | disableGRPCRouteController specifies whether to disable the GRPCRoute Controller. |
+| kubelb.disableGatewayController | bool | `false` | disableGatewayController specifies whether to disable the Gateway Controller. |
+| kubelb.disableHTTPRouteController | bool | `false` | disableHTTPRouteController specifies whether to disable the HTTPRoute Controller. |
+| kubelb.disableIngressController | bool | `false` | disableIngressController specifies whether to disable the Ingress Controller. |
+| kubelb.disableTCPRouteController | bool | `false` | disableTCPRouteController specifies whether to disable the TCPRoute Controller. |
+| kubelb.disableTLSRouteController | bool | `false` | disableTLSRouteController specifies whether to disable the TLSRoute Controller. |
+| kubelb.disableUDPRouteController | bool | `false` | disableUDPRouteController specifies whether to disable the UDPRoute Controller. |
+| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
+| kubelb.enableLeaderElection | bool | `true` | Enable the leader election. |
+| kubelb.enableSecretSynchronizer | bool | `false` | Enable to automatically convert Secrets labelled with `kubelb.k8c.io/managed-by: kubelb` to Sync Secrets. This is used to sync secrets from tenants to the LB cluster in a controlled and secure way. |
+| kubelb.gatewayAPICRDsChannel | string | `"experimental"` | gatewayAPICRDsChannel specifies the channel for the Gateway API CRDs. Options are `standard` and `experimental`. |
+| kubelb.ingressConversion.copyTLSSecrets | bool | `true` | copyTLSSecrets copies TLS secrets from Ingress namespace to Gateway namespace for cross-namespace certificate references |
+| kubelb.ingressConversion.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables creation of Envoy Gateway policies (SecurityPolicy, BackendTrafficPolicy) |
+| kubelb.ingressConversion.domainReplace | string | `""` | domainReplace is the domain suffix to replace in hostnames |
+| kubelb.ingressConversion.domainSuffix | string | `""` | domainSuffix is the replacement domain suffix for hostnames |
+| kubelb.ingressConversion.enabled | bool | `false` | enabled enables automatic Ingress to HTTPRoute conversion |
+| kubelb.ingressConversion.gatewayAnnotations | string | `""` | gatewayAnnotations are annotations to add to created Gateway (comma-separated key=value pairs) Example: "cert-manager.io/cluster-issuer=letsencrypt,external-dns.alpha.kubernetes.io/target=lb.example.com" |
+| kubelb.ingressConversion.gatewayClass | string | `"kubelb"` | gatewayClass is the GatewayClass name for created Gateway |
+| kubelb.ingressConversion.gatewayName | string | `"kubelb"` | gatewayName is the name of the Gateway for converted HTTPRoutes |
+| kubelb.ingressConversion.gatewayNamespace | string | `"kubelb"` | gatewayNamespace is the namespace for the shared Gateway (required) |
+| kubelb.ingressConversion.ingressClass | string | `""` | ingressClass filters Ingresses to convert (empty = convert all) |
+| kubelb.ingressConversion.propagateExternalDnsAnnotations | bool | `true` | propagateExternalDnsAnnotations propagates external-dns annotations to Gateway/HTTPRoute |
+| kubelb.ingressConversion.standaloneMode | bool | `false` | standaloneMode runs as standalone converter, disabling all other controllers |
+| kubelb.installGatewayAPICRDs | bool | `false` | installGatewayAPICRDs Installs and manages the Gateway API CRDs using gateway crd controller. |
+| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
+| kubelb.maxNodeAddressCount | int | `0` | Maximum number of node addresses to forward to the LB cluster. When set, addresses are selected with topology-aware round-robin spread across zones (topology.kubernetes.io/zone). 0 means no limit. |
+| kubelb.nodeAddressLabelSelector | string | `""` | Only use nodes matching this label selector as endpoint addresses (e.g. kubelb.k8c.io/endpoint=true). |
+| kubelb.nodeAddressType | string | `"ExternalIP"` | Address type to use for routing traffic to node ports. Values are ExternalIP, InternalIP. |
+| kubelb.tenantName | string | `nil` | Name of the tenant, must be unique against a load balancer cluster. |
+| kubelb.useGatewayClass | bool | `true` | useGatewayClass specifies whether to target resources with `kubelb` gateway class or all resources. |
+| kubelb.useIngressClass | bool | `true` | useIngressClass specifies whether to target resources with `kubelb` ingress class or all resources. |
+| kubelb.useLoadBalancerClass | bool | `false` | useLoadBalancerClass specifies whether to target services of type LoadBalancer with `kubelb` load balancer class or all services of type LoadBalancer. |
+| metrics.port | int | `9445` | Port where the CCM exposes metrics |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| rbac.allowLeaderElectionRole | bool | `true` |  |
+| rbac.allowMetricsReaderRole | bool | `true` |  |
+| rbac.allowProxyRole | bool | `true` |  |
+| rbac.enabled | bool | `true` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"128Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.runAsUser | int | `65532` |  |
+| service.port | int | `8443` |  |
+| service.protocol | string | `"TCP"` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| tolerations | list | `[]` |  |
 <!-- helm-values-kubelb-ccm-ee end -->
 
 {{% /tab %}}
@@ -143,17 +219,85 @@ kubectl apply -f kubelb-ccm/crds/
 helm upgrade --install kubelb-ccm kubelb-ccm --namespace kubelb -f kubelb-ccm/values.yaml --create-namespace
 ```
 
-### Review KubeLB CCM CE values
+### KubeLB CCM CE Values
 
 <!-- helm-values-kubelb-ccm start -->
-The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
-
-```sh
-helm show values oci://quay.io/kubermatic/helm-charts/kubelb-ccm --version=v1.4.3
-helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-ccm --version=v1.4.3
-```
-
-You can also browse the [v1.4.3 Community Edition chart reference](https://github.com/kubermatic/kubelb/blob/v1.4.3/charts/kubelb-ccm/README.md#values).
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `10` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
+| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"quay.io/kubermatic/kubelb-ccm"` |  |
+| image.tag | string | `"v1.3.9"` |  |
+| imagePullSecrets | list | `[]` |  |
+| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
+| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
+| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
+| kubelb.clusterSecretName | string | `"kubelb-cluster"` | Name of the secret that contains kubeconfig for the loadbalancer cluster |
+| kubelb.disableGRPCRouteController | bool | `false` | disableGRPCRouteController specifies whether to disable the GRPCRoute Controller. |
+| kubelb.disableGatewayController | bool | `false` | disableGatewayController specifies whether to disable the Gateway Controller. |
+| kubelb.disableHTTPRouteController | bool | `false` | disableHTTPRouteController specifies whether to disable the HTTPRoute Controller. |
+| kubelb.disableIngressController | bool | `false` | disableIngressController specifies whether to disable the Ingress Controller. |
+| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
+| kubelb.enableLeaderElection | bool | `true` | Enable the leader election. |
+| kubelb.enableSecretSynchronizer | bool | `false` | Enable to automatically convert Secrets labelled with `kubelb.k8c.io/managed-by: kubelb` to Sync Secrets. This is used to sync secrets from tenants to the LB cluster in a controlled and secure way. |
+| kubelb.gatewayAPICRDsChannel | string | `"standard"` | gatewayAPICRDsChannel specifies the channel for the Gateway API CRDs. Options are `standard` and `experimental`. |
+| kubelb.ingressConversion.copyTLSSecrets | bool | `true` | copyTLSSecrets copies TLS secrets from Ingress namespace to Gateway namespace for cross-namespace certificate references |
+| kubelb.ingressConversion.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables creation of Envoy Gateway policies (SecurityPolicy, BackendTrafficPolicy) |
+| kubelb.ingressConversion.domainReplace | string | `""` | domainReplace is the domain suffix to replace in hostnames |
+| kubelb.ingressConversion.domainSuffix | string | `""` | domainSuffix is the replacement domain suffix for hostnames |
+| kubelb.ingressConversion.enabled | bool | `false` | enabled enables automatic Ingress to HTTPRoute conversion |
+| kubelb.ingressConversion.gatewayAnnotations | string | `""` | gatewayAnnotations are annotations to add to created Gateway (comma-separated key=value pairs) Example: "cert-manager.io/cluster-issuer=letsencrypt,external-dns.alpha.kubernetes.io/target=lb.example.com" |
+| kubelb.ingressConversion.gatewayClass | string | `"kubelb"` | gatewayClass is the GatewayClass name for created Gateway |
+| kubelb.ingressConversion.gatewayName | string | `"kubelb"` | gatewayName is the name of the Gateway for converted HTTPRoutes |
+| kubelb.ingressConversion.gatewayNamespace | string | `"kubelb"` | gatewayNamespace is the namespace for the shared Gateway (required) |
+| kubelb.ingressConversion.ingressClass | string | `""` | ingressClass filters Ingresses to convert (empty = convert all) |
+| kubelb.ingressConversion.propagateExternalDnsAnnotations | bool | `true` | propagateExternalDnsAnnotations propagates external-dns annotations to Gateway/HTTPRoute |
+| kubelb.ingressConversion.standaloneMode | bool | `false` | standaloneMode runs as standalone converter, disabling all other controllers |
+| kubelb.installGatewayAPICRDs | bool | `false` | installGatewayAPICRDs Installs and manages the Gateway API CRDs using gateway crd controller. |
+| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
+| kubelb.nodeAddressType | string | `"ExternalIP"` | Address type to use for routing traffic to node ports. Values are ExternalIP, InternalIP. |
+| kubelb.tenantName | string | `nil` | Name of the tenant, must be unique against a load balancer cluster. |
+| kubelb.useGatewayClass | bool | `true` | useGatewayClass specifies whether to target resources with `kubelb` gateway class or all resources. |
+| kubelb.useIngressClass | bool | `true` | useIngressClass specifies whether to target resources with `kubelb` ingress class or all resources. |
+| kubelb.useLoadBalancerClass | bool | `false` | useLoadBalancerClass specifies whether to target services of type LoadBalancer with `kubelb` load balancer class or all services of type LoadBalancer. |
+| metrics.port | int | `9445` | Port where the CCM exposes metrics |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| priorityClassName | string | `""` | PriorityClassName for the manager pod (e.g., "system-cluster-critical") |
+| rbac.allowLeaderElectionRole | bool | `true` |  |
+| rbac.allowMetricsReaderRole | bool | `true` |  |
+| rbac.allowProxyRole | bool | `true` |  |
+| rbac.enabled | bool | `true` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"500m"` |  |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"100m"` |  |
+| resources.requests.memory | string | `"128Mi"` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.runAsUser | int | `65532` |  |
+| service.port | int | `8443` |  |
+| service.protocol | string | `"TCP"` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| tolerations | list | `[]` |  |
 <!-- helm-values-kubelb-ccm end -->
 
 {{% /tab %}}

--- a/content/kubelb/main/installation/tenant-cluster/_index.en.md
+++ b/content/kubelb/main/installation/tenant-cluster/_index.en.md
@@ -1,41 +1,41 @@
 +++
-title = "Install KubeLB CCM and setup Tenant Cluster"
-linkTitle = "Setup Tenant Cluster"
+title = "Install KubeLB CCM and set up the tenant cluster"
+linkTitle = "Set Up Tenant Cluster"
 date = 2023-10-27T10:07:15+02:00
 weight = 20
 +++
 
 ## Prerequisites
 
-* KubeLB management cluster kubernetes API access.
-* Registered as a tenant in the KubeLB management cluster.
+* Access to the Kubernetes API of the KubeLB management cluster.
+* A tenant registered in the KubeLB management cluster.
 
 See [Requirements]({{< relref "../requirements" >}}) for the full port and resource sizing reference.
 
-* Create a namespace **kubelb** for the CCM to be deployed in.
-* The agent expects a **Secret** with a kubeconf file named **`kubelb`** to access the management/load balancing cluster.
-  * First register the tenant in the management cluster by following [tenant registration]({{< relref "../../tutorials/tenants">}}) guidelines.
-  * Fetch the generated kubeconfig and create a secret from the management cluster by using these command:
+* Create a `kubelb` namespace for KubeLB CCM.
+* KubeLB CCM expects a Secret named `kubelb-cluster` by default. Its `kubelb` data key must contain the kubeconfig for the management cluster.
+  * First register the tenant by following the [tenant registration]({{< relref "../../tutorials/tenants">}}) guide.
+  * Fetch the generated kubeconfig from the management cluster, switch to the tenant cluster, and create the Secret:
 
   ```sh
   # Replace with the tenant cluster kubeconfig path
   TENANT_KUBECONFIG=~/.kube/<tenant-cluster>
-  #  Replace with the tenant name
+  # Replace with the tenant name
   TENANT_NAME=tenant-shroud
-  KUBELB_KUBECONFIG=$(kubectl get secret kubelb-ccm-kubeconfig -n $TENANT_NAME --template={{.data.kubelb}})
-  # At this point we have the kubeconfig in base64 encoded format.
-  # Switch the context to the Tenant cluster
-  export KUBECONFIG=$TENANT_KUBECONFIG
-  kubectl --namespace kubelb create secret generic kubelb-cluster --from-literal=kubelb="$(echo $KUBELB_KUBECONFIG | base64 -d)"
+  KUBELB_KUBECONFIG_B64=$(kubectl get secret kubelb-ccm-kubeconfig --namespace "$TENANT_NAME" --template='{{ .data.kubelb }}')
+  # Switch to the tenant cluster.
+  export KUBECONFIG="$TENANT_KUBECONFIG"
+  kubectl --namespace kubelb create secret generic kubelb-cluster \
+    --from-literal=kubelb="$(printf '%s' "$KUBELB_KUBECONFIG_B64" | base64 -d)"
   ```
 
-* The name of secret can be overridden using `.Values.kubelb.clusterSecretName`, if required. If not the secret needs to be named `kubelb` and look like:
+* Override the Secret name with `.Values.kubelb.clusterSecretName` if required. Otherwise, the Secret is named `kubelb-cluster` and looks like this:
 
-  ```
-  kubectl get secrets -o yaml kubelb-cluster
+  ```sh
+  kubectl get secret kubelb-cluster --namespace kubelb -o yaml
   ```
 
-  ```
+  ```yaml
   apiVersion: v1
   data:
     kubelb: xxx-base64-encoded-xxx
@@ -46,20 +46,19 @@ See [Requirements]({{< relref "../requirements" >}}) for the full port and resou
   type: Opaque
   ```
 
-* Update the `tenantName` in the `values.yaml` to a unique identifier for the tenant. This is used to identify the tenant in the manager cluster. Tenants are registered in the management cluster by the Platform Provider and the name is prefixed with `tenant-`. So for example, a tenant named `my-tenant` will be registered as `tenant-my-tenant`. **NOTE: We have an automation in place and both tenant name without and with `tenant-` prefix are supported.**
+* Set `tenantName` in `values.yaml` to the tenant's unique identifier. The management cluster stores tenant namespaces with a `tenant-` prefix; for example, `my-tenant` becomes `tenant-my-tenant`. KubeLB accepts the name with or without this prefix.
 
 At this point a minimal `values.yaml` should look like this:
 
 ```yaml
 kubelb:
-    clusterSecretName: kubelb-cluster
-    tenantName: <unique-identifier-for-tenant>
+  clusterSecretName: kubelb-cluster
+  tenantName: <unique-identifier-for-tenant>
 ```
 
 {{% notice info %}}
 
-**Important configurations for private clusters!**
-If your cluster only uses internal IPs for nodes (check the following example output) you would need to change the value `kubelb.nodeAddressType` to `InternalIP`:
+**Private clusters:** If the tenant nodes do not have external IP addresses, set `kubelb.nodeAddressType` to `InternalIP`.
 
 ```bash
 kubectl get nodes -o wide
@@ -80,9 +79,9 @@ kubelb:
 
 {{% /notice %}}
 
-## Installation for KubeLB CCM
+## Install KubeLB CCM
 
-{{% notice warning %}} In case if Gateway API needs to be enabled for the cluster. Please set the following fields in the `values.yaml`. This is required otherwise due to missing CRDs, kubelb will not be able to start.
+{{% notice warning %}} To enable Gateway API support, set both fields below in `values.yaml`. KubeLB CCM cannot start with Gateway API enabled unless the CRDs are installed.
 
 ```yaml
 kubelb:
@@ -110,7 +109,7 @@ kubelb:
     tenantName: <unique-identifier-for-tenant>
 ```
 
-### Install the helm chart
+### Install the Helm chart
 
 ```sh
 helm pull oci://quay.io/kubermatic/helm-charts/kubelb-ccm-ee --version=v1.4.3 --untardir "." --untar
@@ -120,97 +119,21 @@ kubectl apply -f kubelb-ccm-ee/crds/
 helm upgrade --install kubelb-ccm kubelb-ccm-ee --namespace kubelb -f kubelb-ccm-ee/values.yaml --create-namespace
 ```
 
-### KubeLB CCM EE Values
+### Review KubeLB CCM EE values
 
 <!-- helm-values-kubelb-ccm-ee start -->
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `10` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
-| extraVolumeMounts | list | `[]` |  |
-| extraVolumes | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
-| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"quay.io/kubermatic/kubelb-ccm-ee"` |  |
-| image.tag | string | `"v1.3.9"` |  |
-| imagePullSecrets[0].name | string | `"kubermatic-quay.io"` |  |
-| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
-| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
-| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
-| kubelb.clusterSecretName | string | `"kubelb-cluster"` | Name of the secret that contains kubeconfig for the loadbalancer cluster |
-| kubelb.disableBackendTrafficPolicyController | bool | `false` | disableBackendTrafficPolicyController specifies whether to disable the BackendTrafficPolicy Controller. |
-| kubelb.disableClientTrafficPolicyController | bool | `false` | disableClientTrafficPolicyController specifies whether to disable the ClientTrafficPolicy Controller. |
-| kubelb.disableGRPCRouteController | bool | `false` | disableGRPCRouteController specifies whether to disable the GRPCRoute Controller. |
-| kubelb.disableGatewayController | bool | `false` | disableGatewayController specifies whether to disable the Gateway Controller. |
-| kubelb.disableHTTPRouteController | bool | `false` | disableHTTPRouteController specifies whether to disable the HTTPRoute Controller. |
-| kubelb.disableIngressController | bool | `false` | disableIngressController specifies whether to disable the Ingress Controller. |
-| kubelb.disableTCPRouteController | bool | `false` | disableTCPRouteController specifies whether to disable the TCPRoute Controller. |
-| kubelb.disableTLSRouteController | bool | `false` | disableTLSRouteController specifies whether to disable the TLSRoute Controller. |
-| kubelb.disableUDPRouteController | bool | `false` | disableUDPRouteController specifies whether to disable the UDPRoute Controller. |
-| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
-| kubelb.enableLeaderElection | bool | `true` | Enable the leader election. |
-| kubelb.enableSecretSynchronizer | bool | `false` | Enable to automatically convert Secrets labelled with `kubelb.k8c.io/managed-by: kubelb` to Sync Secrets. This is used to sync secrets from tenants to the LB cluster in a controlled and secure way. |
-| kubelb.gatewayAPICRDsChannel | string | `"experimental"` | gatewayAPICRDsChannel specifies the channel for the Gateway API CRDs. Options are `standard` and `experimental`. |
-| kubelb.ingressConversion.copyTLSSecrets | bool | `true` | copyTLSSecrets copies TLS secrets from Ingress namespace to Gateway namespace for cross-namespace certificate references |
-| kubelb.ingressConversion.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables creation of Envoy Gateway policies (SecurityPolicy, BackendTrafficPolicy) |
-| kubelb.ingressConversion.domainReplace | string | `""` | domainReplace is the domain suffix to replace in hostnames |
-| kubelb.ingressConversion.domainSuffix | string | `""` | domainSuffix is the replacement domain suffix for hostnames |
-| kubelb.ingressConversion.enabled | bool | `false` | enabled enables automatic Ingress to HTTPRoute conversion |
-| kubelb.ingressConversion.gatewayAnnotations | string | `""` | gatewayAnnotations are annotations to add to created Gateway (comma-separated key=value pairs) Example: "cert-manager.io/cluster-issuer=letsencrypt,external-dns.alpha.kubernetes.io/target=lb.example.com" |
-| kubelb.ingressConversion.gatewayClass | string | `"kubelb"` | gatewayClass is the GatewayClass name for created Gateway |
-| kubelb.ingressConversion.gatewayName | string | `"kubelb"` | gatewayName is the name of the Gateway for converted HTTPRoutes |
-| kubelb.ingressConversion.gatewayNamespace | string | `"kubelb"` | gatewayNamespace is the namespace for the shared Gateway (required) |
-| kubelb.ingressConversion.ingressClass | string | `""` | ingressClass filters Ingresses to convert (empty = convert all) |
-| kubelb.ingressConversion.propagateExternalDnsAnnotations | bool | `true` | propagateExternalDnsAnnotations propagates external-dns annotations to Gateway/HTTPRoute |
-| kubelb.ingressConversion.standaloneMode | bool | `false` | standaloneMode runs as standalone converter, disabling all other controllers |
-| kubelb.installGatewayAPICRDs | bool | `false` | installGatewayAPICRDs Installs and manages the Gateway API CRDs using gateway crd controller. |
-| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
-| kubelb.maxNodeAddressCount | int | `0` | Maximum number of node addresses to forward to the LB cluster. When set, addresses are selected with topology-aware round-robin spread across zones (topology.kubernetes.io/zone). 0 means no limit. |
-| kubelb.nodeAddressLabelSelector | string | `""` | Only use nodes matching this label selector as endpoint addresses (e.g. kubelb.k8c.io/endpoint=true). |
-| kubelb.nodeAddressType | string | `"ExternalIP"` | Address type to use for routing traffic to node ports. Values are ExternalIP, InternalIP. |
-| kubelb.tenantName | string | `nil` | Name of the tenant, must be unique against a load balancer cluster. |
-| kubelb.useGatewayClass | bool | `true` | useGatewayClass specifies whether to target resources with `kubelb` gateway class or all resources. |
-| kubelb.useIngressClass | bool | `true` | useIngressClass specifies whether to target resources with `kubelb` ingress class or all resources. |
-| kubelb.useLoadBalancerClass | bool | `false` | useLoadBalancerClass specifies whether to target services of type LoadBalancer with `kubelb` load balancer class or all services of type LoadBalancer. |
-| metrics.port | int | `9445` | Port where the CCM exposes metrics |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext.runAsNonRoot | bool | `true` |  |
-| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| rbac.allowLeaderElectionRole | bool | `true` |  |
-| rbac.allowMetricsReaderRole | bool | `true` |  |
-| rbac.allowProxyRole | bool | `true` |  |
-| rbac.enabled | bool | `true` |  |
-| replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"500m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"128Mi"` |  |
-| securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.runAsUser | int | `65532` |  |
-| service.port | int | `8443` |  |
-| service.protocol | string | `"TCP"` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| serviceMonitor.enabled | bool | `false` |  |
-| tolerations | list | `[]` |  |
+The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
+
+```sh
+helm show values oci://quay.io/kubermatic/helm-charts/kubelb-ccm-ee --version=v1.4.3
+helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-ccm-ee --version=v1.4.3
+```
 <!-- helm-values-kubelb-ccm-ee end -->
 
 {{% /tab %}}
 {{% tab name="Community Edition" %}}
 
-### Install the helm chart
+### Install the Helm chart
 
 ```sh
 helm pull oci://quay.io/kubermatic/helm-charts/kubelb-ccm --version=v1.4.3 --untardir "." --untar
@@ -220,85 +143,17 @@ kubectl apply -f kubelb-ccm/crds/
 helm upgrade --install kubelb-ccm kubelb-ccm --namespace kubelb -f kubelb-ccm/values.yaml --create-namespace
 ```
 
-### KubeLB CCM CE Values
+### Review KubeLB CCM CE values
 
 <!-- helm-values-kubelb-ccm start -->
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `10` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
-| extraVolumeMounts | list | `[]` |  |
-| extraVolumes | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| grafana.dashboards.annotations | object | `{}` | Additional annotations for dashboard ConfigMaps |
-| grafana.dashboards.enabled | bool | `false` | Requires grafana to be deployed with `sidecar.dashboards.enabled=true`. For more info: <https://github.com/grafana/helm-charts/tree/grafana-10.5.13/charts/grafana#:~:text=%5B%5D-,sidecar.dashboards.enabled,-Enables%20the%20cluster> |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"quay.io/kubermatic/kubelb-ccm"` |  |
-| image.tag | string | `"v1.3.9"` |  |
-| imagePullSecrets | list | `[]` |  |
-| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` |  |
-| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` |  |
-| kubeRbacProxy.image.tag | string | `"v0.20.1"` |  |
-| kubelb.clusterSecretName | string | `"kubelb-cluster"` | Name of the secret that contains kubeconfig for the loadbalancer cluster |
-| kubelb.disableGRPCRouteController | bool | `false` | disableGRPCRouteController specifies whether to disable the GRPCRoute Controller. |
-| kubelb.disableGatewayController | bool | `false` | disableGatewayController specifies whether to disable the Gateway Controller. |
-| kubelb.disableHTTPRouteController | bool | `false` | disableHTTPRouteController specifies whether to disable the HTTPRoute Controller. |
-| kubelb.disableIngressController | bool | `false` | disableIngressController specifies whether to disable the Ingress Controller. |
-| kubelb.enableGatewayAPI | bool | `false` | enableGatewayAPI specifies whether to enable the Gateway API and Gateway Controllers. By default Gateway API is disabled since without Gateway APIs installed the controller cannot start. |
-| kubelb.enableLeaderElection | bool | `true` | Enable the leader election. |
-| kubelb.enableSecretSynchronizer | bool | `false` | Enable to automatically convert Secrets labelled with `kubelb.k8c.io/managed-by: kubelb` to Sync Secrets. This is used to sync secrets from tenants to the LB cluster in a controlled and secure way. |
-| kubelb.gatewayAPICRDsChannel | string | `"standard"` | gatewayAPICRDsChannel specifies the channel for the Gateway API CRDs. Options are `standard` and `experimental`. |
-| kubelb.ingressConversion.copyTLSSecrets | bool | `true` | copyTLSSecrets copies TLS secrets from Ingress namespace to Gateway namespace for cross-namespace certificate references |
-| kubelb.ingressConversion.disableEnvoyGatewayFeatures | bool | `false` | disableEnvoyGatewayFeatures disables creation of Envoy Gateway policies (SecurityPolicy, BackendTrafficPolicy) |
-| kubelb.ingressConversion.domainReplace | string | `""` | domainReplace is the domain suffix to replace in hostnames |
-| kubelb.ingressConversion.domainSuffix | string | `""` | domainSuffix is the replacement domain suffix for hostnames |
-| kubelb.ingressConversion.enabled | bool | `false` | enabled enables automatic Ingress to HTTPRoute conversion |
-| kubelb.ingressConversion.gatewayAnnotations | string | `""` | gatewayAnnotations are annotations to add to created Gateway (comma-separated key=value pairs) Example: "cert-manager.io/cluster-issuer=letsencrypt,external-dns.alpha.kubernetes.io/target=lb.example.com" |
-| kubelb.ingressConversion.gatewayClass | string | `"kubelb"` | gatewayClass is the GatewayClass name for created Gateway |
-| kubelb.ingressConversion.gatewayName | string | `"kubelb"` | gatewayName is the name of the Gateway for converted HTTPRoutes |
-| kubelb.ingressConversion.gatewayNamespace | string | `"kubelb"` | gatewayNamespace is the namespace for the shared Gateway (required) |
-| kubelb.ingressConversion.ingressClass | string | `""` | ingressClass filters Ingresses to convert (empty = convert all) |
-| kubelb.ingressConversion.propagateExternalDnsAnnotations | bool | `true` | propagateExternalDnsAnnotations propagates external-dns annotations to Gateway/HTTPRoute |
-| kubelb.ingressConversion.standaloneMode | bool | `false` | standaloneMode runs as standalone converter, disabling all other controllers |
-| kubelb.installGatewayAPICRDs | bool | `false` | installGatewayAPICRDs Installs and manages the Gateway API CRDs using gateway crd controller. |
-| kubelb.logLevel | string | `"info"` | To configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity. |
-| kubelb.nodeAddressType | string | `"ExternalIP"` | Address type to use for routing traffic to node ports. Values are ExternalIP, InternalIP. |
-| kubelb.tenantName | string | `nil` | Name of the tenant, must be unique against a load balancer cluster. |
-| kubelb.useGatewayClass | bool | `true` | useGatewayClass specifies whether to target resources with `kubelb` gateway class or all resources. |
-| kubelb.useIngressClass | bool | `true` | useIngressClass specifies whether to target resources with `kubelb` ingress class or all resources. |
-| kubelb.useLoadBalancerClass | bool | `false` | useLoadBalancerClass specifies whether to target services of type LoadBalancer with `kubelb` load balancer class or all services of type LoadBalancer. |
-| metrics.port | int | `9445` | Port where the CCM exposes metrics |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext.runAsNonRoot | bool | `true` |  |
-| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| priorityClassName | string | `""` | PriorityClassName for the manager pod (e.g., "system-cluster-critical") |
-| rbac.allowLeaderElectionRole | bool | `true` |  |
-| rbac.allowMetricsReaderRole | bool | `true` |  |
-| rbac.allowProxyRole | bool | `true` |  |
-| rbac.enabled | bool | `true` |  |
-| replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"500m"` |  |
-| resources.limits.memory | string | `"512Mi"` |  |
-| resources.requests.cpu | string | `"100m"` |  |
-| resources.requests.memory | string | `"128Mi"` |  |
-| securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.runAsUser | int | `65532` |  |
-| service.port | int | `8443` |  |
-| service.protocol | string | `"TCP"` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| serviceMonitor.enabled | bool | `false` |  |
-| tolerations | list | `[]` |  |
+The chart publishes the complete, version-matched configuration reference. Inspect it directly instead of relying on a copied values table:
+
+```sh
+helm show values oci://quay.io/kubermatic/helm-charts/kubelb-ccm --version=v1.4.3
+helm show readme oci://quay.io/kubermatic/helm-charts/kubelb-ccm --version=v1.4.3
+```
+
+You can also browse the [v1.4.3 Community Edition chart reference](https://github.com/kubermatic/kubelb/blob/v1.4.3/charts/kubelb-ccm/README.md#values).
 <!-- helm-values-kubelb-ccm end -->
 
 {{% /tab %}}
@@ -319,7 +174,7 @@ kubelb-ccm-7c9f7d6b8d-4qk2n   2/2     Running   0          1m
 
 The `kubelb-ccm` pod must be in `Running` state before load balancer services are reconciled.
 
-## Setup the tenant cluster
+## Set up the tenant cluster
 
 ### Install Gateway API CRDs
 


### PR DESCRIPTION
## What changed

- clarify KubeLB Manager and CCM prerequisites and Gateway API warnings
- correct the default tenant Secret name to `kubelb-cluster` and document its `kubelb` data key
- improve the tenant kubeconfig commands with consistent names and quoting
- normalize installation titles, headings, and terminology

The Helm values tables and their `helm-values-*` marker blocks remain unchanged; the KubeLB release pipeline continues to own and update them.

## Why

The tenant instructions mixed the Secret name, data key, and kubeconfig terminology, while several installation steps used ambiguous or incorrect wording.

## Impact

Readers get a consistent tenant bootstrap workflow without changing the generated chart reference or release automation.

## Validation

- verified all four release-managed Helm values blocks are byte-for-byte identical to the pre-PR content
- full Hugo build: 6,086 pages
- Chrome review of both installation pages and edition tabs

