### PR TITLE
docs: normalize KubeLB navigation and terminology

### DIFF
--- a/content/kubelb/main/ce-ee-matrix/_index.en.md
+++ b/content/kubelb/main/ce-ee-matrix/_index.en.md
@@ -7,8 +7,8 @@ weight = 8
 
 KubeLB is available in two editions:
 
-- **Community Edition (CE)**: Free, open source version that is available to the public. The CE is stable, production ready software available at <https://github.com/kubermatic/kubelb>
-- **Enterprise Edition (EE)**: Only available through an active subscription. In addition to the commercial support, SLAs for the product, the EE version contains a larger feature set in comparison to the CE version.
+- **Community Edition (CE):** Free, open source, and production-ready. Source code is available at <https://github.com/kubermatic/kubelb>.
+- **Enterprise Edition (EE):** Available with an active subscription. EE adds commercially supported features and product SLAs.
 
 {{% notice note %}}
 [Get in touch with Kubermatic](mailto:sales@kubermatic.com) to find out more about the KubeLB Enterprise offering.
@@ -37,9 +37,9 @@ KubeLB is available in two editions:
 | **Security** |||
 | Web Application Firewall (Beta) | ❌ | ✔️ |
 | Tenant self-service WAF policies (TenantWAFPolicy) | ❌ | ✔️ |
-| mTLS backend transport | ❌ | ✔️ |
+| mTLS backend transport (Beta) | ❌ | ✔️ |
 | Automated network policies | ❌ | ✔️ |
-| Airgap & Offline Support | ❌ | ✔️ |
+| Air-gapped and offline support | ❌ | ✔️ |
 | **Management** |||
 | Ingress to Gateway API Migration (Beta) | ✔️ | ✔️ |
 | Bring your own certificates | ✔️ | ✔️ |
@@ -48,7 +48,7 @@ KubeLB is available in two editions:
 | Gateway/LoadBalancer limits | ❌ | ✔️ |
 | Load Balancing Policies | ❌ | ✔️ |
 | Gateway API backend pools | ❌ | ✔️ |
-| CLI tunneling | ❌ | ✔️ |
+| CLI tunneling (Beta) | ❌ | ✔️ |
 | **Observability** |||
 | Prometheus metrics | ✔️ | ✔️ |
 | Grafana dashboards | ✔️ | ✔️ |

--- a/content/kubelb/main/cli/_index.en.md
+++ b/content/kubelb/main/cli/_index.en.md
@@ -2,7 +2,7 @@
 title = "KubeLB CLI"
 date = 2025-08-27T10:07:15+02:00
 weight = 30
-description = "Learn how you can use KubeLB CLI to provision Load Balancers and tunnels to expose local workloads"
+description = "Use KubeLB CLI to provision load balancers, create secure tunnels, and migrate Ingress resources to Gateway API."
 +++
 
 ![KubeLB CLI](/img/kubelb/common/logo.png?classes=logo-height)
@@ -14,7 +14,7 @@ KubeLB CLI is a command line tool that complements KubeLB and manages load balan
 The source code is open source and available at [kubermatic/kubelb-cli](https://github.com/kubermatic/kubelb-cli).
 
 {{% notice note %}}
-KubeLB CLI is currently in beta feature stage and is not yet ready for production use. We are actively working on the feature set and taking feedback from the community and our customers to improve the CLI.
+**Feature stage: Beta / Technical Preview.** KubeLB CLI is supported for non-business-critical use, but its commands and configuration may change between releases. Test workflows before adopting them broadly.
 {{% /notice %}}
 
 ## Installation

--- a/content/kubelb/main/cli/compatibility-matrix/_index.en.md
+++ b/content/kubelb/main/cli/compatibility-matrix/_index.en.md
@@ -1,6 +1,8 @@
 +++
 title = "CLI Compatibility Matrix"
+linkTitle = "Compatibility"
 date = 2025-08-27T00:00:00+01:00
+description = "Supported KubeLB CLI and management-cluster version combinations."
 weight = 30
 +++
 
@@ -9,10 +11,10 @@ KubeLB CLI uses the Kubernetes management cluster that has KubeLB installed as i
 Introduced alongside KubeLB v1.2, the CLI requires the KubeLB management cluster to be at least v1.2.
 
 {{% notice note %}}
-KubeLB CLI is in beta and not yet ready for production use.
+**Feature stage: Beta / Technical Preview.** Use KubeLB CLI for non-business-critical workflows and validate compatibility before upgrading.
 {{% /notice %}}
 
-| KubeLB CLI | KubeLB Management Cluster |
+| KubeLB CLI | KubeLB management cluster |
 |------------|---------------------------|
 | v0.1.0     | v1.2+                     |
 

--- a/content/kubelb/main/cli/ingress-to-gateway-api/_index.en.md
+++ b/content/kubelb/main/cli/ingress-to-gateway-api/_index.en.md
@@ -2,12 +2,13 @@
 title = "Ingress to Gateway API"
 linkTitle = "Ingress to Gateway API"
 date = 2026-02-04T00:00:00+01:00
+description = "Assess, preview, and convert Ingress resources to Gateway API with KubeLB CLI or its local dashboard."
 weight = 15
 aliases = ["/kubelb/main/ingress-to-gateway-api/cli-and-dashboard/"]
 +++
 
 {{% notice warning %}}
-**Beta Feature:** The Ingress conversion tools are provided on a best-effort basis. Not all NGINX annotations have Gateway API equivalents. Test thoroughly in non-production environments first.
+**Feature stage: Beta / Technical Preview.** Not all ingress-nginx annotations have Gateway API equivalents. Use these tools for non-business-critical migrations and validate every conversion before applying it.
 {{% /notice %}}
 
 KubeLB CLI ships with two interfaces for migrating Ingress resources to Gateway API: a **command-line workflow** and a **web dashboard**. Both use the same conversion engine and [configuration](#configuration) and produce identical results.

--- a/content/kubelb/main/cli/loadbalancing/_index.en.md
+++ b/content/kubelb/main/cli/loadbalancing/_index.en.md
@@ -1,6 +1,8 @@
 +++
 title = "Load Balancing"
+linkTitle = "Load Balancers"
 date = 2025-08-27T00:00:00+01:00
+description = "Create public or private load balancers for external endpoints with KubeLB CLI."
 weight = 20
 +++
 
@@ -18,7 +20,7 @@ Create a load balancer with the `kubelb loadbalancer create` command:
 kubelb loadbalancer create my-app --endpoints 10.0.1.1:8080,10.0.1.2:8080 --hostname my-app.example.com
 ```
 
-This creates a Load Balancer resource that forwards traffic to the endpoints `10.0.1.1:8080` and `10.0.1.2:8080` and is accessible at `https://my-app.example.com`.
+This creates a `LoadBalancer` resource that forwards traffic to the endpoints `10.0.1.1:8080` and `10.0.1.2:8080` and is accessible at `https://my-app.example.com`.
 
 The hostname is optional; if omitted, KubeLB generates a random hostname when a wildcard domain is enabled for the tenant or globally.
 

--- a/content/kubelb/main/cli/tunneling/_index.en.md
+++ b/content/kubelb/main/cli/tunneling/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "Tunneling"
 date = 2025-08-27T00:00:00+01:00
+description = "Expose local applications through reusable, TLS-secured KubeLB tunnels."
 weight = 10
 enterprise = true
 +++

--- a/content/kubelb/main/dashboard/_index.en.md
+++ b/content/kubelb/main/dashboard/_index.en.md
@@ -9,7 +9,7 @@ description = "Web UI for KubeLB: browse tenants, LoadBalancers, and Routes, vie
 ## Overview
 
 KubeLB Dashboard is the web UI for KubeLB. A single chart and binary cover both
-Community and Enterprise editions; there is no separate EE build. Source code
+Community Edition and Enterprise Edition; there is no separate EE build. Source code
 and upstream documentation are at
 [kubermatic/kubelb-dashboard](https://github.com/kubermatic/kubelb-dashboard).
 

--- a/content/kubelb/main/ingress-to-gateway-api/_index.en.md
+++ b/content/kubelb/main/ingress-to-gateway-api/_index.en.md
@@ -112,7 +112,7 @@ You cannot gradually shift traffic percentages between Ingress and Gateway, and 
 
 ## Migration Options
 
-### Option 1: KubeLB [Beta]
+### Option 1: KubeLB (Beta)
 
 KubeLB includes a migration tool that converts Ingress resources to Gateway API. It is free to use and open source.
 

--- a/content/kubelb/main/ingress-to-gateway-api/cert-manager/_index.en.md
+++ b/content/kubelb/main/ingress-to-gateway-api/cert-manager/_index.en.md
@@ -1,7 +1,8 @@
 +++
-title = "Cert Manager Migration"
-linkTitle = "Cert Manager"
+title = "cert-manager Migration"
+linkTitle = "cert-manager"
 date = 2026-01-30T00:00:00+01:00
+description = "Update cert-manager to issue certificates for Gateway API resources during an Ingress migration."
 weight = 3
 +++
 

--- a/content/kubelb/main/ingress-to-gateway-api/external-dns/_index.en.md
+++ b/content/kubelb/main/ingress-to-gateway-api/external-dns/_index.en.md
@@ -1,7 +1,8 @@
 +++
-title = "External DNS Migration"
-linkTitle = "External DNS"
+title = "external-dns Migration"
+linkTitle = "external-dns"
 date = 2026-01-30T00:00:00+01:00
+description = "Configure external-dns to manage records for Gateway API resources during an Ingress migration."
 weight = 4
 +++
 

--- a/content/kubelb/main/ingress-to-gateway-api/kubelb-automation/_index.en.md
+++ b/content/kubelb/main/ingress-to-gateway-api/kubelb-automation/_index.en.md
@@ -1,12 +1,13 @@
 +++
-title = "Automated Conversion with KubeLB [Beta]"
-linkTitle = "KubeLB Automation"
+title = "Automated Conversion with KubeLB (Beta)"
+linkTitle = "Automated Conversion"
 date = 2026-01-30T00:00:00+01:00
+description = "Continuously convert ingress-nginx resources to Gateway API with KubeLB's Beta migration controller."
 weight = 1
 +++
 
 {{% notice warning %}}
-**Beta Feature:** This converter is provided on a best-effort basis. Not all NGINX annotations have Gateway API equivalents. Test thoroughly in non-production environments first. Some configurations will require manual intervention.
+**Feature stage: Beta / Technical Preview.** Not all ingress-nginx annotations have Gateway API equivalents. Use the converter for non-business-critical migrations, validate every generated resource, and expect some configurations to require manual changes.
 {{% /notice %}}
 
 KubeLB can automatically convert Ingress resources to Gateway API. It watches your Ingresses and creates the equivalent HTTPRoutes and GRPCRoutes.

--- a/content/kubelb/main/insights/checks/_index.en.md
+++ b/content/kubelb/main/insights/checks/_index.en.md
@@ -2,6 +2,7 @@
 title = "Check Catalog"
 linkTitle = "Check Catalog"
 date = 2026-07-29T10:00:00+02:00
+description = "Reference for KubeLB Insights checks, prerequisites, findings, and remediation."
 weight = 10
 +++
 

--- a/content/kubelb/main/installation/air-gap/_index.en.md
+++ b/content/kubelb/main/installation/air-gap/_index.en.md
@@ -18,9 +18,9 @@ KubeLB charts are configured to pull every image from that mirror.
 What is supported:
 
 - Registry rewrite for charts and images across the entire stack: manager, CCM, connection-manager,
-  Envoy proxy data plane, and all addons, etc.
+  Envoy Proxy data plane, and all addons, etc.
 - A single `imagePullSecret` propagated to manager, CCM, connection-manager and
-  all addon workloads, including manager-created Envoy proxy pods.
+  all addon workloads, including manager-created Envoy Proxy pods.
 - A self-contained mirror bundle shipped inside the `kubelb-manager-ee` Helm
   chart at `airgapped/`. Everything you need to mirror is in there, including a script that uses `crane` to copy all images and charts to your mirror in one shot.
 
@@ -66,7 +66,7 @@ You will find:
 |------|----------|
 | `artifacts.txt` | Union of `images.txt` + `charts.txt` (oci:// stripped) — the default input for `mirror-images.sh`. This includes all the artifacts(images, charts) shipped or used by KubeLB |
 | `images.txt` | Every container image (manager + CCM + all addons) |
-| `images-core.txt` | Images rendered from the manager and CCM charts (manager, CCM, connection-manager, kube-rbac-proxy) plus the runtime images referenced in code (Envoy proxy, Envoy Gateway shutdown manager); no addons |
+| `images-core.txt` | Images rendered from the manager and CCM charts (manager, CCM, connection-manager, kube-rbac-proxy) plus the runtime images referenced in code (Envoy Proxy, Envoy Gateway shutdown manager); no addons |
 | `images-<addon>.txt` | Per-addon images: `agentgateway`, `cert-manager`, `envoy-gateway`, `external-dns`, `ingress-nginx`, `metallb` |
 | `images-valkey.txt` | Valkey images, required for the AI budget rate-limit path |
 | `images-ratelimit.txt` | Envoy rate-limit service images, required for the AI budget rate-limit path |
@@ -151,14 +151,14 @@ helm install kubelb-manager \
 ```
 
 `global.imageRegistry` rewrites every image referenced by the chart, including
-the manager binary, `kube-rbac-proxy`, the connection-manager, the Envoy proxy
+the manager binary, `kube-rbac-proxy`, the connection-manager, the Envoy Proxy
 data plane and the Envoy Gateway shutdown manager. `global.imagePullSecrets` is
 propagated to every pod spec the chart and the manager controllers create.
 
 ### How the runtime rewrite works
 
 The chart passes `global.imageRegistry` to the manager binary as the
-`--image-registry` flag. At runtime the manager rewrites the Envoy proxy,
+`--image-registry` flag. At runtime the manager rewrites the Envoy Proxy,
 shutdown-manager, and WAF WASM init-container images before creating pods:
 the first path segment is stripped when it contains a dot or a colon (i.e.
 when it is a registry host), and the mirror registry is prepended. For
@@ -276,7 +276,7 @@ helm template kubelb-addons oci://mirror.internal/kubermatic/helm-charts/kubelb-
 
 The `mirror-creds` pull secret is missing from a namespace where KubeLB schedules
 workloads. The CCM install only puts it in `kubelb`. If you have set
-`kubelb.namespace` or the manager creates Envoy proxy pods in a different
+`kubelb.namespace` or the manager creates Envoy Proxy pods in a different
 namespace, copy the secret there too, or re-run Step 3 with the additional
 namespace.
 
@@ -287,7 +287,7 @@ to find the offender. If a specific image is not getting rewritten, file an
 issue against `kubermatic/kubelb-ee`; the air-gap patch for that addon
 chart needs an update.
 
-### Manager-created Envoy proxy pods pull from `docker.io`
+### Manager-created Envoy Proxy pods pull from `docker.io`
 
 The Envoy data plane and the Envoy Gateway shutdown manager are exposed on the
 manager chart as `kubelb.envoyProxy.image` and

--- a/content/kubelb/main/installation/configuration/_index.en.md
+++ b/content/kubelb/main/installation/configuration/_index.en.md
@@ -2,12 +2,12 @@
 title = "KubeLB Management Cluster Configuration"
 linkTitle = "Management Configuration"
 date = 2023-10-27T10:07:15+02:00
-description = "Configure the KubeLB manager in the management cluster through the Config CRD."
+description = "Configure KubeLB Manager in the management cluster through the Config CRD."
 weight = 40
 aliases = ["/kubelb/main/tutorials/config/"]
 +++
 
-The `Config` CRD manages the configuration of the KubeLB manager in the management cluster. Example:
+The `Config` CRD manages KubeLB Manager configuration in the management cluster. Example:
 
 ```yaml
 apiVersion: kubelb.k8c.io/v1alpha1
@@ -208,7 +208,7 @@ spec:
     # The class to use for LB service in the management cluster
     class: "metallb.universe.tf/metallb"
     disable: false
-    # Enterprise Edition Only
+    # Enterprise Edition only
     limit: 5
 ```
 
@@ -269,7 +269,7 @@ spec:
     defaultGateway:
       name: "default"
       namespace: "envoy-gateway"
-    # Enterprise Edition Only (all the below options are only available in Enterprise Edition)
+    # All options below are available in Enterprise Edition only.
     gateway:
       limit: 10
     disableHTTPRoute: false

--- a/content/kubelb/main/installation/requirements/_index.en.md
+++ b/content/kubelb/main/installation/requirements/_index.en.md
@@ -14,15 +14,15 @@ See the [Compatibility Matrix]({{< relref "../../compatibility-matrix" >}}) for 
 
 Use a dedicated cluster as the KubeLB management cluster. It hosts the data plane for all tenants and should not run unrelated workloads.
 
-The KubeLB manager must be installed in the `kubelb` namespace. The Envoy proxy pods connect to the xDS control plane at the hard-coded address `envoycp.kubelb.svc:8001`, so installing the manager in any other namespace breaks the data plane.
+KubeLB Manager must be installed in the `kubelb` namespace. The Envoy Proxy pods connect to the xDS control plane at the hard-coded address `envoycp.kubelb.svc:8001`, so installing the manager in any other namespace breaks the data plane.
 
 ## Network connectivity
 
 | Direction | Source | Destination | Port/Protocol | Purpose | Required |
 |-----------|--------|-------------|---------------|---------|----------|
 | Tenant to Management | KubeLB CCM | Management cluster Kubernetes API server | HTTPS, typically 6443 | The CCM connects to the management cluster using the kubeconfig stored in the `kubelb-cluster` secret. The API endpoint advertised in the management cluster's `kube-public/cluster-info` ConfigMap must be reachable from all tenant clusters. | Always |
-| Management to Tenant | Envoy proxy pods | Tenant cluster node addresses | NodePort range, default 30000-32767/TCP,UDP | Direct backend transport mode (default). Traffic is forwarded to the node address selected by `nodeAddressType`. | Direct mode |
-| Management to Tenant | Envoy proxy pods | Tenant proxy | Tenant proxy NodePort, or 15443/TCP with `serviceType: LoadBalancer` | mTLS backend transport mode (Enterprise Edition). All backend traffic goes through the encrypted tenant proxy instead of plain NodePorts. | mTLS mode |
+| Management to Tenant | Envoy Proxy pods | Tenant cluster node addresses | NodePort range, default 30000-32767/TCP,UDP | Direct backend transport mode (default). Traffic is forwarded to the node address selected by `nodeAddressType`. | Direct mode |
+| Management to Tenant | Envoy Proxy pods | Tenant proxy | Tenant proxy NodePort, or 15443/TCP with `serviceType: LoadBalancer` | mTLS backend transport mode (Enterprise Edition). All backend traffic goes through the encrypted tenant proxy instead of plain NodePorts. | mTLS mode |
 | Clients to Management | Application clients | LoadBalancer services and Gateway listeners in the management cluster | Service-defined ports; Envoy data plane listener ports are allocated from 10000-65535 | Application traffic provisioned by KubeLB. | Always |
 | Tenant/CLI to Management | Tunnel agents and `kubelb` CLI | Tunnel connection manager, exposed via Ingress or HTTPRoute | HTTPS, 443 | Tunneling (Enterprise Edition). Connections are outbound-only from the tenant side. | Tunneling |
 
@@ -30,16 +30,16 @@ The KubeLB manager must be installed in the `kubelb` namespace. The Envoy proxy 
 
 | Port | Protocol | Component | Scope | Purpose |
 |------|----------|-----------|-------|---------|
-| 8001 | TCP | KubeLB manager | In-cluster | Envoy xDS control plane (`envoycp` service) |
-| 9443 | TCP | KubeLB manager | Pod | Metrics endpoint, exposed via kube-rbac-proxy service on 8443 |
-| 8081 | TCP | KubeLB manager | Pod | Health and readiness probes |
+| 8001 | TCP | KubeLB Manager | In-cluster | Envoy xDS control plane (`envoycp` service) |
+| 9443 | TCP | KubeLB Manager | Pod | Metrics endpoint, exposed via kube-rbac-proxy service on 8443 |
+| 8081 | TCP | KubeLB Manager | Pod | Health and readiness probes |
 | 9445 | TCP | KubeLB CCM | Pod | Metrics endpoint, exposed via kube-rbac-proxy service on 8443 |
 | 8081 | TCP | KubeLB CCM | Pod | Health and readiness probes |
-| 9001 | TCP | Envoy proxy pod | Localhost, unless debug mode is enabled | Envoy admin interface |
-| 19001 | TCP | Envoy proxy pod | Pod | Stats endpoint (`/stats/prometheus`) |
-| 19002 | TCP | Envoy proxy pod | Pod | Shutdown manager |
-| 19003 | TCP | Envoy proxy pod | Pod | Readiness |
-| 19004 | TCP | Envoy proxy pod | Pod | Health check listener |
+| 9001 | TCP | Envoy Proxy pod | Localhost, unless debug mode is enabled | Envoy admin interface |
+| 19001 | TCP | Envoy Proxy pod | Pod | Stats endpoint (`/stats/prometheus`) |
+| 19002 | TCP | Envoy Proxy pod | Pod | Shutdown manager |
+| 19003 | TCP | Envoy Proxy pod | Pod | Readiness |
+| 19004 | TCP | Envoy Proxy pod | Pod | Health check listener |
 | 15443 | TCP | Tenant proxy (EE) | Tenant cluster, reachable from management cluster | mTLS backend transport listener |
 | 19000 | TCP | Tenant proxy (EE) | Pod | Envoy admin interface |
 | 19001 | TCP | Tenant proxy (EE) | Pod | Stats endpoint |
@@ -55,10 +55,10 @@ The KubeLB manager must be installed in the `kubelb` namespace. The Envoy proxy 
 | kubelb-manager | 100m CPU / 128Mi | 500m CPU / 512Mi |
 | kubelb-ccm | 100m CPU / 128Mi | 500m CPU / 512Mi |
 | Connection manager (EE) | 250m CPU / 128Mi | 500m CPU / 256Mi |
-| Envoy proxy pods | none | none |
+| Envoy Proxy pods | none | none |
 | Tenant proxy Envoy (EE) | 100m CPU / 128Mi | 1 CPU / 512Mi |
 
-The managed Envoy proxy pods ship with no default requests or limits (`kubelb.envoyProxy.resources: {}`). Set them for production so the data plane gets scheduled with guaranteed capacity and cannot starve other workloads. Envoy proxies default to 2 replicas with one pod per node.
+The managed Envoy Proxy pods ship with no default requests or limits (`kubelb.envoyProxy.resources: {}`). Set them for production so the data plane gets scheduled with guaranteed capacity and cannot starve other workloads. Envoy Proxy defaults to 2 replicas with one pod per node.
 
 ## Next steps
 

--- a/content/kubelb/main/observability/metric-references/_index.en.md
+++ b/content/kubelb/main/observability/metric-references/_index.en.md
@@ -2,6 +2,7 @@
 title = "Metric References"
 linkTitle = "Metric References"
 date = 2026-07-29T00:00:00+02:00
+description = "Prometheus metric references for KubeLB Community Edition and Enterprise Edition components."
 weight = 30
 aliases = ["/kubelb/main/tutorials/observability/metrics-and-dashboards/references/"]
 +++

--- a/content/kubelb/main/observability/metric-references/ce/_index.en.md
+++ b/content/kubelb/main/observability/metric-references/ce/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "Community Edition"
 linkTitle = "Community Edition"
+description = "Prometheus metric reference for KubeLB Community Edition components."
 date = 2026-07-29T00:00:00+02:00
 weight = 10
 aliases = ["/kubelb/main/tutorials/observability/metrics-and-dashboards/references/ce/"]

--- a/content/kubelb/main/observability/metric-references/ee/_index.en.md
+++ b/content/kubelb/main/observability/metric-references/ee/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "Enterprise Edition"
 linkTitle = "Enterprise Edition"
+description = "Prometheus metric reference for KubeLB Enterprise Edition components."
 date = 2026-07-29T00:00:00+02:00
 weight = 20
 enterprise = true

--- a/content/kubelb/main/observability/metrics-and-dashboards/envoy-proxy/_index.en.md
+++ b/content/kubelb/main/observability/metrics-and-dashboards/envoy-proxy/_index.en.md
@@ -2,6 +2,7 @@
 title = "Envoy Proxy Dashboard"
 linkTitle = "Envoy Proxy"
 date = 2026-07-29T00:00:00+02:00
+description = "Monitor KubeLB-managed Envoy Proxy health, connections, request performance, and configuration in Grafana."
 weight = 20
 aliases = ["/kubelb/main/tutorials/observability/metrics-and-dashboards/envoy-proxy/"]
 +++

--- a/content/kubelb/main/observability/metrics-and-dashboards/kubelb/_index.en.md
+++ b/content/kubelb/main/observability/metrics-and-dashboards/kubelb/_index.en.md
@@ -2,6 +2,7 @@
 title = "KubeLB Dashboards"
 linkTitle = "KubeLB"
 date = 2026-07-29T00:00:00+02:00
+description = "Overview of the Grafana dashboards for KubeLB Manager, CCM, controllers, and fleet health."
 weight = 10
 aliases = ["/kubelb/main/tutorials/observability/metrics-and-dashboards/kubelb/"]
 +++

--- a/content/kubelb/main/observability/traffic-flow/_index.en.md
+++ b/content/kubelb/main/observability/traffic-flow/_index.en.md
@@ -2,6 +2,7 @@
 title = "Traffic Flow Visibility"
 linkTitle = "Traffic Flow"
 date = 2026-07-29T00:00:00+02:00
+description = "Use Hubble or Kiali to visualize traffic through KubeLB and its tenant backends."
 weight = 20
 aliases = ["/kubelb/main/tutorials/observability/traffic-flow/"]
 +++

--- a/content/kubelb/main/references/ce/_index.en.md
+++ b/content/kubelb/main/references/ce/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "KubeLB Community Edition CRD References"
 linkTitle = "Community Edition"
+description = "Custom Resource Definition reference for KubeLB Community Edition."
 date = 2024-04-06T12:00:00+02:00
 weight = 10
 +++

--- a/content/kubelb/main/references/ee/_index.en.md
+++ b/content/kubelb/main/references/ee/_index.en.md
@@ -1,6 +1,7 @@
 +++
 title = "KubeLB Enterprise Edition CRD References"
 linkTitle = "Enterprise Edition"
+description = "Custom Resource Definition reference for KubeLB Enterprise Edition."
 date = 2024-03-06T12:00:00+02:00
 weight = 20
 enterprise = true

--- a/content/kubelb/main/security/vulnerability-reporting/_index.en.md
+++ b/content/kubelb/main/security/vulnerability-reporting/_index.en.md
@@ -2,6 +2,7 @@
 title = "Vulnerability Reporting"
 linkTitle = "Vulnerability Reporting"
 date = 2026-01-16T00:00:00+02:00
+description = "Private vulnerability reporting process, response targets, and disclosure expectations for KubeLB."
 weight = 10
 +++
 

--- a/content/kubelb/main/support-policy/_index.en.md
+++ b/content/kubelb/main/support-policy/_index.en.md
@@ -5,9 +5,9 @@ description = "What Enterprise Edition support covers, what it does not, and how
 weight = 45
 +++
 
-KubeLB has an open-source community edition and an enterprise edition. The community edition is free to use and is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+KubeLB Community Edition is free to use and licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
-The enterprise edition requires an active [KubeLB subscription](https://www.kubermatic.com/products/kubelb/), which includes SLA-backed support from the Kubermatic engineering team.
+Enterprise Edition requires an active [KubeLB subscription](https://www.kubermatic.com/products/kubelb/), which includes SLA-backed support from the Kubermatic engineering team.
 
 ## Enterprise Edition Support
 

--- a/content/kubelb/main/tutorials/_index.en.md
+++ b/content/kubelb/main/tutorials/_index.en.md
@@ -2,12 +2,20 @@
 title = "Guides"
 linkTitle = "Guides"
 date = 2023-10-27T10:07:15+02:00
-description = "Get familiar with KubeLB and read step-by-step instructions to handle important scenarios"
+description = "Task-oriented guides for exposing workloads, managing tenants, tuning Envoy Proxy, and securing KubeLB traffic."
 weight = 20
 chapter = true
 +++
 
-## Table of Contents
+Choose the path that matches your task:
+
+- Start with [Tenants]({{< relref "./tenants" >}}) when connecting a cluster to KubeLB.
+- Expose workloads with [TCP/UDP load balancing]({{< relref "./loadbalancer" >}}), [Ingress]({{< relref "./ingress" >}}), or [Gateway API]({{< relref "./gatewayapi" >}}).
+- Tune data-plane behavior under [Envoy Proxy]({{< relref "./envoy-proxy" >}}).
+- Configure certificates, DNS, secrets, and policies under [Security]({{< relref "./security" >}}).
+- Build managed AI endpoints under [AI]({{< relref "./ai" >}}).
+
+## All guides
 
 {{% children depth=2 %}}
 {{% /children %}}

--- a/content/kubelb/main/tutorials/backend-tls/_index.en.md
+++ b/content/kubelb/main/tutorials/backend-tls/_index.en.md
@@ -2,6 +2,7 @@
 title = "Backend TLS Re-encryption"
 linkTitle = "Backend TLS"
 date = 2026-04-23T10:00:00+02:00
+description = "Encrypt Layer 4 connections from KubeLB's Envoy Proxy to TLS-enabled backend services."
 weight = 40
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/bgp/_index.en.md
+++ b/content/kubelb/main/tutorials/bgp/_index.en.md
@@ -1,7 +1,8 @@
 +++
-title = "Layer 4 Load balancing with BGP"
-linkTitle = "BGP Support"
+title = "Layer 4 Load Balancing with BGP"
+linkTitle = "BGP"
 date = 2025-08-27T10:07:15+02:00
+description = "Advertise Layer 4 load balancer addresses with BGP by integrating KubeLB with MetalLB."
 weight = 5
 +++
 
@@ -11,7 +12,7 @@ KubeLB therefore works with any load balancing appliance, regardless of the rout
 
 ## Setup
 
-We'll use [MetalLB](https://metallb.universe.tf) with BGP for this tutorial. Update the values.yaml file for KubeLB manager to enable metallb:
+We'll use [MetalLB](https://metallb.universe.tf) with BGP for this tutorial. Update `values.yaml` for KubeLB Manager to enable MetalLB:
 
 ```yaml
 kubelb-addons:

--- a/content/kubelb/main/tutorials/client-ip-preservation/_index.en.md
+++ b/content/kubelb/main/tutorials/client-ip-preservation/_index.en.md
@@ -2,6 +2,7 @@
 title = "Client IP Preservation"
 linkTitle = "Client IP Preservation"
 date = 2025-01-16T10:00:00+02:00
+description = "Preserve original client IP addresses across KubeLB's multi-cluster Layer 4 and Layer 7 traffic paths."
 weight = 6
 +++
 

--- a/content/kubelb/main/tutorials/envoy-proxy/circuit-breakers/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/circuit-breakers/_index.en.md
@@ -2,6 +2,7 @@
 title = "Circuit Breakers"
 linkTitle = "Circuit Breakers"
 date = 2025-01-16T10:00:00+02:00
+description = "Configure global and per-tenant Envoy circuit-breaker thresholds to protect upstream services."
 weight = 3
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/envoy-proxy/endpoint-limiting/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/endpoint-limiting/_index.en.md
@@ -2,6 +2,7 @@
 title = "Endpoint Limiting"
 linkTitle = "Endpoint Limiting"
 date = 2025-01-16T10:00:00+02:00
+description = "Limit Envoy upstream endpoints to reduce health-check fan-out in large KubeLB environments."
 weight = 4
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/envoy-proxy/graceful-shutdown/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/graceful-shutdown/_index.en.md
@@ -2,6 +2,7 @@
 title = "Graceful Shutdown"
 linkTitle = "Graceful Shutdown"
 date = 2025-01-16T10:00:00+02:00
+description = "Drain Envoy Proxy connections during pod termination to prevent request failures during rollouts."
 weight = 1
 +++
 

--- a/content/kubelb/main/tutorials/envoy-proxy/health-checks/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/health-checks/_index.en.md
@@ -2,6 +2,7 @@
 title = "Health Checks"
 linkTitle = "Health Checks"
 date = 2026-07-22T10:00:00+02:00
+description = "Configure TCP, HTTP, and gRPC active health checks across KubeLB configuration levels."
 weight = 6
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/envoy-proxy/overload-manager/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/overload-manager/_index.en.md
@@ -2,6 +2,7 @@
 title = "Overload Manager"
 linkTitle = "Overload Manager"
 date = 2025-01-16T10:00:00+02:00
+description = "Protect Envoy Proxy instances from memory and connection exhaustion with overload actions."
 weight = 2
 +++
 

--- a/content/kubelb/main/tutorials/envoy-proxy/timeouts/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/timeouts/_index.en.md
@@ -2,6 +2,7 @@
 title = "Timeouts"
 linkTitle = "Timeouts"
 date = 2026-05-05T10:00:00+02:00
+description = "Configure HTTP and TCP timeouts globally, per tenant, or per route for KubeLB traffic."
 weight = 5
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/gatewayapi/_index.en.md
+++ b/content/kubelb/main/tutorials/gatewayapi/_index.en.md
@@ -14,7 +14,7 @@ In KubeLB, the admins of the management cluster are the Platform Provider, respo
 
 Kubermatic's default recommendation is to use Gateway API and use [Envoy Gateway](https://gateway.envoyproxy.io/) as the Gateway API implementation. Install Envoy Gateway by following this [guide](https://gateway.envoyproxy.io/docs/install/install-helm/) or any other Gateway API implementation of your choice.
 
-Update values.yaml for KubeLB manager chart to enable the Gateway API addon.
+Update `values.yaml` for the KubeLB Manager chart to enable the Gateway API addon.
 
 ```yaml
 kubelb:
@@ -64,7 +64,7 @@ spec:
 
 **Leave it empty if you named your Gateway Class as `kubelb`**
 
-### Gateway Class Mappings (Enterprise Edition Only)
+### Gateway Class Mappings (Enterprise Edition only)
 
 A tenant is not limited to a single gateway class. `classMappings` maps gateway class names used in the tenant cluster (`source`) to gateway class names in the management cluster (`target`). Mappings can be set globally on the `Config` and overridden per tenant; a tenant mapping replaces a global mapping with the same `source`. Up to 32 mappings are allowed per resource.
 

--- a/content/kubelb/main/tutorials/gatewayapi/backend-pools/_index.en.md
+++ b/content/kubelb/main/tutorials/gatewayapi/backend-pools/_index.en.md
@@ -2,6 +2,7 @@
 title = "Backend Pools"
 linkTitle = "Backend Pools"
 date = 2026-07-10T00:00:00+05:00
+description = "Combine multiple KubeLB load balancers behind one HTTPRoute with health-aware failover and session affinity."
 weight = 6
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/gatewayapi/backend-traffic-policy/_index.en.md
+++ b/content/kubelb/main/tutorials/gatewayapi/backend-traffic-policy/_index.en.md
@@ -2,6 +2,7 @@
 title = "Backend Traffic Policy"
 linkTitle = "Backend Traffic Policy"
 date = 2025-01-16T10:00:00+02:00
+description = "Synchronize Envoy Gateway BackendTrafficPolicy resources to configure retries, timeouts, and upstream behavior."
 weight = 5
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/gatewayapi/client-traffic-policy/_index.en.md
+++ b/content/kubelb/main/tutorials/gatewayapi/client-traffic-policy/_index.en.md
@@ -2,6 +2,7 @@
 title = "Client Traffic Policy"
 linkTitle = "Client Traffic Policy"
 date = 2025-01-16T10:00:00+02:00
+description = "Synchronize Envoy Gateway ClientTrafficPolicy resources to configure downstream connections and TLS."
 weight = 4
 enterprise = true
 +++

--- a/content/kubelb/main/tutorials/ingress/_index.en.md
+++ b/content/kubelb/main/tutorials/ingress/_index.en.md
@@ -2,6 +2,7 @@
 title = "Ingress"
 linkTitle = "Ingress"
 date = 2023-10-27T10:07:15+02:00
+description = "Set up Layer 7 load balancing with Kubernetes Ingress and plan migration to Gateway API."
 weight = 4
 +++
 
@@ -56,7 +57,7 @@ spec:
 
 ### Shared
 
-Update values.yaml for KubeLB manager chart to enable the ingress-nginx addon.
+Update `values.yaml` for the KubeLB Manager chart to enable the ingress-nginx addon.
 
 ```yaml
 kubelb-addons:

--- a/content/kubelb/main/tutorials/loadbalancer/_index.en.md
+++ b/content/kubelb/main/tutorials/loadbalancer/_index.en.md
@@ -2,6 +2,7 @@
 title = "TCP/UDP Load Balancing"
 linkTitle = "TCP/UDP Load Balancing"
 date = 2023-10-27T10:07:15+02:00
+description = "Set up Layer 4 TCP and UDP load balancing with Kubernetes LoadBalancer Services."
 weight = 2
 +++
 
@@ -209,7 +210,7 @@ Configure the CCM through the KubeLB CCM helm chart. Common options:
 kubelb:
   # Use ExternalIP or InternalIP in the management cluster to route traffic back to the node ports of the tenant cluster.
   nodeAddressType: ExternalIP
-  # This can be enabled to use KubeLB in a cluster where another load balancer provider is already running. When enabled, kubeLB will only manage
+  # This can be enabled to use KubeLB in a cluster where another load balancer provider is already running. When enabled, KubeLB will only manage
   # services of type LoadBalancer that are using the `kubelb` LoadBalancerClass.
   useLoadBalancerClass: false
 ```

--- a/content/kubelb/main/tutorials/security/cert-management/_index.en.md
+++ b/content/kubelb/main/tutorials/security/cert-management/_index.en.md
@@ -2,13 +2,14 @@
 title = "Certificate Management"
 linkTitle = "Certificate Management"
 date = 2023-10-27T10:07:15+02:00
+description = "Automate tenant TLS certificates with cert-manager and KubeLB Enterprise Edition."
 weight = 1
 enterprise = true
 +++
 
 ## Setup
 
-### Install Cert-Manager
+### Install cert-manager
 
 Install [cert-manager](https://cert-manager.io) to manage certificates for your tenants.
 
@@ -17,7 +18,7 @@ These are minimal examples. See the [cert-manager documentation](https://cert-ma
 {{< tabs name="cert-manager" >}}
 {{% tab name="Gateway API" %}}
 
-Update values.yaml for KubeLB manager chart to enable the cert-manager addon.
+Update `values.yaml` for the KubeLB Manager chart to enable the cert-manager addon.
 
 ```yaml
 kubelb-addons:
@@ -35,7 +36,7 @@ kubelb-addons:
 {{% /tab %}}
 {{% tab name="Ingress" %}}
 
-Update values.yaml for KubeLB manager chart to enable the cert-manager addon.
+Update `values.yaml` for the KubeLB Manager chart to enable the cert-manager addon.
 
 ```yaml
 kubelb-addons:

--- a/content/kubelb/main/tutorials/security/dns/_index.en.md
+++ b/content/kubelb/main/tutorials/security/dns/_index.en.md
@@ -2,19 +2,20 @@
 title = "DNS Management"
 linkTitle = "DNS Management"
 date = 2023-10-27T10:07:15+02:00
+description = "Automate tenant DNS records with external-dns and KubeLB Enterprise Edition."
 weight = 2
 enterprise = true
 +++
 
 ## Setup
 
-### Install External-dns
+### Install external-dns
 
 KubeLB uses [external-dns](https://github.com/kubernetes-sigs/external-dns) to manage DNS records for the tenant clusters.
 
 This is a minimal example. See the [external-dns documentation](https://kubernetes-sigs.github.io/external-dns) for setup with other providers.
 
-Update the values.yaml for KubeLB manager chart to enable the external-dns addon.
+Update `values.yaml` for the KubeLB Manager chart to enable the external-dns addon.
 
 ```yaml
 kubelb-addons:

--- a/content/kubelb/main/tutorials/security/network-policies/_index.en.md
+++ b/content/kubelb/main/tutorials/security/network-policies/_index.en.md
@@ -2,6 +2,7 @@
 title = "Automated Network Policies"
 linkTitle = "Network Policies"
 date = 2026-04-23T10:00:00+02:00
+description = "Generate tenant-isolation NetworkPolicies from global defaults and per-tenant overrides."
 weight = 3
 enterprise = true
 +++
@@ -49,7 +50,7 @@ The controller creates the following policies in each tenant namespace. Names ar
 | --- | --- |
 | `kubelb-deny-all-ingress` | Default deny all ingress traffic to tenant namespace. |
 | `kubelb-allow-same-namespace` | Allow pod-to-pod traffic within the tenant namespace. |
-| `kubelb-allow-manager-ingress` | Allow ingress from the KubeLB manager namespace. |
+| `kubelb-allow-manager-ingress` | Allow ingress from the KubeLB Manager namespace. |
 | `kubelb-allow-dns-egress` | Allow DNS resolution via `kube-system` on port 53 (UDP/TCP). |
 | `kubelb-allow-xds-egress` | Allow xDS control-plane communication to the manager on port 8001/TCP. |
 | `kubelb-allow-metrics-ingress` | Allow Prometheus metrics scraping on port 19001/TCP. |

--- a/content/kubelb/main/tutorials/security/secrets/_index.en.md
+++ b/content/kubelb/main/tutorials/security/secrets/_index.en.md
@@ -1,7 +1,8 @@
 +++
 title = "Bring Your Own Secrets"
-linkTitle = "Bring Your Own Secrets"
+linkTitle = "Secrets"
 date = 2023-10-27T10:07:15+02:00
+description = "Synchronize selected Kubernetes Secrets from tenant clusters to the KubeLB management cluster."
 weight = 4
 +++
 

--- a/content/kubelb/main/tutorials/tenants/_index.en.md
+++ b/content/kubelb/main/tutorials/tenants/_index.en.md
@@ -2,6 +2,7 @@
 title = "Tenants"
 linkTitle = "Tenants"
 date = 2023-10-27T10:07:15+02:00
+description = "Register KubeLB tenants and configure per-tenant load-balancing, DNS, certificate, and quota settings."
 weight = 1
 +++
 
@@ -11,7 +12,7 @@ Tenants are the consumers of the load balancer services in the management cluste
 Tenant configuration has a higher precedence than the global configuration and overrides the global configuration values for the tenant if the fields are available in both the tenant and global configuration.
 {{% /notice %}}
 
-## Kubermatic Kubernetes Platform (Enterprise Edition Only)
+## Kubermatic Kubernetes Platform (Enterprise Edition only)
 
 For details, go through [KKP integration details]({{< relref "../../installation/kkp">}})
 
@@ -38,13 +39,13 @@ spec:
     - "internal.company.io/*"
   loadBalancer:
     class: "metallb.universe.tf/metallb"
-    # Enterprise Edition Only
+    # Enterprise Edition only
     limit: 10
   ingress:
     class: "nginx"
   gatewayAPI:
     class: "eg"
-  # All of the below configurations are Enterprise Edition Only
+  # All configurations below are available in Enterprise Edition only.
   dns:
     allowedDomains:
       - "*.example.com"


### PR DESCRIPTION
## What changed

- standardize KubeLB component, edition, and feature-stage terminology
- add missing page descriptions and shorten selected sidebar labels
- add task-based entry points to the Guides landing page
- clarify support and CE/EE overview copy

## Why

KubeLB's main documentation used inconsistent product capitalization, edition labels, Beta/Technical Preview notices, and sparse page metadata. The changes make feature maturity easier to identify and navigation easier to scan without changing technical behavior.
