### PR TITLE
KubeLB: update CLI docs for the merge into kubermatic/kubelb

### DIFF
--- a/content/kubelb/main/cli/_index.en.md
+++ b/content/kubelb/main/cli/_index.en.md
@@ -11,7 +11,7 @@ description = "Use KubeLB CLI to provision load balancers, create secure tunnels
 
 KubeLB CLI is a command line tool that complements KubeLB and manages load balancing configurations for multiple tenants in Kubernetes and non-Kubernetes environments.
 
-The source code is open source and available at [kubermatic/kubelb-cli](https://github.com/kubermatic/kubelb-cli).
+The source code is open source and available in the [kubermatic/kubelb](https://github.com/kubermatic/kubelb) repository under `cli/`. Before KubeLB v1.5.0, the CLI lived in its own repository, [kubermatic/kubelb-cli](https://github.com/kubermatic/kubelb-cli), and was versioned independently (last standalone release: v0.2.0).
 
 {{% notice note %}}
 **Feature stage: Beta / Technical Preview.** KubeLB CLI is supported for non-business-critical use, but its commands and configuration may change between releases. Test workflows before adopting them broadly.
@@ -21,19 +21,38 @@ The source code is open source and available at [kubermatic/kubelb-cli](https://
 
 ### Manual Installation
 
-Download the pre-compiled binary for your system from the [releases page](https://github.com/kubermatic/kubelb-cli/releases) and copy it to the desired location.
+Starting with KubeLB v1.5.0, the CLI is released together with KubeLB from the [kubermatic/kubelb releases page](https://github.com/kubermatic/kubelb/releases) and shares the KubeLB version number. Download the `kubelb-cli_<version>_<os>_<arch>` archive for your platform; the binary inside is named `kubelb`.
+
+```bash
+VERSION=1.5.0
+curl -LO https://github.com/kubermatic/kubelb/releases/download/v${VERSION}/kubelb-cli_${VERSION}_linux_amd64.tar.gz
+tar -xzf kubelb-cli_${VERSION}_linux_amd64.tar.gz kubelb
+sudo install kubelb /usr/local/bin/
+```
+
+Releases are signed with keyless cosign and carry provenance attestations. Verify a download with:
+
+```bash
+gh attestation verify kubelb-cli_${VERSION}_linux_amd64.tar.gz --repo kubermatic/kubelb
+```
+
+Releases before v1.5.0 were published from [kubermatic/kubelb-cli](https://github.com/kubermatic/kubelb-cli/releases) and signed with a static cosign key instead.
 
 {{% notice note %}}
 KubeLB CLI is currently available for Linux, macOS, and Windows.
 {{% /notice %}}
 
-### Install using `go install`
+### Build from source
 
-With Go installed, build the binary from source:
+With Go installed, build the binary from the `cli/` directory of the [kubermatic/kubelb](https://github.com/kubermatic/kubelb) repository:
 
 ```bash
-go install github.com/kubermatic/kubelb-cli@v0.2.0
+git clone https://github.com/kubermatic/kubelb.git
+cd kubelb/cli
+make build
 ```
+
+This creates the binary at `./bin/kubelb`.
 
 ### Configuration
 

--- a/content/kubelb/main/cli/compatibility-matrix/_index.en.md
+++ b/content/kubelb/main/cli/compatibility-matrix/_index.en.md
@@ -10,6 +10,8 @@ KubeLB CLI uses the Kubernetes management cluster that has KubeLB installed as i
 
 Introduced alongside KubeLB v1.2, the CLI requires the KubeLB management cluster to be at least v1.2.
 
+Starting with KubeLB v1.5.0, the CLI is released together with KubeLB and shares its version number; standalone versioning ended with v0.2.0. Use the CLI version that matches your management cluster release.
+
 {{% notice note %}}
 **Feature stage: Beta / Technical Preview.** Use KubeLB CLI for non-business-critical workflows and validate compatibility before upgrading.
 {{% /notice %}}
@@ -17,6 +19,8 @@ Introduced alongside KubeLB v1.2, the CLI requires the KubeLB management cluster
 | KubeLB CLI | KubeLB management cluster |
 |------------|---------------------------|
 | v0.1.0     | v1.2+                     |
+| v0.2.0     | v1.2+                     |
+| v1.5.0+    | same version as the CLI   |
 
 ## Support Policy
 

--- a/content/kubelb/main/cli/ingress-to-gateway-api/_index.en.md
+++ b/content/kubelb/main/cli/ingress-to-gateway-api/_index.en.md
@@ -21,11 +21,7 @@ For background on why to migrate and the overall strategy, see the [Ingress to G
 
 **1. Install the CLI**
 
-Download from the [releases page](https://github.com/kubermatic/kubelb-cli/releases) or build from source:
-
-```bash
-go install github.com/kubermatic/kubelb-cli@latest
-```
+Download the `kubelb-cli` archive from the [kubermatic/kubelb releases page](https://github.com/kubermatic/kubelb/releases); the binary inside is named `kubelb`. See [Installation]({{< relref "../#installation" >}}) for details and source builds.
 
 **2. Set your kubeconfig**
 


### PR DESCRIPTION
The CLI moved into kubermatic/kubelb under `cli/` and ships with KubeLB releases from v1.5.0, sharing its version number (kubermatic/kubelb#497). Points install instructions at the new releases page (`kubelb-cli_<version>_<os>_<arch>` archives, binary named `kubelb`), replaces the stale `go install github.com/kubermatic/kubelb-cli` snippets with a source build from `cli/`, adds keyless cosign verification, and extends the compatibility matrix for the unified versioning.