### PR TITLE
KubeLB v1.5: release notes, upgrade/rollback guidance, and measured operational caveats

### DIFF
--- a/content/kubelb/main/cli/tunneling/_index.en.md
+++ b/content/kubelb/main/cli/tunneling/_index.en.md
@@ -115,4 +115,8 @@ kubelb tunnel connect my-app --port 1313
 
 This will connect to the tunnel and forward traffic to the port `1313` on the local machine.
 
+### Tunnel Hostnames
+
+When the tenant has `dns.allowExplicitHostnames: false` (see [DNS](../../tutorials/security/dns/#enable-dns-automation)), a `Tunnel` with `spec.hostname` set is rejected with `no hostname configurable`. Request a generated hostname under the tenant's wildcard domain instead by annotating the `Tunnel` with `kubelb.k8c.io/request-wildcard-domain: "true"` — the same annotation used on [LoadBalancer resources](../../tutorials/loadbalancer/#load-balancer-hostname-support).
+
 For deleting, inspecting, and listing tunnels, see the [Tunnel API](../../references/api/tunnel/) documentation.

--- a/content/kubelb/main/dashboard/_index.en.md
+++ b/content/kubelb/main/dashboard/_index.en.md
@@ -187,7 +187,10 @@ metrics:
 ```
 
 Metrics are **capability-gated**: if Prometheus is unreachable or does not expose
-the Envoy series, the metrics panels are hidden. The API templates all PromQL
+the Envoy series, the Metrics tab is absent entirely rather than showing an
+error. [Auto-discovery](#observability-auto-discovery) only finds a Prometheus
+listening on the standard port `9090`; for any other port, set
+`metrics.prometheusUrl` explicitly. The API templates all PromQL
 server-side from a fixed set of named queries. The browser never sends raw
 PromQL, so the dashboard cannot be used as an open Prometheus proxy.
 
@@ -247,6 +250,24 @@ watch:
 
 Enable watch streaming per deployment once validated against your cluster. If
 a watch stream fails, the dashboard falls back to polling.
+
+{{% notice warning %}}
+Watch streams are long-lived HTTP connections, so whatever fronts the dashboard
+must allow them. On the default Envoy Gateway path the dashboard HTTPRoute sets
+no timeout, and Envoy's 15-second default request timeout kills every stream:
+the dashboard silently falls back to polling and logs reconnect noise. Set
+explicit timeouts on the dashboard HTTPRoute rule (the same values the
+connection-manager route uses):
+
+```yaml
+spec:
+  rules:
+    - timeouts:
+        request: 3600s
+        backendRequest: 3600s
+```
+
+{{% /notice %}}
 
 ## Read-Only Mode
 

--- a/content/kubelb/main/installation/management-cluster/_index.en.md
+++ b/content/kubelb/main/installation/management-cluster/_index.en.md
@@ -355,6 +355,8 @@ spec:
 
 All three fields default to Envoy's maximum, so out of the box KubeLB's managed Envoy never rejects headers the edge already accepted. Lower them if you want the managed Envoy to enforce a smaller cap.
 
+On the Gateway API path the effective ceiling is therefore Envoy Gateway's stock limits of **100 request headers / 60 KiB**, not KubeLB's: oversized requests are rejected with `431` at the Envoy Gateway hop before KubeLB's configured limits apply, unless a [ClientTrafficPolicy]({{< relref "../../tutorials/gatewayapi/client-traffic-policy" >}}) raising them is attached to the Gateway.
+
 The Envoy Gateway edge is not managed by KubeLB. Raise its limit yourself on the `EnvoyProxy` resource that your `GatewayClass` references, for example with a bootstrap runtime layer:
 
 ```yaml

--- a/content/kubelb/main/installation/upgrade/_index.en.md
+++ b/content/kubelb/main/installation/upgrade/_index.en.md
@@ -141,7 +141,20 @@ kubectl get crd listenersets.gateway.networking.k8s.io
 
 Recovery is the CRD apply itself. Run the management cluster command above; the pod recovers on its own once the CRD exists. No rollback or reinstall is needed.
 
+### Expected disruption
+
+Plan for a one-time Layer 7 disruption of roughly **1.5–2.5 minutes** during the manager upgrade. It is caused by the Envoy resource-naming migration and the Envoy Gateway roll, and it happens once per management cluster. Layer 4 traffic is unaffected.
+
+A `helm upgrade` that fails on a transient apiserver error is safe to re-run with the identical command; it picks up where it left off.
+
 ### Rolling back
+
+Do **not** downgrade the Gateway API CRDs when rolling back. The newer CRDs work with the older Envoy Gateway, so a rollback of the workloads needs no CRD change at all.
+
+Two version-skew traps to avoid:
+
+* When rolling a tenant's CCM back to v1.4.x, set `kubelb.installGatewayAPICRDs=false` on the CCM chart. The old CCM's CRD installer crashloops trying to downgrade the newer CRDs already on the cluster.
+* A fresh `helm install` of an older chart on a cluster that already has the newer CRDs needs `--skip-crds`. Unlike `helm upgrade`, `helm install` applies the chart's `crds/` directory, and that apply is a CRD downgrade.
 
 v1.5.0 installs a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy that rejects any Gateway API CRD older than v1.5.0. If you downgrade to a v1.4.x bundle while it is in place, the apply is denied with:
 

--- a/content/kubelb/main/release-notes/_index.en.md
+++ b/content/kubelb/main/release-notes/_index.en.md
@@ -6,66 +6,67 @@ weight = 60
 aliases = ["/kubelb/main/cli/release-notes/"]
 +++
 
+## v1.5.0
+
+**GitHub release: [v1.5.0](https://github.com/kubermatic/kubelb/releases/tag/v1.5.0)**
+
+### Urgent Upgrade Notes
+
+These notes apply to both Community Edition (`kubelb-manager`) and Enterprise
+Edition (`kubelb-manager-ee`). See [Upgrading KubeLB]({{< relref "../installation/upgrade" >}})
+for the full upgrade procedure.
+
+#### Apply the Gateway API CRDs before upgrading
+
+KubeLB v1.5.0 upgrades the bundled Envoy Gateway from 1.7.2 to 1.8.3. Envoy
+Gateway 1.8.3 requires the `ListenerSet` CRD
+(`listenersets.gateway.networking.k8s.io`), which is part of Gateway API v1.5.
+The chart ships this CRD, but Helm only applies a chart's `crds/` directory on
+`helm install`; it skips it on `helm upgrade`. Existing installations therefore
+end up running Envoy Gateway 1.8.3 without the CRD it needs.
+
+Before running `helm upgrade`, apply the Gateway API bundle:
+
+```bash
+kubectl apply --server-side --force-conflicts -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+```
+
+Fresh installations are unaffected, because `helm install` applies the CRDs
+itself.
+
 {{% notice warning %}}
-This document is a work in progress and may be incomplete or out of date.
+The failure is delayed if you skip this step. The upgrade reports success and
+traffic keeps flowing, because the existing `envoy-gateway` pod keeps running.
+The new pod never becomes ready, and the Gateway API control plane only goes
+down the next time that pod restarts — a node reboot, an eviction, or a scale
+event, which can be days later. The pod then crashloops with
+`no matches for kind "ListenerSet" in version "gateway.networking.k8s.io/v1"`.
+Recovery is the same `kubectl apply` above.
 {{% /notice %}}
 
-## Kubermatic KubeLB v1.x.x
+#### Expected disruption
 
-- [v1.x.x](#v1xx)
-  - [Community Edition](#community-edition)
-  - [Enterprise Edition](#enterprise-edition)
+Expect a one-time Layer 7 disruption of roughly 1.5–2.5 minutes during the
+manager upgrade, caused by the Envoy resource-naming migration and the Envoy
+Gateway roll. Layer 4 traffic is unaffected.
 
-## v1.x.x
+#### Rolling back
 
-**GitHub release: [v1.x.x](https://github.com/kubermatic/kubelb/releases/tag/v1.x.x)**
+v1.5.0 installs a `safe-upgrades.gateway.networking.k8s.io`
+ValidatingAdmissionPolicy that denies rolling the Gateway API CRDs back to a
+v1.4.x bundle. Do not downgrade the CRDs: the newer CRDs work with the older
+Envoy Gateway. See [Rolling back]({{< relref "../installation/upgrade#rolling-back" >}})
+for the full rollback constraints.
 
-### Highlights
+#### Leftover CRD from v1.5.0-beta.0
 
-#### Community Edition(CE)
+Clusters upgraded from `v1.5.0-beta.0` still carry the
+`virtualkeys.kubelb.k8c.io` CRD. The feature it belonged to was removed before
+v1.5.0 and Helm never deletes CRDs, so the leftover is inert but should be
+cleaned up:
 
-_content_
+```bash
+kubectl delete crd virtualkeys.kubelb.k8c.io
+```
 
-#### Enterprise Edition(EE)
-
-_content_
-
-### Community Edition
-
-#### Urgent Upgrade Notes
-
-_content_
-
-#### Deprecation
-
-_content_
-
-#### API Changes
-
-_content_
-
-#### Features
-
-_content_
-
-#### Design
-
-_content_
-
-#### Bug or Regression
-
-_content_
-
-#### Other (Cleanup, Flake, or Chore)
-
-_content_
-
-**Full Changelog**: <https://github.com/kubermatic/kubelb/compare/v1.0.0...v1.x.x>
-
-### Enterprise Edition
-
-**Enterprise Edition includes everything in Community Edition. The notes below cover changes specific to the Enterprise Edition.**
-
-#### EE Features
-
-_content_
+**Full Changelog**: <https://github.com/kubermatic/kubelb/compare/v1.4.0...v1.5.0>

--- a/content/kubelb/main/security/_index.en.md
+++ b/content/kubelb/main/security/_index.en.md
@@ -64,6 +64,17 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.4.3 \
 {{% /tab %}}
 {{< /tabs >}}
 
+The [KubeLB Dashboard]({{< relref "../dashboard" >}}) images
+(`kubelb-dashboard`, `kubelb-dashboard-api`) are built and signed from a
+different repository and workflow, so the commands above fail against them.
+Verify them with the dashboard identity instead:
+
+```bash
+cosign verify quay.io/kubermatic/kubelb-dashboard:v1.0.1 \
+  --certificate-identity-regexp="^https://github.com/kubermatic/kubelb-dashboard/.github/workflows/publish.yml@refs/tags/v.*" \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
 ## Verify Helm Chart Signatures
 
 {{< tabs name="verify-helm" >}}

--- a/content/kubelb/main/tutorials/envoy-proxy/health-checks/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/health-checks/_index.en.md
@@ -9,6 +9,10 @@ enterprise = true
 
 KubeLB configures Envoy active health checking on the upstream clusters that back your services. By default every TCP cluster gets a connect-only TCP check. This page shows how to replace that with tuned TCP, HTTP, or gRPC checks on the `Config`, `Tenant`, `LoadBalancer`, and `Route` resources, or through tenant-side annotations.
 
+{{% notice warning %}}
+Active health checks cannot be disabled and have no fail-open: the panic threshold is 0 by design, so a wrong `http.path` or `http.expectedStatuses` takes the route to 0% healthy and all traffic fails. gRPC checks require HTTP/2-capable backends. Pod-level failure detection requires `externalTrafficPolicy: Local` on the tenant Service, because checks target the node port, not individual pods. And in `Direct` (non-mTLS) backend transport, a backend that accepts TCP connections but serves errors is never ejected by the default connect-only check — set `kubelb.k8c.io/health-check-type: HTTP` on the Service to get HTTP-level checking.
+{{% /notice %}}
+
 ## Why Configurable Health Checks?
 
 The built-in connect-only TCP check confirms that a backend accepts TCP connections. It does not confirm that the application behind it is serving traffic. A pod that has crashed at the application layer but still holds an open socket keeps receiving requests.

--- a/content/kubelb/main/tutorials/gatewayapi/_index.en.md
+++ b/content/kubelb/main/tutorials/gatewayapi/_index.en.md
@@ -111,6 +111,20 @@ It is recommended to create the Gateway in tenant cluster directly since the Gat
 In Community Edition, only one Gateway is allowed per tenant and it must be named `kubelb`.
 {{% /notice %}}
 
+#### Gateways on cloud load balancer providers
+
+Each Gateway gets its own `LoadBalancer` Service, provisioned by Envoy Gateway in the management cluster. Cloud providers that require Service annotations (location, scheme, and similar) need them on the Gateway's `spec.infrastructure.annotations`; the `defaultAnnotations` configured on the `Config` resource do **not** reach the Service that Envoy Gateway provisions.
+
+```yaml
+spec:
+  gatewayClassName: kubelb
+  infrastructure:
+    annotations:
+      load-balancer.hetzner.cloud/location: fsn1
+```
+
+Missing provider annotations surface as `PROGRAMMED=False` with reason `AddressNotAssigned` on the Gateway; the real cause is only visible in the events of the load balancer Service on the management cluster.
+
 #### Gateways with an unserved GatewayClass
 
 A Gateway whose `gatewayClassName` is not served by KubeLB is ignored: no load balancer is provisioned and the Gateway status stays at the Gateway API default of `Accepted: Unknown` with the message "Waiting for controller", which looks the same as a controller outage. To make the cause visible, the CCM emits a Warning event with reason `GatewayClassNotAccepted` on the Gateway, listing the GatewayClasses it does serve. The event shows up in `kubectl describe gateway <name>`.

--- a/content/kubelb/main/tutorials/loadbalancer/_index.en.md
+++ b/content/kubelb/main/tutorials/loadbalancer/_index.en.md
@@ -116,6 +116,11 @@ spec:
 Persistence is based on the source IP as observed by the KubeLB Envoy Proxy. Behind a NAT gateway or another proxy, multiple clients can share one observed IP and will be pinned to the same endpoint.
 {{% /notice %}}
 
+Two caveats to be aware of:
+
+* `sessionAffinityConfig.clientIP.timeoutSeconds` on the Service is silently ignored. The Maglev hash that implements persistence has no stickiness window; a client stays pinned until the endpoint set changes.
+* Inside the tenant cluster, `sessionAffinity` keys on the client IP as seen at the NodePort hop — which is the KubeLB Envoy pod IP, not the original client. Pod-level fan-out therefore collapses to roughly one pod per node.
+
 ## Hostname Endpoints
 
 Endpoint addresses can reference a DNS hostname instead of an IP. This is useful when the backend has no stable IP. Envoy resolves the hostname continuously (strict DNS), so the endpoint follows DNS changes. If both `ip` and `hostname` are set, `ip` wins.

--- a/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
@@ -97,7 +97,13 @@ Switching between `Direct` and `MTLS` changes the backend traffic path. Plan it 
 
 ### Confirm the mode change on an existing installation
 
-Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic. On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
+Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic.
+
+{{% notice warning %}}
+The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on a real cluster, the switch costs roughly 20–30 seconds of hard failure on active routes and destroys every client keepalive connection pool — each in-flight request gets a 503 **and** a closed connection. Until pools rebuild, expect around a 5x throughput collapse and a 20x connection-rate spike under load. Schedule a maintenance window and make sure clients have retry policies.
+{{% /notice %}}
+
+On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
 
 ```bash
 kubectl --context <management> -n kubelb annotate config default \


### PR DESCRIPTION
KubeLB v1.5 pre-release docs batch. Everything here is backed by measurements from release testing on real clusters:

- Release notes: replace the placeholder with the v1.5.0 urgent upgrade notes (Gateway API CRD pre-apply for Envoy Gateway 1.8.3, delayed crashloop symptom, expected one-time L7 disruption window, `virtualkeys` CRD cleanup for beta.0 upgraders).
- Upgrade guide: expected disruption subsection (~1.5-2.5 min L7, L4 unaffected, failed `helm upgrade` safe to re-run) and rollback constraints (do not downgrade Gateway API CRDs; CCM rollback needs `kubelb.installGatewayAPICRDs=false`; older-chart install over newer CRDs needs `--skip-crds`).
- Dashboard: watch streams need a long-lived-connection timeout in front of the dashboard (snippet included); Metrics tab is silently absent unless Prometheus is on :9090 or `metrics.prometheusUrl` is set; dashboard images have their own cosign identity.
- Health checks: warning box (no fail-open, cannot disable, gRPC needs HTTP/2 backends, `externalTrafficPolicy: Local` for pod-level detection, Direct-mode ejection caveat).
- mTLS: measured mode-flip impact (fleet-wide, ~20-30s hard failure, keepalive pools destroyed) and maintenance-window recommendation.
- Gateway API: cloud providers need annotations in `spec.infrastructure.annotations`; header-limit ceiling on the Gateway API path is Envoy Gateway's stock 100/60KiB unless a ClientTrafficPolicy raises it.
- Load balancer: session-persistence caveats (`timeoutSeconds` ignored; affinity keys on the Envoy pod IP).
- Tunneling: `no hostname configurable` error and the `request-wildcard-domain` annotation.

Hugo build clean (extended v0.164.0).
