### PR TITLE
Fix empty config blocks in the KDP 1.1 quickstart

### DIFF
--- a/content/developer-platform/v1.1/setup/quickstart/_index.en.md
+++ b/content/developer-platform/v1.1/setup/quickstart/_index.en.md
@@ -59,7 +59,7 @@ This automates the process of obtaining and renewing TLS certificates from Let's
 Save the following content to a file named `cluster-issuer.yaml`, and change the value of the `email` field to your email address:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/letsencrypt.cluster-issuer.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/letsencrypt.cluster-issuer.yaml" >}}
 ```
 
 Create the _ClusterIssuer_ by applying the manifest:
@@ -115,7 +115,7 @@ Then create a `Gateway` with HTTPS listeners for each hostname, annotated so cer
 Save the following content to a file named `gateway.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/gateway.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/gateway.yaml" >}}
 ```
 
 Replace `<GATEWAY_NAMESPACE>`, `<GATEWAY_CLASS>`, and `<DOMAIN>` with your values, then apply:
@@ -128,7 +128,7 @@ Finally, create `HTTPRoute` resources to route traffic to Dex and the Dashboard.
 Save the following content to a file named `http-routes.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/http-routes.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/http-routes.yaml" >}}
 ```
 
 Replace `<GATEWAY_NAMESPACE>` and `<DOMAIN>`, then apply:
@@ -154,7 +154,7 @@ The provided configuration creates an initial admin user and prepares Dex for th
 Save the following content to a file named `dex.values.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/dex.values.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/dex.values.yaml" >}}
 ```
 
 Before deploying Dex, you need to replace the following placeholder variables in the `dex.values.yaml` file with your own values:
@@ -205,7 +205,7 @@ It's configured to use Dex for authenticating user requests.
 Save the following content to a file named `kcp.values.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/kcp.values.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/kcp.values.yaml" >}}
 ```
 
 Before deploying kcp, you need to replace the following placeholder variables in the `kcp.values.yaml` file with your own values:
@@ -295,7 +295,7 @@ It connects to the kcp control plane and includes a one-time bootstrap job that 
 Save the following content to a file named `kdp.values.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/kdp.values.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/kdp.values.yaml" >}}
 ```
 
 Before deploying KDP, you need to replace the following placeholder variables in the `kdp.values.yaml` file with your own values:
@@ -324,7 +324,7 @@ It's configured to use Dex for user login and connects to kcp, providing develop
 Save the following content to a file named `kdp-dashboard.values.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/kdp-dashboard.values.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/kdp-dashboard.values.yaml" >}}
 ```
 
 Before deploying the KDP dashboard, you need to replace the following placeholder variables in the `kdp-dashboard.values.yaml` file with your own values:
@@ -368,7 +368,7 @@ Before proceeding, ensure you have an OpenAI API key.
 Save the following content to a file named `ai-agent.values.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/ai-agent.values.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/ai-agent.values.yaml" >}}
 ```
 
 Replace the following placeholder variables:
@@ -407,7 +407,7 @@ Then add the following `HTTPRoute` alongside your existing Dex and Dashboard rou
 Save the following content to a file named `ai-agent.http-route.yaml`:
 
 ```yaml
-{{< readfile "developer-platform/setup/quickstart/data/ai-agent.http-route.yaml" >}}
+{{< readfile "developer-platform/v1.1/setup/quickstart/data/ai-agent.http-route.yaml" >}}
 ```
 
 Replace `<GATEWAY_NAMESPACE>` and `<DOMAIN>`, then apply:


### PR DESCRIPTION
The nine `readfile` includes in the KDP 1.1 quickstart omit the version segment, so they resolve to `developer-platform/setup/quickstart/data/…`, which exists neither at the project root nor under `contentDir`. Hugo returns nothing, so **every config block on the page renders empty** — that is what is served today:

```
$ curl -s https://docs.kubermatic.com/developer-platform/v1.1/setup/quickstart/ | grep -c staticClients
0
```

This points the includes at the version directory that actually holds the files, restoring the ClusterIssuer, Gateway, HTTPRoute, Dex, kcp, KDP, dashboard and AI Agent values.

Verified with the CI build (`hack/ci/verify-hugo.sh`): `staticClients` and `gatewayClassName` now render on the page, where both were absent before.

`v1.0` and `v0.9.0` have the same bug (9 includes each) and are deliberately left out of this PR.