### PR TITLE
KubeLB v1.5: measured operational caveats from release testing

### DIFF
--- a/content/kubelb/main/cli/tunneling/_index.en.md
+++ b/content/kubelb/main/cli/tunneling/_index.en.md
@@ -115,4 +115,8 @@ kubelb tunnel connect my-app --port 1313
 
 This will connect to the tunnel and forward traffic to the port `1313` on the local machine.
 
+### Tunnel Hostnames
+
+When the tenant has `dns.allowExplicitHostnames: false` (see [DNS](../../tutorials/security/dns/#enable-dns-automation)), a `Tunnel` with `spec.hostname` set is rejected with `no hostname configurable`. Request a generated hostname under the tenant's wildcard domain instead by annotating the `Tunnel` with `kubelb.k8c.io/request-wildcard-domain: "true"` — the same annotation used on [LoadBalancer resources](../../tutorials/loadbalancer/#load-balancer-hostname-support).
+
 For deleting, inspecting, and listing tunnels, see the [Tunnel API](../../references/api/tunnel/) documentation.

--- a/content/kubelb/main/dashboard/_index.en.md
+++ b/content/kubelb/main/dashboard/_index.en.md
@@ -187,7 +187,10 @@ metrics:
 ```
 
 Metrics are **capability-gated**: if Prometheus is unreachable or does not expose
-the Envoy series, the metrics panels are hidden. The API templates all PromQL
+the Envoy series, the Metrics tab is absent entirely rather than showing an
+error. [Auto-discovery](#observability-auto-discovery) only finds a Prometheus
+listening on the standard port `9090`; for any other port, set
+`metrics.prometheusUrl` explicitly. The API templates all PromQL
 server-side from a fixed set of named queries. The browser never sends raw
 PromQL, so the dashboard cannot be used as an open Prometheus proxy.
 
@@ -247,6 +250,24 @@ watch:
 
 Enable watch streaming per deployment once validated against your cluster. If
 a watch stream fails, the dashboard falls back to polling.
+
+{{% notice warning %}}
+Watch streams are long-lived HTTP connections, so whatever fronts the dashboard
+must allow them. On the default Envoy Gateway path the dashboard HTTPRoute sets
+no timeout, and Envoy's 15-second default request timeout kills every stream:
+the dashboard silently falls back to polling and logs reconnect noise. Set
+explicit timeouts on the dashboard HTTPRoute rule (the same values the
+connection-manager route uses):
+
+```yaml
+spec:
+  rules:
+    - timeouts:
+        request: 3600s
+        backendRequest: 3600s
+```
+
+{{% /notice %}}
 
 ## Read-Only Mode
 

--- a/content/kubelb/main/installation/management-cluster/_index.en.md
+++ b/content/kubelb/main/installation/management-cluster/_index.en.md
@@ -355,6 +355,8 @@ spec:
 
 All three fields default to Envoy's maximum, so out of the box KubeLB's managed Envoy never rejects headers the edge already accepted. Lower them if you want the managed Envoy to enforce a smaller cap.
 
+On the Gateway API path the effective ceiling is therefore Envoy Gateway's stock limits of **100 request headers / 60 KiB**, not KubeLB's: oversized requests are rejected with `431` at the Envoy Gateway hop before KubeLB's configured limits apply, unless a [ClientTrafficPolicy]({{< relref "../../tutorials/gatewayapi/client-traffic-policy" >}}) raising them is attached to the Gateway.
+
 The Envoy Gateway edge is not managed by KubeLB. Raise its limit yourself on the `EnvoyProxy` resource that your `GatewayClass` references, for example with a bootstrap runtime layer:
 
 ```yaml

--- a/content/kubelb/main/installation/upgrade/_index.en.md
+++ b/content/kubelb/main/installation/upgrade/_index.en.md
@@ -141,7 +141,20 @@ kubectl get crd listenersets.gateway.networking.k8s.io
 
 Recovery is the CRD apply itself. Run the management cluster command above; the pod recovers on its own once the CRD exists. No rollback or reinstall is needed.
 
+### Expected disruption
+
+Plan for a one-time Layer 7 disruption of roughly **1.5–2.5 minutes** during the manager upgrade. It is caused by the Envoy resource-naming migration and the Envoy Gateway roll, and it happens once per management cluster. Layer 4 traffic is unaffected.
+
+A `helm upgrade` that fails on a transient apiserver error is safe to re-run with the identical command; it picks up where it left off.
+
 ### Rolling back
+
+Do **not** downgrade the Gateway API CRDs when rolling back. The newer CRDs work with the older Envoy Gateway, so a rollback of the workloads needs no CRD change at all.
+
+Two version-skew traps to avoid:
+
+* When rolling a tenant's CCM back to v1.4.x, set `kubelb.installGatewayAPICRDs=false` on the CCM chart. The old CCM's CRD installer crashloops trying to downgrade the newer CRDs already on the cluster.
+* A fresh `helm install` of an older chart on a cluster that already has the newer CRDs needs `--skip-crds`. Unlike `helm upgrade`, `helm install` applies the chart's `crds/` directory, and that apply is a CRD downgrade.
 
 v1.5.0 installs a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy that rejects any Gateway API CRD older than v1.5.0. If you downgrade to a v1.4.x bundle while it is in place, the apply is denied with:
 

--- a/content/kubelb/main/security/_index.en.md
+++ b/content/kubelb/main/security/_index.en.md
@@ -64,6 +64,17 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.4.3 \
 {{% /tab %}}
 {{< /tabs >}}
 
+The [KubeLB Dashboard]({{< relref "../dashboard" >}}) images
+(`kubelb-dashboard`, `kubelb-dashboard-api`) are built and signed from a
+different repository and workflow, so the commands above fail against them.
+Verify them with the dashboard identity instead:
+
+```bash
+cosign verify quay.io/kubermatic/kubelb-dashboard:v1.0.1 \
+  --certificate-identity-regexp="^https://github.com/kubermatic/kubelb-dashboard/.github/workflows/publish.yml@refs/tags/v.*" \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
 ## Verify Helm Chart Signatures
 
 {{< tabs name="verify-helm" >}}

--- a/content/kubelb/main/tutorials/envoy-proxy/health-checks/_index.en.md
+++ b/content/kubelb/main/tutorials/envoy-proxy/health-checks/_index.en.md
@@ -9,6 +9,10 @@ enterprise = true
 
 KubeLB configures Envoy active health checking on the upstream clusters that back your services. By default every TCP cluster gets a connect-only TCP check. This page shows how to replace that with tuned TCP, HTTP, or gRPC checks on the `Config`, `Tenant`, `LoadBalancer`, and `Route` resources, or through tenant-side annotations.
 
+{{% notice warning %}}
+Active health checks cannot be disabled and have no fail-open: the panic threshold is 0 by design, so a wrong `http.path` or `http.expectedStatuses` takes the route to 0% healthy and all traffic fails. gRPC checks require HTTP/2-capable backends. Pod-level failure detection requires `externalTrafficPolicy: Local` on the tenant Service, because checks target the node port, not individual pods. And in `Direct` (non-mTLS) backend transport, a backend that accepts TCP connections but serves errors is never ejected by the default connect-only check — set `kubelb.k8c.io/health-check-type: HTTP` on the Service to get HTTP-level checking.
+{{% /notice %}}
+
 ## Why Configurable Health Checks?
 
 The built-in connect-only TCP check confirms that a backend accepts TCP connections. It does not confirm that the application behind it is serving traffic. A pod that has crashed at the application layer but still holds an open socket keeps receiving requests.

--- a/content/kubelb/main/tutorials/gatewayapi/_index.en.md
+++ b/content/kubelb/main/tutorials/gatewayapi/_index.en.md
@@ -111,6 +111,20 @@ It is recommended to create the Gateway in tenant cluster directly since the Gat
 In Community Edition, only one Gateway is allowed per tenant and it must be named `kubelb`.
 {{% /notice %}}
 
+#### Gateways on cloud load balancer providers
+
+Each Gateway gets its own `LoadBalancer` Service, provisioned by Envoy Gateway in the management cluster. Cloud providers that require Service annotations (location, scheme, and similar) need them on the Gateway's `spec.infrastructure.annotations`; the `defaultAnnotations` configured on the `Config` resource do **not** reach the Service that Envoy Gateway provisions.
+
+```yaml
+spec:
+  gatewayClassName: kubelb
+  infrastructure:
+    annotations:
+      load-balancer.hetzner.cloud/location: fsn1
+```
+
+Missing provider annotations surface as `PROGRAMMED=False` with reason `AddressNotAssigned` on the Gateway; the real cause is only visible in the events of the load balancer Service on the management cluster.
+
 #### Gateways with an unserved GatewayClass
 
 A Gateway whose `gatewayClassName` is not served by KubeLB is ignored: no load balancer is provisioned and the Gateway status stays at the Gateway API default of `Accepted: Unknown` with the message "Waiting for controller", which looks the same as a controller outage. To make the cause visible, the CCM emits a Warning event with reason `GatewayClassNotAccepted` on the Gateway, listing the GatewayClasses it does serve. The event shows up in `kubectl describe gateway <name>`.

--- a/content/kubelb/main/tutorials/loadbalancer/_index.en.md
+++ b/content/kubelb/main/tutorials/loadbalancer/_index.en.md
@@ -116,6 +116,11 @@ spec:
 Persistence is based on the source IP as observed by the KubeLB Envoy Proxy. Behind a NAT gateway or another proxy, multiple clients can share one observed IP and will be pinned to the same endpoint.
 {{% /notice %}}
 
+Two caveats to be aware of:
+
+* `sessionAffinityConfig.clientIP.timeoutSeconds` on the Service is silently ignored. The Maglev hash that implements persistence has no stickiness window; a client stays pinned until the endpoint set changes.
+* Inside the tenant cluster, `sessionAffinity` keys on the client IP as seen at the NodePort hop — which is the KubeLB Envoy pod IP, not the original client. Pod-level fan-out therefore collapses to roughly one pod per node.
+
 ## Hostname Endpoints
 
 Endpoint addresses can reference a DNS hostname instead of an IP. This is useful when the backend has no stable IP. Envoy resolves the hostname continuously (strict DNS), so the endpoint follows DNS changes. If both `ip` and `hostname` are set, `ip` wins.

--- a/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
@@ -103,6 +103,15 @@ Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant tr
 The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on real clusters, switching to `MTLS` costs from ~15 seconds up to a few minutes of hard failure per tenant — the duration is not deterministic (Layer 4 routes recover last, and a slow tenant apiserver extends the window). The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Switching back to `Direct` is close to hitless. Schedule a maintenance window and make sure clients have retry policies.
 {{% /notice %}}
 
+{{% notice warning %}}
+**Do not treat the `TenantState` conditions as a "switch complete" signal.** `TenantProxyReady` and the
+other conditions report control-plane state and go `True` several seconds to a few minutes *before* traffic
+actually flows through the new path (Layer 4 recovers last). An automation that runs `kubectl wait` on these
+conditions and then proceeds will act during the outage. The only trustworthy "done" signal is a real
+request succeeding end to end on a route in the affected tenant. There is no dataplane-convergence condition
+in v1.5.
+{{% /notice %}}
+
 On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
 
 ```bash

--- a/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
@@ -97,7 +97,13 @@ Switching between `Direct` and `MTLS` changes the backend traffic path. Plan it 
 
 ### Confirm the mode change on an existing installation
 
-Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic. On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
+Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic.
+
+{{% notice warning %}}
+The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on a real cluster, the switch costs roughly 20–30 seconds of hard failure on active routes and destroys every client keepalive connection pool — each in-flight request gets a 503 **and** a closed connection. Until pools rebuild, expect around a 5x throughput collapse and a 20x connection-rate spike under load. Schedule a maintenance window and make sure clients have retry policies.
+{{% /notice %}}
+
+On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
 
 ```bash
 kubectl --context <management> -n kubelb annotate config default \

--- a/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
@@ -100,7 +100,7 @@ Switching between `Direct` and `MTLS` changes the backend traffic path. Plan it 
 Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic.
 
 {{% notice warning %}}
-The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on a real cluster, the switch costs roughly 20–30 seconds of hard failure on active routes and destroys every client keepalive connection pool — each in-flight request gets a 503 **and** a closed connection. Until pools rebuild, expect around a 5x throughput collapse and a 20x connection-rate spike under load. Schedule a maintenance window and make sure clients have retry policies.
+The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on real clusters, switching to `MTLS` costs from ~15 seconds up to a few minutes of hard failure per tenant — the duration is not deterministic (Layer 4 routes recover last, and a slow tenant apiserver extends the window). The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Switching back to `Direct` is close to hitless. Schedule a maintenance window and make sure clients have retry policies.
 {{% /notice %}}
 
 On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:

--- a/content/kubelb/v1.5/cli/tunneling/_index.en.md
+++ b/content/kubelb/v1.5/cli/tunneling/_index.en.md
@@ -115,4 +115,8 @@ kubelb tunnel connect my-app --port 1313
 
 This will connect to the tunnel and forward traffic to the port `1313` on the local machine.
 
+### Tunnel Hostnames
+
+When the tenant has `dns.allowExplicitHostnames: false` (see [DNS](../../tutorials/security/dns/#enable-dns-automation)), a `Tunnel` with `spec.hostname` set is rejected with `no hostname configurable`. Request a generated hostname under the tenant's wildcard domain instead by annotating the `Tunnel` with `kubelb.k8c.io/request-wildcard-domain: "true"` — the same annotation used on [LoadBalancer resources](../../tutorials/loadbalancer/#load-balancer-hostname-support).
+
 For deleting, inspecting, and listing tunnels, see the [Tunnel API](../../references/api/tunnel/) documentation.

--- a/content/kubelb/v1.5/dashboard/_index.en.md
+++ b/content/kubelb/v1.5/dashboard/_index.en.md
@@ -187,7 +187,10 @@ metrics:
 ```
 
 Metrics are **capability-gated**: if Prometheus is unreachable or does not expose
-the Envoy series, the metrics panels are hidden. The API templates all PromQL
+the Envoy series, the Metrics tab is absent entirely rather than showing an
+error. [Auto-discovery](#observability-auto-discovery) only finds a Prometheus
+listening on the standard port `9090`; for any other port, set
+`metrics.prometheusUrl` explicitly. The API templates all PromQL
 server-side from a fixed set of named queries. The browser never sends raw
 PromQL, so the dashboard cannot be used as an open Prometheus proxy.
 
@@ -247,6 +250,24 @@ watch:
 
 Enable watch streaming per deployment once validated against your cluster. If
 a watch stream fails, the dashboard falls back to polling.
+
+{{% notice warning %}}
+Watch streams are long-lived HTTP connections, so whatever fronts the dashboard
+must allow them. On the default Envoy Gateway path the dashboard HTTPRoute sets
+no timeout, and Envoy's 15-second default request timeout kills every stream:
+the dashboard silently falls back to polling and logs reconnect noise. Set
+explicit timeouts on the dashboard HTTPRoute rule (the same values the
+connection-manager route uses):
+
+```yaml
+spec:
+  rules:
+    - timeouts:
+        request: 3600s
+        backendRequest: 3600s
+```
+
+{{% /notice %}}
 
 ## Read-Only Mode
 

--- a/content/kubelb/v1.5/installation/management-cluster/_index.en.md
+++ b/content/kubelb/v1.5/installation/management-cluster/_index.en.md
@@ -381,6 +381,8 @@ spec:
 
 All three fields default to Envoy's maximum, so out of the box KubeLB's managed Envoy never rejects headers the edge already accepted. Lower them if you want the managed Envoy to enforce a smaller cap.
 
+On the Gateway API path the effective ceiling is therefore Envoy Gateway's stock limits of **100 request headers / 60 KiB**, not KubeLB's: oversized requests are rejected with `431` at the Envoy Gateway hop before KubeLB's configured limits apply, unless a [ClientTrafficPolicy]({{< relref "../../tutorials/gatewayapi/client-traffic-policy" >}}) raising them is attached to the Gateway.
+
 The Envoy Gateway edge is not managed by KubeLB. Raise its limit yourself on the `EnvoyProxy` resource that your `GatewayClass` references, for example with a bootstrap runtime layer:
 
 ```yaml

--- a/content/kubelb/v1.5/installation/upgrade/_index.en.md
+++ b/content/kubelb/v1.5/installation/upgrade/_index.en.md
@@ -141,7 +141,20 @@ kubectl get crd listenersets.gateway.networking.k8s.io
 
 Recovery is the CRD apply itself. Run the management cluster command above; the pod recovers on its own once the CRD exists. No rollback or reinstall is needed.
 
+### Expected disruption
+
+Plan for a one-time Layer 7 disruption of roughly **1.5–2.5 minutes** during the manager upgrade. It is caused by the Envoy resource-naming migration and the Envoy Gateway roll, and it happens once per management cluster. Layer 4 traffic is unaffected.
+
+A `helm upgrade` that fails on a transient apiserver error is safe to re-run with the identical command; it picks up where it left off.
+
 ### Rolling back
+
+Do **not** downgrade the Gateway API CRDs when rolling back. The newer CRDs work with the older Envoy Gateway, so a rollback of the workloads needs no CRD change at all.
+
+Two version-skew traps to avoid:
+
+* When rolling a tenant's CCM back to v1.4.x, set `kubelb.installGatewayAPICRDs=false` on the CCM chart. The old CCM's CRD installer crashloops trying to downgrade the newer CRDs already on the cluster.
+* A fresh `helm install` of an older chart on a cluster that already has the newer CRDs needs `--skip-crds`. Unlike `helm upgrade`, `helm install` applies the chart's `crds/` directory, and that apply is a CRD downgrade.
 
 v1.5.0 installs a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy that rejects any Gateway API CRD older than v1.5.0. If you downgrade to a v1.4.x bundle while it is in place, the apply is denied with:
 

--- a/content/kubelb/v1.5/security/_index.en.md
+++ b/content/kubelb/v1.5/security/_index.en.md
@@ -64,6 +64,17 @@ cosign verify quay.io/kubermatic/kubelb-manager:v1.5.0 \
 {{% /tab %}}
 {{< /tabs >}}
 
+The [KubeLB Dashboard]({{< relref "../dashboard" >}}) images
+(`kubelb-dashboard`, `kubelb-dashboard-api`) are built and signed from a
+different repository and workflow, so the commands above fail against them.
+Verify them with the dashboard identity instead:
+
+```bash
+cosign verify quay.io/kubermatic/kubelb-dashboard:v1.0.1 \
+  --certificate-identity-regexp="^https://github.com/kubermatic/kubelb-dashboard/.github/workflows/publish.yml@refs/tags/v.*" \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
 ## Verify Helm Chart Signatures
 
 {{< tabs name="verify-helm" >}}

--- a/content/kubelb/v1.5/tutorials/envoy-proxy/health-checks/_index.en.md
+++ b/content/kubelb/v1.5/tutorials/envoy-proxy/health-checks/_index.en.md
@@ -9,6 +9,10 @@ enterprise = true
 
 KubeLB configures Envoy active health checking on the upstream clusters that back your services. By default every TCP cluster gets a connect-only TCP check. This page shows how to replace that with tuned TCP, HTTP, or gRPC checks on the `Config`, `Tenant`, `LoadBalancer`, and `Route` resources, or through tenant-side annotations.
 
+{{% notice warning %}}
+Active health checks cannot be disabled and have no fail-open: the panic threshold is 0 by design, so a wrong `http.path` or `http.expectedStatuses` takes the route to 0% healthy and all traffic fails. gRPC checks require HTTP/2-capable backends. Pod-level failure detection requires `externalTrafficPolicy: Local` on the tenant Service, because checks target the node port, not individual pods. And in `Direct` (non-mTLS) backend transport, a backend that accepts TCP connections but serves errors is never ejected by the default connect-only check — set `kubelb.k8c.io/health-check-type: HTTP` on the Service to get HTTP-level checking.
+{{% /notice %}}
+
 ## Why Configurable Health Checks?
 
 The built-in connect-only TCP check confirms that a backend accepts TCP connections. It does not confirm that the application behind it is serving traffic. A pod that has crashed at the application layer but still holds an open socket keeps receiving requests.

--- a/content/kubelb/v1.5/tutorials/gatewayapi/_index.en.md
+++ b/content/kubelb/v1.5/tutorials/gatewayapi/_index.en.md
@@ -111,6 +111,20 @@ It is recommended to create the Gateway in tenant cluster directly since the Gat
 In Community Edition, only one Gateway is allowed per tenant and it must be named `kubelb`.
 {{% /notice %}}
 
+#### Gateways on cloud load balancer providers
+
+Each Gateway gets its own `LoadBalancer` Service, provisioned by Envoy Gateway in the management cluster. Cloud providers that require Service annotations (location, scheme, and similar) need them on the Gateway's `spec.infrastructure.annotations`; the `defaultAnnotations` configured on the `Config` resource do **not** reach the Service that Envoy Gateway provisions.
+
+```yaml
+spec:
+  gatewayClassName: kubelb
+  infrastructure:
+    annotations:
+      load-balancer.hetzner.cloud/location: fsn1
+```
+
+Missing provider annotations surface as `PROGRAMMED=False` with reason `AddressNotAssigned` on the Gateway; the real cause is only visible in the events of the load balancer Service on the management cluster.
+
 #### Gateways with an unserved GatewayClass
 
 A Gateway whose `gatewayClassName` is not served by KubeLB is ignored: no load balancer is provisioned and the Gateway status stays at the Gateway API default of `Accepted: Unknown` with the message "Waiting for controller", which looks the same as a controller outage. To make the cause visible, the CCM emits a Warning event with reason `GatewayClassNotAccepted` on the Gateway, listing the GatewayClasses it does serve. The event shows up in `kubectl describe gateway <name>`.

--- a/content/kubelb/v1.5/tutorials/loadbalancer/_index.en.md
+++ b/content/kubelb/v1.5/tutorials/loadbalancer/_index.en.md
@@ -116,6 +116,11 @@ spec:
 Persistence is based on the source IP as observed by the KubeLB Envoy Proxy. Behind a NAT gateway or another proxy, multiple clients can share one observed IP and will be pinned to the same endpoint.
 {{% /notice %}}
 
+Two caveats to be aware of:
+
+* `sessionAffinityConfig.clientIP.timeoutSeconds` on the Service is silently ignored. The Maglev hash that implements persistence has no stickiness window; a client stays pinned until the endpoint set changes.
+* Inside the tenant cluster, `sessionAffinity` keys on the client IP as seen at the NodePort hop — which is the KubeLB Envoy pod IP, not the original client. Pod-level fan-out therefore collapses to roughly one pod per node.
+
 ## Hostname Endpoints
 
 Endpoint addresses can reference a DNS hostname instead of an IP. This is useful when the backend has no stable IP. Envoy resolves the hostname continuously (strict DNS), so the endpoint follows DNS changes. If both `ip` and `hostname` are set, `ip` wins.

--- a/content/kubelb/v1.5/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/v1.5/tutorials/mtls-backend-transport/_index.en.md
@@ -97,7 +97,22 @@ Switching between `Direct` and `MTLS` changes the backend traffic path. Plan it 
 
 ### Confirm the mode change on an existing installation
 
-Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic. On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
+Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic.
+
+{{% notice warning %}}
+The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on real clusters, switching to `MTLS` costs from ~15 seconds up to a few minutes of hard failure per tenant — the duration is not deterministic (Layer 4 routes recover last, and a slow tenant apiserver extends the window). The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Switching back to `Direct` is close to hitless. Schedule a maintenance window and make sure clients have retry policies.
+{{% /notice %}}
+
+{{% notice warning %}}
+**Do not treat the `TenantState` conditions as a "switch complete" signal.** `TenantProxyReady` and the
+other conditions report control-plane state and go `True` several seconds to a few minutes *before* traffic
+actually flows through the new path (Layer 4 recovers last). An automation that runs `kubectl wait` on these
+conditions and then proceeds will act during the outage. The only trustworthy "done" signal is a real
+request succeeding end to end on a route in the affected tenant. There is no dataplane-convergence condition
+in v1.5.
+{{% /notice %}}
+
+On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:
 
 ```bash
 kubectl --context <management> -n kubelb annotate config default \


### PR DESCRIPTION
Adds the operational caveats found during v1.5 round-3 release testing to nine KubeLB pages, in both the `main` and `v1.5` trees.

These were originally #2261, closed to fold into the full v1.5 docs push. #2268 landed as a straight snapshot of `main`, so none of it made it in.

## What

| Page | Added |
|---|---|
| `tutorials/mtls-backend-transport` | The `Direct` → `MTLS` flip is fleet-wide with no per-tenant canary, costs ~15s to a few minutes of hard failure per tenant (not deterministic, L4 recovers last), and destroys client keepalive pools. `Direct` is close to hitless. `TenantState` conditions go green before traffic flows, so verify with a real request |
| `installation/upgrade` | One-time L7 disruption window, and the rollback constraints: do not downgrade the Gateway API CRDs, CCM rollback to v1.4.x needs `installGatewayAPICRDs=false`, older-chart `helm install` needs `--skip-crds` |
| `installation/management-cluster` | Envoy Gateway's stock 100 header / 60 KiB ceiling rejects with `431` at the EG hop, before KubeLB's own limits apply |
| `dashboard` | Envoy's 15s default request timeout kills watch streams on the default EG path (dashboard falls back to polling silently); auto-discovery only finds Prometheus on `:9090` |
| `security` | Dashboard images are signed from a different repository, so they need their own cosign identity |
| `tutorials/envoy-proxy/health-checks` | No fail-open (panic threshold is 0 by design), gRPC checks need HTTP/2 backends, pod-level detection needs `externalTrafficPolicy: Local`, connect-only checks never eject a backend serving errors |
| `tutorials/gatewayapi` | Cloud provider annotations must go on `spec.infrastructure.annotations`; `defaultAnnotations` on `Config` do not reach the Service Envoy Gateway provisions. Failure surfaces as `AddressNotAssigned` with the real cause only in the management cluster's Service events |
| `tutorials/loadbalancer` | `sessionAffinityConfig.clientIP.timeoutSeconds` is silently ignored, and affinity keys on the KubeLB Envoy pod IP rather than the original client |
| `cli/tunneling` | `no hostname configurable` rejection with `dns.allowExplicitHostnames: false`, and the `request-wildcard-domain` annotation to get a generated hostname |

