### PR TITLE
Drop unverified v1.5 timing and rollback claims from the KubeLB docs

### DIFF
--- a/content/kubelb/main/installation/upgrade/_index.en.md
+++ b/content/kubelb/main/installation/upgrade/_index.en.md
@@ -141,20 +141,7 @@ kubectl get crd listenersets.gateway.networking.k8s.io
 
 Recovery is the CRD apply itself. Run the management cluster command above; the pod recovers on its own once the CRD exists. No rollback or reinstall is needed.
 
-### Expected disruption
-
-Plan for a one-time Layer 7 disruption of roughly **1.5–2.5 minutes** during the manager upgrade. It is caused by the Envoy resource-naming migration and the Envoy Gateway roll, and it happens once per management cluster. Layer 4 traffic is unaffected.
-
-A `helm upgrade` that fails on a transient apiserver error is safe to re-run with the identical command; it picks up where it left off.
-
 ### Rolling back
-
-Do **not** downgrade the Gateway API CRDs when rolling back. The newer CRDs work with the older Envoy Gateway, so a rollback of the workloads needs no CRD change at all.
-
-Two version-skew traps to avoid:
-
-* When rolling a tenant's CCM back to v1.4.x, set `kubelb.installGatewayAPICRDs=false` on the CCM chart. The old CCM's CRD installer crashloops trying to downgrade the newer CRDs already on the cluster.
-* A fresh `helm install` of an older chart on a cluster that already has the newer CRDs needs `--skip-crds`. Unlike `helm upgrade`, `helm install` applies the chart's `crds/` directory, and that apply is a CRD downgrade.
 
 v1.5.0 installs a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy that rejects any Gateway API CRD older than v1.5.0. If you downgrade to a v1.4.x bundle while it is in place, the apply is denied with:
 

--- a/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/main/tutorials/mtls-backend-transport/_index.en.md
@@ -100,16 +100,15 @@ Switching between `Direct` and `MTLS` changes the backend traffic path. Plan it 
 Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic.
 
 {{% notice warning %}}
-The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on real clusters, switching to `MTLS` costs from ~15 seconds up to a few minutes of hard failure per tenant — the duration is not deterministic (Layer 4 routes recover last, and a slow tenant apiserver extends the window). The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Switching back to `Direct` is close to hitless. Schedule a maintenance window and make sure clients have retry policies.
+The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Schedule a maintenance window and make sure clients have retry policies.
 {{% /notice %}}
 
 {{% notice warning %}}
 **Do not treat the `TenantState` conditions as a "switch complete" signal.** `TenantProxyReady` and the
-other conditions report control-plane state and go `True` several seconds to a few minutes *before* traffic
-actually flows through the new path (Layer 4 recovers last). An automation that runs `kubectl wait` on these
-conditions and then proceeds will act during the outage. The only trustworthy "done" signal is a real
-request succeeding end to end on a route in the affected tenant. There is no dataplane-convergence condition
-in v1.5.
+other conditions report control-plane state and go `True` *before* traffic actually flows through the new
+path. An automation that runs `kubectl wait` on these conditions and then proceeds will act during the
+outage. The only trustworthy "done" signal is a real request succeeding end to end on a route in the
+affected tenant. There is no dataplane-convergence condition in v1.5.
 {{% /notice %}}
 
 On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:

--- a/content/kubelb/v1.5/installation/upgrade/_index.en.md
+++ b/content/kubelb/v1.5/installation/upgrade/_index.en.md
@@ -141,20 +141,7 @@ kubectl get crd listenersets.gateway.networking.k8s.io
 
 Recovery is the CRD apply itself. Run the management cluster command above; the pod recovers on its own once the CRD exists. No rollback or reinstall is needed.
 
-### Expected disruption
-
-Plan for a one-time Layer 7 disruption of roughly **1.5–2.5 minutes** during the manager upgrade. It is caused by the Envoy resource-naming migration and the Envoy Gateway roll, and it happens once per management cluster. Layer 4 traffic is unaffected.
-
-A `helm upgrade` that fails on a transient apiserver error is safe to re-run with the identical command; it picks up where it left off.
-
 ### Rolling back
-
-Do **not** downgrade the Gateway API CRDs when rolling back. The newer CRDs work with the older Envoy Gateway, so a rollback of the workloads needs no CRD change at all.
-
-Two version-skew traps to avoid:
-
-* When rolling a tenant's CCM back to v1.4.x, set `kubelb.installGatewayAPICRDs=false` on the CCM chart. The old CCM's CRD installer crashloops trying to downgrade the newer CRDs already on the cluster.
-* A fresh `helm install` of an older chart on a cluster that already has the newer CRDs needs `--skip-crds`. Unlike `helm upgrade`, `helm install` applies the chart's `crds/` directory, and that apply is a CRD downgrade.
 
 v1.5.0 installs a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy that rejects any Gateway API CRD older than v1.5.0. If you downgrade to a v1.4.x bundle while it is in place, the apply is denied with:
 

--- a/content/kubelb/v1.5/tutorials/mtls-backend-transport/_index.en.md
+++ b/content/kubelb/v1.5/tutorials/mtls-backend-transport/_index.en.md
@@ -100,16 +100,15 @@ Switching between `Direct` and `MTLS` changes the backend traffic path. Plan it 
 Switching the mode re-plumbs the tenant dataplane and briefly disrupts tenant traffic.
 
 {{% notice warning %}}
-The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. Measured on real clusters, switching to `MTLS` costs from ~15 seconds up to a few minutes of hard failure per tenant — the duration is not deterministic (Layer 4 routes recover last, and a slow tenant apiserver extends the window). The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Switching back to `Direct` is close to hitless. Schedule a maintenance window and make sure clients have retry policies.
+The flip is fleet-wide: there is no per-tenant canary in v1.5, so every tenant switches at once. The switch also destroys every client keepalive connection pool: each in-flight request gets a 503 **and** a closed connection, so expect a connection-rate spike until pools rebuild. Schedule a maintenance window and make sure clients have retry policies.
 {{% /notice %}}
 
 {{% notice warning %}}
 **Do not treat the `TenantState` conditions as a "switch complete" signal.** `TenantProxyReady` and the
-other conditions report control-plane state and go `True` several seconds to a few minutes *before* traffic
-actually flows through the new path (Layer 4 recovers last). An automation that runs `kubectl wait` on these
-conditions and then proceeds will act during the outage. The only trustworthy "done" signal is a real
-request succeeding end to end on a route in the affected tenant. There is no dataplane-convergence condition
-in v1.5.
+other conditions report control-plane state and go `True` *before* traffic actually flows through the new
+path. An automation that runs `kubectl wait` on these conditions and then proceeds will act during the
+outage. The only trustworthy "done" signal is a real request succeeding end to end on a route in the
+affected tenant. There is no dataplane-convergence condition in v1.5.
 {{% /notice %}}
 
 On an installation with existing tenants, KubeLB holds the mode change until the `Config` carries a confirmation annotation with the target mode:


### PR DESCRIPTION
Removes the unverified measurements added in #2269, from both the `main` and `v1.5` trees. Nothing else in that PR is touched.

