### PR TITLE
Update Gateway API docs for KKP 2.31

### DIFF
--- a/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
@@ -31,14 +31,12 @@ for example by doing `cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32`.
 A sample configuration for Prometheus and Alertmanager could look like this:
 
 ```yaml
+httpRoute:
+  domain: kkp.example.com
+  path: /dex
+  pathType: PathPrefix
+
 dex:
-  ingress:
-    hosts:
-      - host: kkp.example.com
-        paths:
-          - path: /dex
-            pathType: ImplementationSpecific
-            
   config:
     staticClients:
     # keep the KKP client for the login to the KKP dashboard
@@ -126,26 +124,40 @@ iap:
         github_team: mygroup
 ```
 
-With all this configured, it's now time to install/upgrade the `iap` Helm chart:
+The KKP installer deploys the `iap` chart together with the monitoring stack: release `iap` in
+namespace `monitoring` on the master or seed, and for User Cluster MLA release `iap` in namespace `mla`.
+The installer labels these namespaces for Gateway access automatically. If you prefer to manage the chart
+yourself, install it manually. Using namespace `monitoring` and release name `iap` matches what the
+installer would create:
 
 **Helm 3**
 
 ```bash
-helm --namespace iap upgrade --install --wait --values /path/to/your/helm-values.yaml iap charts/iap/
+helm --namespace monitoring upgrade --install --wait --values /path/to/your/helm-values.yaml iap charts/iap/
 ```
 
-This will create one Ingress per deployment you configured. If all your Ingress hosts are subdomains of your
-primary domain, the wildcard DNS record we already set up earlier will be enough. Otherwise you will need to
-update your DNS accordingly.
+This will create one HTTPRoute per deployment you configured, attached to the KKP Gateway (`kubermatic` in the
+`kubermatic` namespace by default; configure the top-level `httpRoute.gatewayName` and `httpRoute.gatewayNamespace`
+values to point elsewhere, for example at a seed Gateway). Each deployment's `ingress.host` value is reused as the
+HTTPRoute hostname. If all your hosts are subdomains of your primary domain, the wildcard DNS record we already set
+up earlier will be enough. Otherwise you will need to update your DNS accordingly.
 
-In addition, this will also create a TLS certificate for each IAP deployment. Once you setup the required DNS
-records (see next steps) you can check their progress like so:
+The Gateway accepts HTTPRoutes only from namespaces labeled `kubermatic.io/gateway-access=true`. The KKP installer
+labels the required namespaces automatically; when you install the `iap` chart manually with Helm as shown above,
+make sure the namespace carries the label:
 
 ```bash
-watch kubectl -n iap get certificates
-#NAME           READY   SECRET             AGE
-#prometheus     True    prometheus-tls     1h
-#alertmanager   True    alertmanager-tls   1h
+kubectl label namespace monitoring kubermatic.io/gateway-access=true --overwrite
+```
+
+TLS for each IAP hostname is provided by the shared Gateway listener: the HTTPRoute-Gateway sync controller
+adds a listener per hostname and cert-manager issues the certificates based on the Gateway's issuer
+annotation. Once you setup the required DNS records (see next steps) you can check the issued certificates
+like so:
+
+```bash
+watch kubectl -n monitoring get httproute
+kubectl -n kubermatic get gateway kubermatic -o jsonpath='{.spec.listeners[*].hostname}'
 ```
 
 ### DNS Records

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/kkp-security/securing-system-services/_index.en.md
@@ -152,12 +152,14 @@ kubectl label namespace monitoring kubermatic.io/gateway-access=true --overwrite
 
 TLS for each IAP hostname is provided by the shared Gateway listener: the HTTPRoute-Gateway sync controller
 adds a listener per hostname and cert-manager issues the certificates based on the Gateway's issuer
-annotation. Once you setup the required DNS records (see next steps) you can check the issued certificates
-like so:
+annotation. Once you setup the required DNS records (see next steps) you can check that the HTTPRoutes are
+accepted, that the sync controller added listeners for the IAP hostnames, and that the certificates were
+issued:
 
 ```bash
 watch kubectl -n monitoring get httproute
 kubectl -n kubermatic get gateway kubermatic -o jsonpath='{.spec.listeners[*].hostname}'
+kubectl get certificates -A
 ```
 
 ### DNS Records

--- a/content/kubermatic/main/architecture/concept/kkp-concepts/networking/_index.en.md
+++ b/content/kubermatic/main/architecture/concept/kkp-concepts/networking/_index.en.md
@@ -13,6 +13,8 @@ The [expose strategy]({{< ref "../../../../tutorials-howtos/networking/expose-st
 
 This section explains how the connection between user clusters and the control plane is established, as well as the general networking concept in KKP.
 
+Traffic to the management plane itself (the KKP dashboard, API, Dex and the monitoring and logging UIs) enters the master cluster through the Kubernetes Gateway API. KKP deploys Envoy Gateway as the implementation and the Kubermatic Operator manages a Gateway named `kubermatic` together with the HTTPRoutes for the exposed services. See the [Gateway API Migration Guide]({{< ref "../../../../tutorials-howtos/networking/gateway-api-migration/" >}}) for details. The expose strategies described below are unaffected by this and govern only how user cluster control planes are reached.
+
 ![KKP Network](images/network.png?classes=shadow,border "This diagram illustrates the necessary connections for KKP.")
 
 The following diagrams illustrate all available [expose strategy]({{< ref "../../../../tutorials-howtos/networking/expose-strategies" >}}) available in KKP.

--- a/content/kubermatic/main/installation/install-kkp-ce/_index.en.md
+++ b/content/kubermatic/main/installation/install-kkp-ce/_index.en.md
@@ -117,7 +117,7 @@ tar -xzvf "kubermatic-ce-v${VERSION}-darwin-${ARCH}.tar.gz"
 
 The installation and configuration for a KKP system consists of two important files:
 
-* A `values.yaml` used to configure the various Helm charts KKP ships with. This is where nginx, Prometheus,
+* A `values.yaml` used to configure the various Helm charts KKP ships with. This is where the Envoy Gateway, Prometheus,
   Dex, etc. can be adjusted to the target environment. A single `values.yaml` is used to configure all Helm charts
   combined.
 * A `kubermatic.yaml` that configures KKP itself and is an instance of the
@@ -131,11 +131,24 @@ Both files will include secret data, so make sure to securely store them (e.g. i
 The release archive hosted on GitHub contains examples for both of the configuration files (`values.example.yaml` and
 `kubermatic.example.yaml`). It's a good idea to take them as a starting point and add more options as necessary.
 
+KKP uses the Gateway API with Envoy Gateway to route external traffic to the dashboard, API and Dex. The installer deploys the `envoy-gateway-controller` chart and the Kubermatic Operator creates a Gateway named `kubermatic` and the matching HTTPRoutes. Make sure the `httpRoute` block in your `values.yaml` references your domain:
+
+```yaml
+# this is a snippet, not a full values.yaml!
+httpRoute:
+  gatewayName: kubermatic
+  gatewayNamespace: kubermatic
+  domain: "kkp.example.com"  # replace with your domain
+  timeout: 3600s
+```
+
+`httpRoute.domain` must be set explicitly. Nothing defaults it, and with an empty value the Dex chart fails at API-server validation during the installation.
+
 The key items to consider while preparing your configuration files are described in the table below.
 
 | Description                                                                                                                                                                                                                                                                                                  | YAML Paths and File                                                                                                                                                                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| The base domain under which KKP shall be accessible (e.g. `kkp.example.com`).                                                                                                                                                                                                                                | `.spec.ingress.domain` (`kubermatic.yaml`), `.dex.ingress.hosts[0].host` and `dex.ingress.tls[0].hosts[0]` (`values.yaml`); also adjust `.dex.config.staticClients[*].RedirectURIs` (`values.yaml`) according to your domain.                                                                                |
+| The base domain under which KKP shall be accessible (e.g. `kkp.example.com`).                                                                                                                                                                                                                                | `.spec.ingress.domain` (`kubermatic.yaml`) and `.httpRoute.domain` (`values.yaml`); also adjust `.dex.config.staticClients[*].RedirectURIs` (`values.yaml`) according to your domain.                                                                                                                         |
 | The certificate issuer for KKP (KKP requires it since the dashboard and Dex are accessible only via HTTPS); by default cert-manager is used, but you have to reference an issuer that you need to create later on.                                                                                           | `.spec.ingress.certificateIssuer.name` (`kubermatic.yaml`)                                                                                                                                                                                                                                                   |
 | For proper authentication, shared secrets must be configured between Dex and KKP. `.spec.auth.issuerClientSecret` and `.spec.auth.issuerCookieKey` are required for logging into the KKP dashboard and have to be set.                                                                                        | `.dex.config.staticClients[*].secret` (`values.yaml`), `.spec.auth.issuerClientSecret` (`kubermatic.yaml`); this needs to be equal to `.dex.config.staticClients[name=="kubermaticIssuer"].secret` (`values.yaml`), `.spec.auth.issuerCookieKey` and `.spec.auth.serviceAccountKey` (both `kubermatic.yaml`) |
 | To authenticate via an external identity provider, you need to set up connectors in Dex. Check out [the Dex documentation](https://dexidp.io/docs/connectors/) for a list of available providers. This is not required, but highly recommended for multi-user installations.                                 | `.dex.config.connectors` (`values.yaml`; commented in example file)                                                                                                                                                                                                                                          |
@@ -191,23 +204,40 @@ KubermaticConfiguration and let the installer set it in `values.yaml` as well.
 If the Master Cluster's cloud provider does not support `Services` of type `LoadBalancer` (e.g. in an on-premise environment)
 you can configure KKP to not create such `Services`. Later parts of the documentation will cover this case while setting up DNS as well.
 
-To prepare your configuration correctly for this case, ensure that `nginx-ingress-controller` will be set up with a `Service`
-of type `NodePort` instead of `LoadBalancer`. This can be done by providing the appropriate configuration in your `values.yaml`
-file (this will bind access to `Ingress` resources exposed via plain HTTP to port **32080** and encrypted HTTPS to port **32443** on all nodes):
+To prepare your configuration correctly for this case, configure the Envoy Gateway data plane `Service`
+to be of type `NodePort` instead of `LoadBalancer`. This can be done by providing the appropriate configuration in your `values.yaml`
+file (this will bind access via plain HTTP to port **30080** and encrypted HTTPS to port **30443** on all nodes):
 
 ```yaml
 # this is a snippet, not a full values.yaml!
-nginx:
-  controller:
-    service:
-      type: NodePort
-      nodePorts:
-        http: 32080
-        https: 32443
+envoyProxy:
+  service:
+    type: NodePort
+    # Cluster makes every cluster node serve the NodePorts. The default, Local,
+    # preserves the client source IP but drops traffic that reaches a node
+    # without a local Envoy pod.
+    externalTrafficPolicy: Cluster
+    patch:
+      type: JSONMerge
+      value:
+        spec:
+          type: NodePort
+          # the patch replaces the port list, so every entry must be complete.
+          # targetPort must point at the ports the Envoy proxy container
+          # listens on: 10080 for HTTP and 10443 for HTTPS.
+          ports:
+            - name: http
+              port: 80
+              nodePort: 30080
+              targetPort: 10080
+            - name: https
+              port: 443
+              nodePort: 30443
+              targetPort: 10443
 ```
 
-Make sure to include **32443** as port in all URLs both in `kubermatic.yaml` and `values.yaml`, e.g. the token issuer URL from `kubermatic.yaml`
-should now be `https://kkp.example.com:32443/dex`.
+Make sure to include **30443** as port in all URLs both in `kubermatic.yaml` and `values.yaml`, e.g. the token issuer URL from `kubermatic.yaml`
+should now be `https://kkp.example.com:30443/dex`.
 
 ### Create a StorageClass
 
@@ -346,8 +376,11 @@ spec:
       name: letsencrypt-prod-acme-account-key
     solvers:
     - http01:
-       ingress:
-         class: nginx
+       gatewayHTTPRoute:
+         parentRefs:
+         - kind: Gateway
+           name: kubermatic
+           namespace: kubermatic
 ```
 
 Save this (or the adjusted `ClusterIssuer` you are going to use) to a file (e.g. `clusterissuer.yaml`) and apply it
@@ -360,8 +393,8 @@ kubectl apply -f ./clusterissuer.yaml
 ### Create DNS Records
 
 In order to acquire a valid certificate, a DNS name needs to point to your cluster. Depending on your environment
-this can mean a `LoadBalancer` service or a `NodePort` service. The `nginx-ingress-controller` Helm chart will by default
-create a load balancer, unless you [reconfigured it because your environment does not support load balancers](#without-loadbalancers).
+this can mean a `LoadBalancer` service or a `NodePort` service. The Envoy Gateway data plane is by default
+exposed via a load balancer, unless you [reconfigured it because your environment does not support load balancers](#without-loadbalancers).
 
 The installer will do its best to inform you about the required DNS records to set up. You will receive an output
 similar to this:
@@ -370,10 +403,10 @@ similar to this:
 INFO[13:03:33]    📝 Applying Kubermatic Configuration…
 INFO[13:03:33]    ✅ Success.
 INFO[13:03:33]    📡 Determining DNS settings…
-INFO[13:03:33]       The main LoadBalancer is ready.
+INFO[13:03:33]       The main Gateway is ready.
 INFO[13:03:33]
-INFO[13:03:33]         Service             : nginx-ingress-controller / nginx-ingress-controller
-INFO[13:03:33]         Ingress via hostname: EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com
+INFO[13:03:33]         Gateway             : kubermatic / kubermatic
+INFO[13:03:33]         Address via hostname: EXAMPLEEXAMPLEEXAMPLEEXAMPLE-EXAMPLE.eu-central-1.elb.amazonaws.com
 INFO[13:03:33]
 INFO[13:03:33]       Please ensure your DNS settings for "kkp.example.com" include the following records:
 INFO[13:03:33]
@@ -390,17 +423,19 @@ cluster. See the following sections for more information regarding the required 
 #### With LoadBalancers
 
 If your cloud provider supports load balancers, you can find the target IP / hostname by looking at the
-`nginx-ingress-controller` Service:
+Envoy Gateway data plane Service in the `envoy-gateway-controller` namespace (the name follows the pattern
+`envoy-kubermatic-kubermatic-<suffix>`), or by reading the address from the Gateway status:
 
 ```bash
-kubectl -n nginx-ingress-controller get services
+kubectl -n envoy-gateway-controller get services
+kubectl -n kubermatic get gateway kubermatic -o jsonpath='{.status.addresses}'
 ```
 
 Output will be similar to this:
 
 ```bash
-#NAME                       TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-#nginx-ingress-controller   LoadBalancer   10.47.248.232   1.2.3.4        80:32014/TCP,443:30772/TCP   449d
+#NAME                              TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
+#envoy-kubermatic-kubermatic-ab12cd34   LoadBalancer   10.47.248.232   1.2.3.4       80:32014/TCP,443:30772/TCP   5m
 ```
 
 `EXTERNAL-IP` is what you need to put into the DNS record. Note that this can be a hostname (for example on AWS,
@@ -452,7 +487,7 @@ stacks. This involves setting up either individual DNS records per IAP deploymen
 or simply creating a single **wildcard** record: `*.kkp.example.com`.
 
 Whatever you choose, the DNS record needs to point to the same endpoint (IP or hostname, meaning A or CNAME
-records respectively) as the previous record, i.e. `1.2.3.4`. This is because the one nginx-ingress-controller is routing
+records respectively) as the previous record, i.e. `1.2.3.4`. This is because the shared Envoy Gateway is routing
 traffic both for KKP and all other services.
 
 ```plain

--- a/content/kubermatic/main/installation/offline-mode/_index.en.md
+++ b/content/kubermatic/main/installation/offline-mode/_index.en.md
@@ -24,7 +24,7 @@ without Docker.
 There are a number of sources for container images used in a KKP setup:
 
 - The container images used by KKP itself (e.g. `quay.io/kubermatic/kubermatic`)
-- The images used by the various Helm charts used to deploy KKP (nginx, cert-manager,
+- The images used by the various Helm charts used to deploy KKP (Envoy Gateway, cert-manager,
   Grafana, ...)
 - The images used for creating a user cluster control plane (the Kubernetes apiserver,
   scheduler, metrics-server, ...).
@@ -124,7 +124,6 @@ metadata:
   name: kubermatic
 spec:
   mirrorImages:
-    - nginx:1.21.6
     - quay.io/kubermatic/kubelb-manager-ee:v1.1.0
 ```
 

--- a/content/kubermatic/main/installation/single-node-setup/_index.en.md
+++ b/content/kubermatic/main/installation/single-node-setup/_index.en.md
@@ -98,12 +98,12 @@ export KUBECONFIG=$PWD/aws/<cluster_name>-kubeconfig
 - Get the LoadBalancer External IP by following command.
 
   ```bash
-  kubectl get svc -n ingress-nginx
+  kubectl -n envoy-gateway-controller get svc
   ```
 
-- Update DNS mapping with External IP of the nginx ingress controller service. In case of AWS, the CNAME record mapping for $TODO_DNS with External IP should be created.
+- Update DNS mapping with the address of the Envoy Gateway data plane service. In case of AWS, the CNAME record mapping for $TODO_DNS with the load balancer hostname should be created.
 
-- Nginx Ingress Controller Load Balancer configuration - Add the node to backend pool manually.
+- Envoy Gateway Load Balancer configuration - Add the node to backend pool manually.
   > **Known Issue**: Should be supported in the future as part of Feature request[#1822](https://github.com/kubermatic/kubeone/issues/1822)
 
 - Verify the Kubermatic resources and certificates

--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/_index.en.md
@@ -56,7 +56,9 @@ httpRoute:
 
 During the upgrade, the installer deploys the `envoy-gateway-controller` chart, waits up to 10 minutes for the Gateway and the Kubermatic and Dex HTTPRoutes to become ready, and then deletes the legacy Ingress resources. DNS must be flipped from the nginx LoadBalancer to the Envoy Gateway address; until then, requests still reaching nginx get a 404 because its Ingress resources are gone. The installer uninstalls the nginx-ingress-controller Helm release only when run with `--clean-nginx-lb`. For a staged DNS cutover, `--skip-ingress-cleanup` keeps the legacy Ingresses alive during a first pass; the two flags cannot be combined.
 
+{{% notice note %}}
 Separate seed clusters are not cleaned up automatically. If nginx-ingress-controller was deployed on separate seeds, remove it there manually.
+{{% /notice %}}
 
 See the [Gateway API Migration Guide]({{< ref "../../../tutorials-howtos/networking/gateway-api-migration/" >}}) for the complete procedure, including the staged cutover and the user-managed (BYO) Gateway option.
 

--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/_index.en.md
@@ -35,6 +35,31 @@ See [OIDC Provider Configuration]({{< ref "../../../tutorials-howtos/oidc-provid
 Because the dashboard now uses the same OIDC client as the kubeconfig and web terminal flows, it is affected by the existing Dex limitation of one refresh token per user/client pair. Downloading a kubeconfig or opening a web terminal ends the running dashboard session once its ID token expires. See [OIDC refresh tokens are invalidated when the same user/client ID pair is authenticated multiple times]({{< ref "../../../architecture/known-issues/#oidc-refresh-tokens-are-invalidated-when-the-same-userclient-id-pair-is-authenticated-multiple-times" >}}).
 {{% /notice %}}
 
+### Gateway API Replaces nginx-ingress-controller
+
+KKP 2.31 enforces the Gateway API with Envoy Gateway as the only way to route external traffic to the dashboard, API, Dex and the monitoring UIs. The nginx-ingress-controller path has been removed. The `migrateGatewayAPI` Helm value and the `--migrate-gateway-api` installer and `--enable-gateway-api` operator flags are accepted but ignored.
+
+If you already migrated to Gateway API on KKP 2.30, there is nothing to do. Otherwise, prepare your `values.yaml` **before** upgrading:
+
+1. Add the top-level `httpRoute` block and set `httpRoute.domain` to your `spec.ingress.domain`. Nothing defaults it, and with an empty value the Dex chart fails Gateway API validation at the API server, which aborts the dex Helm upgrade in the middle of the installer run.
+
+```yaml
+httpRoute:
+  gatewayName: kubermatic
+  gatewayNamespace: kubermatic
+  domain: "kkp.example.com"  # replace with your domain
+  timeout: 3600s
+```
+
+2. If you use cert-manager with the HTTP01 challenge, migrate your ClusterIssuer solver from `ingress.class: nginx` to `gatewayHTTPRoute` with `parentRefs` pointing at the Gateway `kubermatic` in the namespace `kubermatic`.
+3. If you use external-dns, switch its sources from `ingress` to `gateway-httproute`.
+
+During the upgrade, the installer deploys the `envoy-gateway-controller` chart, waits up to 10 minutes for the Gateway and the Kubermatic and Dex HTTPRoutes to become ready, and then deletes the legacy Ingress resources. DNS must be flipped from the nginx LoadBalancer to the Envoy Gateway address; until then, requests still reaching nginx get a 404 because its Ingress resources are gone. The installer uninstalls the nginx-ingress-controller Helm release only when run with `--clean-nginx-lb`. For a staged DNS cutover, `--skip-ingress-cleanup` keeps the legacy Ingresses alive during a first pass; the two flags cannot be combined.
+
+Separate seed clusters are not cleaned up automatically. If nginx-ingress-controller was deployed on separate seeds, remove it there manually.
+
+See the [Gateway API Migration Guide]({{< ref "../../../tutorials-howtos/networking/gateway-api-migration/" >}}) for the complete procedure, including the staged cutover and the user-managed (BYO) Gateway option.
+
 ## Upgrade Procedure
 
 Before starting the upgrade, make sure your KKP Master and Seed clusters are healthy with no failing or pending Pods. If any Pod is showing problems, investigate and fix the individual problems before applying the upgrade. This includes the control plane components for user clusters, unhealthy user clusters should not be submitted to an upgrade.

--- a/content/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/_index.en.md
+++ b/content/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/_index.en.md
@@ -52,7 +52,7 @@ httpRoute:
 ```
 
 2. If you use cert-manager with the HTTP01 challenge, migrate your ClusterIssuer solver from `ingress.class: nginx` to `gatewayHTTPRoute` with `parentRefs` pointing at the Gateway `kubermatic` in the namespace `kubermatic`.
-3. If you use external-dns, switch its sources from `ingress` to `gateway-httproute`.
+3. If you use external-dns, switch its sources from `ingress` to `gateway-httproute` before the legacy Ingress resources are deleted. With the default `sync` policy, external-dns removes records it created from Ingresses that no longer exist.
 
 During the upgrade, the installer deploys the `envoy-gateway-controller` chart, waits up to 10 minutes for the Gateway and the Kubermatic and Dex HTTPRoutes to become ready, and then deletes the legacy Ingress resources. DNS must be flipped from the nginx LoadBalancer to the Envoy Gateway address; until then, requests still reaching nginx get a 404 because its Ingress resources are gone. The installer uninstalls the nginx-ingress-controller Helm release only when run with `--clean-nginx-lb`. For a staged DNS cutover, `--skip-ingress-cleanup` keeps the legacy Ingresses alive during a first pass; the two flags cannot be combined.
 

--- a/content/kubermatic/main/references/setup-checklist/_index.en.md
+++ b/content/kubermatic/main/references/setup-checklist/_index.en.md
@@ -64,7 +64,7 @@ A helpful shortcut, we recommend our KubeOne tooling container, which contains a
 
 ## Load Balancer
 
-Kubermatic exposes an NGINX server and user clusters API servers via Load Balancers. Therefore, KKP is using the native Kubernetes Service Type `LoadBalancer` implementation. More details about the different expose points you find at the next chapter “DHCP/Networking”
+Kubermatic exposes an Envoy Gateway and user clusters API servers via Load Balancers. Therefore, KKP is using the native Kubernetes Service Type `LoadBalancer` implementation. More details about the different expose points you find at the next chapter “DHCP/Networking”
 
 ### On-Premise/Bring-your-own Load Balancer
 
@@ -112,9 +112,9 @@ For other Load Balancer scenarios we strongly recommend to use cloud environment
 
 ## DNS
 
-Kubermatic requires DNS entries for NGINX and user clusters API servers. These have to be created after the Load Balancers, see [EE Installation - DNS Records](https://docs.kubermatic.com/kubermatic/main/installation/install-kkp-ce/#dns-records) and [EE Seed Cluster - DNS Records](https://docs.kubermatic.com/kubermatic/main/installation/install-kkp-ce/add-seed-cluster-ce/#dns-record).
+Kubermatic requires DNS entries for the Envoy Gateway and user clusters API servers. These have to be created after the Load Balancers, see [EE Installation - DNS Records](https://docs.kubermatic.com/kubermatic/main/installation/install-kkp-ce/#dns-records) and [EE Seed Cluster - DNS Records](https://docs.kubermatic.com/kubermatic/main/installation/install-kkp-ce/add-seed-cluster-ce/#dns-record).
 
-The NGINX server provides access to the Kubermatic UI and the logging and monitoring services (Prometheus, Kibana, etc.). It requires a DNS name like `kubermatic.example.com` and `*.kubermatic.example.com` (e.g.for `prometheus.kubermatic.example.com`). Optional: if no wildcard DNS can be provided, dedicated DNS entries per exposed Service need to get entered (\~5 services).
+The Envoy Gateway provides access to the Kubermatic UI and the logging and monitoring services (Prometheus, Grafana, etc.). It requires a DNS name like `kubermatic.example.com` and `*.kubermatic.example.com` (e.g.for `prometheus.kubermatic.example.com`). Optional: if no wildcard DNS can be provided, dedicated DNS entries per exposed Service need to get entered (\~5 services).
 
 To access a user cluster via API, a wildcard DNS entry per seed cluster (in your case, the master cluster is the only seed) has to be provided. E.g., `*.seed.kubermatic.example.com`. User clusters would be accessible via `cluster-id.seed.kubermatic.example.com`.
 
@@ -126,13 +126,13 @@ Root DNS-Zone: `*.kubermatic.example.com`
 
 | **Service**                                    | **DNS**                                                                                                                                                                                                                                                                               | **IP**                                                                                         |
 |------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
-| KKP UI                                         | `kubermatic.example.com`                                                                                                                                                                                                                                                              | Ingress IP: dynamic or static (virtual IP)                                                     |
-| Management Monitoring / Logging UI - Grafana   | `grafana.kubermatic.example.com`                                                                                                                                                                                                                                                      | Ingress IP: dynamic or static (virtual IP)                                                     |
-| Management Monitoring - Prometheus             | `prometheus.kubermatic.example.com`                                                                                                                                                                                                                                                   | Ingress IP: dynamic or static (virtual IP)                                                     |
-| Management Monitoring - Alertmanager           | `alertmanager.kubermatic.example.com`                                                                                                                                                                                                                                                 | Ingress IP: dynamic or static (virtual IP)                                                     |
+| KKP UI                                         | `kubermatic.example.com`                                                                                                                                                                                                                                                              | Gateway IP: dynamic or static (virtual IP)                                                     |
+| Management Monitoring / Logging UI - Grafana   | `grafana.kubermatic.example.com`                                                                                                                                                                                                                                                      | Gateway IP: dynamic or static (virtual IP)                                                     |
+| Management Monitoring - Prometheus             | `prometheus.kubermatic.example.com`                                                                                                                                                                                                                                                   | Gateway IP: dynamic or static (virtual IP)                                                     |
+| Management Monitoring - Alertmanager           | `alertmanager.kubermatic.example.com`                                                                                                                                                                                                                                                 | Gateway IP: dynamic or static (virtual IP)                                                     |
 | Seed cluster - Kubernetes API Expose Service   | Expose Strategy: **NodePort/Tunneling**: `*.seed.kubermatic.example.com`; **LoadBalancer**: `NONE` (will be exposed by independent LB/IPs per cluster see - [expose strategy LoadBalancer](https://docs.kubermatic.com/kubermatic/master/concepts/expose-strategy/expose_strategy/)). | NodePort Proxy: dynamic or static (virtual IP)**Or** one virtual IP per user cluster in a CIDR |
-| User Cluster Monitoring - Alertmanager         | `alertmanager.seed.kubermatic.example.com`                                                                                                                                                                                                                                            | Ingress IP: dynamic or static (virtual IP)                                                     |
-| User Cluster Monitoring / Logging UI - Grafana | `grafana.seed.kubermatic.example.com`                                                                                                                                                                                                                                                 | Ingress IP: dynamic or static (virtual IP)                                                     |
+| User Cluster Monitoring - Alertmanager         | `alertmanager.seed.kubermatic.example.com`                                                                                                                                                                                                                                            | Gateway IP: dynamic or static (virtual IP)                                                     |
+| User Cluster Monitoring / Logging UI - Grafana | `grafana.seed.kubermatic.example.com`                                                                                                                                                                                                                                                 | Gateway IP: dynamic or static (virtual IP)                                                     |
 
 It is also possible to use [external-dns](https://github.com/kubernetes-sigs/external-dns) as an automatic way to manage DNS Entries for you. Therefore, checkout if your DNS provider is supported: [external-dns provider](https://github.com/kubernetes-sigs/external-dns?tab=readme-ov-file#externaldns)
 
@@ -310,7 +310,7 @@ To set up Kubermatic behind [MetalLB](https://metallb.universe.tf/), we need a f
 
 CIDR for
 
-- Ingress: 1 IP
+- Gateway (Envoy): 1 IP
 
 - Node-Port-Proxy: 1 IP (if expose strategy NodePort or Tunneling), multiple IPs at expose strategy LoadBalancer (for each cluster one IP)
 

--- a/content/kubermatic/main/tutorials-howtos/gitops-argocd/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/gitops-argocd/_index.en.md
@@ -60,7 +60,7 @@ We will install ArgoCD on both the clusters and we will install following compon
 
 1. Core KKP components
    1. Dex (in master)
-   1. ngix-ingress-controller
+   1. nginx-ingress-controller
    1. cert-manager
 1. Backup components
    1. Velero

--- a/content/kubermatic/main/tutorials-howtos/kkp-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-configuration/custom-certificates/_index.en.md
@@ -230,8 +230,9 @@ hostname.
 ### Identity-Aware Proxy
 
 The IAP chart no longer creates per-deployment `Certificate` resources. Each IAP deployment is exposed via an
-HTTPRoute on the shared Gateway and its hostname is covered by the Gateway listener certificate, issued by
-the same cert-manager issuer or by the static Secret referenced via `spec.ingress.gateway.tls.secretRef`.
+HTTPRoute on the shared Gateway. In cert-manager mode, the sync controller adds a listener and a certificate
+per hostname, all issued from the issuer configured for KKP. With a static certificate, the Secret referenced
+via `spec.ingress.gateway.tls.secretRef` must cover every hostname.
 
 The `iap.certIssuer` value still exists in the chart values but no longer has an effect.
 

--- a/content/kubermatic/main/tutorials-howtos/kkp-configuration/custom-certificates/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/kkp-configuration/custom-certificates/_index.en.md
@@ -56,25 +56,11 @@ spec:
       name: my-own-ca-issuer
 ```
 
-Re-apply the changed configuration and the KKP Operator will reconcile the Certificate resource,
-after which cert-manager will provision a new certificate Secret.
+Re-apply the changed configuration and the KKP Operator will annotate the Gateway with the new
+issuer, after which cert-manager will provision the certificate for the Gateway listener.
 
-Similarly, update your Helm `values.yaml` that is used for the Dex/IAP deployment and configure
-the new issuer:
-
-```yaml
-dex:
-  certIssuer:
-    kind: ClusterIssuer # or Issuer, depending on your scenario.
-    name: my-own-ca-issuer
-
-iap:
-  certIssuer:
-    kind: ClusterIssuer # or Issuer, depending on your scenario.
-    name: my-own-ca-issuer
-```
-
-Re-deploy the `iap` Helm chart to perform the changes and update the `Certificate` resources.
+Dex and the IAP deployments are served through the same Gateway as the KKP API, so the issuer
+configured for KKP covers them as well. No separate certificate configuration is needed for Dex or IAP.
 
 ### External
 
@@ -188,9 +174,10 @@ spec:
 
 ### KKP
 
-The KKP Operator manages a single `Ingress` for the KKP API/dashboard. This by default includes setting up
-the required annotations and spec settings for usage with cert-manager. However, if cert-manager
-integration is disabled, the cluster admin is free to manage these settings themselves.
+The KKP Operator manages a `Gateway` and `HTTPRoute` for the KKP API/dashboard. By default the Gateway HTTPS
+listener obtains its certificate via cert-manager, driven by `spec.ingress.certificateIssuer` in the
+`KubermaticConfiguration`. If cert-manager integration is disabled, the cluster admin provides a static
+certificate Secret instead.
 
 To disable cert-manager integration, set `spec.ingress.certificateIssuer` as empty
 in the `KubermaticConfiguration` or omit setting the field entirely:
@@ -201,18 +188,24 @@ spec:
     certificateIssuer: null
 ```
 
-It is now possible to set `spec.tls` on the `kubermatic` `Ingress` to a custom certificate by manually changing
-it with `kubectl edit`:
+Then reference your existing certificate Secret on the Gateway listener via `spec.ingress.gateway.tls.secretRef`:
 
 ```yaml
 spec:
-  tls:
-  - secretName: my-custom-kubermatic-cert
-    hosts:
-    - kkp.example.com
+  ingress:
+    gateway:
+      tls:
+        secretRef:
+          name: my-custom-kubermatic-cert
+          # namespace is optional; defaults to the Gateway namespace.
+          # Cross-namespace references require a Gateway API ReferenceGrant
+          # in the target namespace.
 ```
 
-Refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
+The referenced Secret must be of type `kubernetes.io/tls`. When hostname-specific HTTPS listeners are synced
+for HTTPRoutes, the certificate must cover all served hostnames, for example via a wildcard or SAN certificate.
+
+Refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/secret/#secret-types)
 for details on the format for certificate `Secrets`.
 
 {{% notice warning %}}
@@ -228,33 +221,19 @@ to not put actual secrets into the CA bundle.
 
 ### Dex
 
-The same technique used for KKP is applicable to Dex as well: Set the name of the certificate issuer to an empty
-string to be able to configure your own certificates. Update the Helm `values.yaml` used to deploy the
-chart like so:
-
-```yaml
-dex:
-  certIssuer:
-    name: ""
-```
-
-Re-deploy the chart and the `Certificate` resource will not be created anymore. You have to manually create
-a `dex-tls` Secret in the `oauth` namespace. This `Secret` follows the
-[same format](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) as the one for KKP's API.
+Dex is served through the same Gateway as the KKP API, on the domain configured in the top-level `httpRoute.domain` value.
+Its TLS certificate comes from the Gateway listener, so the issuer configured for KKP covers Dex as well.
+No separate certificate configuration is needed. To use a static certificate for the whole Gateway instead,
+see [KKP](#kkp) above and use `spec.ingress.gateway.tls.secretRef` with a certificate that includes the Dex
+hostname.
 
 ### Identity-Aware Proxy
 
-The configuration is identical to Dex: Disable the cert issuer's name and then manually create the TLS
-certificates.
+The IAP chart no longer creates per-deployment `Certificate` resources. Each IAP deployment is exposed via an
+HTTPRoute on the shared Gateway and its hostname is covered by the Gateway listener certificate, issued by
+the same cert-manager issuer or by the static Secret referenced via `spec.ingress.gateway.tls.secretRef`.
 
-```yaml
-iap:
-  certIssuer:
-    name: ""
-```
-
-For each configured Deployment (`iap.deployments`) a matching Secret needs to be created. For a Deployment
-named `grafana`, the Secret needs to be called `grafana-tls`.
+The `iap.certIssuer` value still exists in the chart values but no longer has an effect.
 
 ### Token Validation
 
@@ -301,19 +280,24 @@ Re-deploy the `iap` Helm chart to apply the changes.
 
 ## Wildcard Certificates
 
-Generally the KKP stack is built to use dedicated certificates for each Ingress / application, but it's
-possible to instead configure a single (usually wildcard) certificate in nginx that will be used as the
-default certificate for all domains.
+Generally the KKP stack is built to use dedicated certificates for each hostname, but it's
+possible to instead configure a single (usually wildcard) certificate that will be used
+as the certificate for all domains served by the KKP Gateway.
 
 As with all other custom certificates, create a new Secret with the certificate and private key in it,
-and then adjust your Helm `values.yaml` to configure nginx like so:
+and then reference it in the `KubermaticConfiguration`:
 
 ```yaml
-nginx:
-  controller:
-    extraArgs:
-      # The value of this flag is in the form "namespace/name".
-      default-ssl-certificate: "mynamespace/mysecret'
+spec:
+  ingress:
+    certificateIssuer: null
+    domain: kkp.example.com
+    gateway:
+      tls:
+        secretRef:
+          name: my-wildcard-cert
 ```
 
-Redeploy the `nginx-ingress-controller` Helm chart to enable the changes.
+The certificate must cover the main domain and all served hostnames (for example `kkp.example.com` and
+`*.kkp.example.com` for the dashboard, Dex, Grafana, Alertmanager and the other exposed services).
+Re-run the `kubermatic-installer` to apply the changes.

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/master-seed/health-assessment/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/master-seed/health-assessment/_index.en.md
@@ -17,7 +17,6 @@ Dashboards list consists of categories as shown below, each containing Dashboard
 - **Kubernetes** - dashboards used for monitoring Kubernetes resources of the seed cluster (described [below](#monitoring-kubernetes)).
 - **Minio** - dashboards used for monitoring local MinIO installation.
 - **Monitoring** - dashboards used for checking the health of the monitoring stack itself.
-- **NGINX Ingress Controller** - dashboards used for visualising NGINX Ingress status.
 
 ![Categories of Grafana dashboards](images/all-dashboards.png?classes=shadow,border)
 

--- a/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/_index.en.md
@@ -115,7 +115,7 @@ Let's start with preparing the values.yaml for the IAP Helm Chart. A starting po
 
 It is also necessary to set up your infrastructure accordingly:
 
-- Configure your DNS with the DNS entry for the domain name that you used in `iap.deployments.grafana.ingress.host` and `iap.deployments.alertmanager.ingress.host` so that it points to the ingress-controller service of KKP.
+- Configure your DNS with the DNS entry for the domain name that you used in `iap.deployments.grafana.ingress.host` and `iap.deployments.alertmanager.ingress.host` so that it points to the KKP Gateway. The IAP chart creates one HTTPRoute per deployment and reuses the `ingress.host` value as the HTTPRoute hostname.
 - Configure the Dex in KKP with the proper configuration for Grafana and Alertmanager IAP, e.g. using the following snippet that can be placed into the KKP values.yaml. Make sure to modify the `RedirectURIs` with your domain name used in `iap.deployments.grafana.ingress.host` and `iap.deployments.alertmanager.ingress.host` and secret with your `iap.deployments.grafana.client_secret` and `iap.deployments.alertmanager.client_secret`:
 
 ```yaml

--- a/content/kubermatic/main/tutorials-howtos/networking/gateway-api-migration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/gateway-api-migration/_index.en.md
@@ -450,7 +450,7 @@ For example, if your LoadBalancer IP changes between nginx and Envoy Gateway, or
 5. Re-run the installer without `--skip-ingress-cleanup` to delete the legacy Ingress resources
 6. Run the installer with `--clean-nginx-lb` to uninstall nginx-ingress-controller and release its LoadBalancer
 
-If you use external-dns, switch its sources from `ingress` to `gateway-httproute` before the cutover, so records are created from the Gateway and its HTTPRoutes automatically.
+If you use external-dns, switch its sources from `ingress` to `gateway-httproute` before the cutover, so records are created from the Gateway and its HTTPRoutes automatically. Do this before the legacy Ingress resources are deleted: with the default `sync` policy, external-dns removes records it created from Ingresses that no longer exist.
 
 ### Preserving Your LoadBalancer IP
 

--- a/content/kubermatic/main/tutorials-howtos/networking/gateway-api-migration/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/gateway-api-migration/_index.en.md
@@ -9,16 +9,16 @@ weight = 155
 
 ## Overview
 
-Kubermatic Kubernetes Platform is transitioning from the nginx-ingress-controller to the Gateway API with Envoy Gateway. This document explains what this means for your deployment, why we are making this change, and how to migrate when you are ready.
+As of KKP 2.31, Gateway API with Envoy Gateway is the only supported way to route external traffic to the Kubermatic dashboard, API, Dex and the related services. The nginx-ingress-controller path has been removed from the source code. If you are upgrading from KKP 2.30 and still use nginx-ingress-controller, the move to Gateway API happens as part of the upgrade to 2.31. This guide explains what the installer does, which knobs control the cleanup of the legacy nginx resources, and how to prepare your configuration before upgrading.
 
-This migration affects how traffic reaches the Kubermatic dashboard and API. The external behavior remains the same, but the underlying implementation changes to use modern Kubernetes standards.
+This change affects how traffic reaches the Kubermatic dashboard and API. The external behavior remains the same, but the underlying implementation uses the Gateway API standard from the Kubernetes community.
 
 ## What is Changing
 
-The current implementation uses `nginx-ingress-controller`, which has been the standard way to expose HTTP services in Kubernetes for several years.
-However, the Kubernetes project has announced the retirement of the community-maintained Ingress NGINX controller, with end of maintenance scheduled for March 2026.
+The previous implementation used `nginx-ingress-controller`, which has been the standard way to expose HTTP services in Kubernetes for several years.
+The Kubernetes project has announced the retirement of the community-maintained Ingress NGINX controller, with end of maintenance scheduled for March 2026. KKP therefore removed the nginx path entirely.
 
-When you migrate, instead of creating Ingress resources, Kubermatic will create Gateway API resources.
+Instead of creating Ingress resources, Kubermatic creates Gateway API resources.
 These are part of the official Gateway API specification from the Kubernetes community.
 By default, KKP deploys Envoy Gateway as the implementation that processes these resources and handles the traffic. If you configure `spec.ingress.gateway.externalGateway`, KKP attaches its HTTPRoutes to the configured user-managed Gateway instead, and the Gateway implementation and data plane are operated outside of KKP.
 
@@ -53,27 +53,20 @@ Kubermatic is not going to delete Ingress LoadBalancer service from the cluster,
 
 ## How the Migration Works
 
-The migration is designed to be explicit and safe. There is no automatic switching that could surprise you during an upgrade.
-Instead, you make a conscious decision to migrate by setting a flag during deployment.
+On KKP 2.31 Gateway API is always enabled. There is no flag that turns it off and no mode in which `kubermatic-operator` creates Ingress resources.
 
-### The Migration Flag
+The `migrateGatewayAPI` Helm value, the `--migrate-gateway-api` installer flag and the `--enable-gateway-api` operator flag are deprecated no-ops. They are still accepted so that scripts and values files written for KKP 2.30 keep working, but they no longer change any behavior. Remove them from your configuration when convenient.
 
-The migration is controlled by two parameters: a Helm value called `migrateGatewayAPI` and the `--migrate-gateway-api` flag in kubermatic-installer.
+For upgrades from KKP 2.30, the migration happens when you run the 2.31 installer, as described in [Migration Steps](#migration-steps).
 
-By default, a Helm Chart configuration `migrateGatewayAPI` is set to `false` in KKP v2.30, meaning your cluster continues using `nginx-ingress-controller` as it always has.
-When you are ready to migrate, you set this to true and redeploy Kubermatic via kubermatic-installer, by providing `--migrate-gateway-api` flag.
+### What Happens During the Upgrade
 
-> Note that if `kubermatic-installer` is not being used for Kubermatic installation and upgrade,
-> you need to manually provide `-enable-gateway-api` flag to `kubermatic-operator`.
+When you deploy or upgrade KKP 2.31, the following sequence occurs:
 
-### What Happens During Migration
-
-When you enable the migration, the following sequence occurs:
-
-1. `kubermatic-installer` deploys the Envoy Gateway controller and its Custom Resource Definitions using Helm.
+1. `kubermatic-installer` deploys the Envoy Gateway controller via its Helm chart and installs the Gateway API Custom Resource Definitions.
    If `spec.ingress.gateway.externalGateway` is configured, the installer only ensures the Gateway API Custom Resource Definitions exist and skips deploying the bundled Envoy Gateway controller. In this mode, the Gateway controller and Gateway data plane are operated externally.
 
-2. `kubermatic-operator` is deployed with the `-enable-gateway-api` startup flag, which allows `kubermatic-operator` to manage Gateway and HTTPRoute resources instead of Ingress resources.
+2. `kubermatic-operator` manages Gateway and HTTPRoute resources. It never creates Ingress resources.
 
 3. `kubermatic-operator` creates the KKP HTTPRoute. In the default mode it also creates the `kubermatic/kubermatic` Gateway. In `externalGateway` mode it does not create a Gateway and instead points the KKP HTTPRoute at the configured external Gateway.
 
@@ -90,26 +83,18 @@ When you enable the migration, the following sequence occurs:
 
 {{% notice note %}}
 
-The kubermatic-installer does *NOT* uninstall the `nginx-ingress-controller` Helm release.
+The installer deletes the legacy Ingress resources (`kubermatic/kubermatic` and `dex/dex`), but it uninstalls the `nginx-ingress-controller` Helm release only when you run it with `--clean-nginx-lb`. Until that final run, both controllers exist in the cluster. After its Ingress resources are deleted, nginx serves no rules and answers with a 404 for any request that still reaches its LoadBalancer.
 
-With the KKP-managed Gateway, both `nginx-ingress-controller` and `envoy-gateway-controller` will be running in your cluster after migration.
-With `spec.ingress.gateway.externalGateway`, KKP does not install the bundled `envoy-gateway-controller`; the external Gateway controller remains managed outside of KKP.
-You must manually uninstall nginx-ingress-controller when you are ready. Only Ingress resources (`kubermatic/kubermatic` and `dex/dex`) are deleted.
+With `spec.ingress.gateway.externalGateway`, KKP does not install the bundled `envoy-gateway-controller`; the external Gateway controller remains managed outside of KKP, and the legacy nginx release must be removed manually.
 
 {{% /notice %}}
 
 ### The Operator Behavior
 
-The kubermatic-operator runs in one of two modes depending on the startup flag.
-If the flag (`-enable-gateway-api`) is not set, it creates and manages Ingress resources. If the flag is set, it creates and manages Gateway and HTTPRoute resources instead.
+The kubermatic-operator always creates and manages Gateway and HTTPRoute resources. There is no Ingress mode and no flag that switches behavior. The operator does not delete legacy Ingress resources at runtime; their cleanup is handled by `kubermatic-installer` at deployment time.
 
-Importantly, the operator does not clean up resources from the other mode.
-This is a safety feature.
-If the operator automatically deleted Gateway resources when running in Ingress mode, or vice versa, it could break cluster access unexpectedly.
-Instead, we handle cleanup explicitly during the migration process.
-
-Also, when kubermatic-operator starts with the Gateway API flag enabled, it checks that the Gateway API Custom Resource Definitions exist in the cluster.
-If they do not exist, the operator refuses to start and provides a clear error message. This fail-fast behavior prevents the operator from starting in a broken state where it cannot function properly.
+When kubermatic-operator starts, it checks that the Gateway API Custom Resource Definitions exist in the cluster.
+If they do not exist, the operator starts without the Gateway and HTTPRoute watches and logs a warning, so no Gateway resources are reconciled until the CRDs are installed.
 
 ## Using a User-Managed Gateway
 
@@ -223,23 +208,7 @@ The referenced Gateway must not be an operator-managed Gateway. A Gateway with a
 
 ### Helm Values and Installer Command
 
-Set Gateway API mode in the Helm values:
-
-```yaml
-migrateGatewayAPI: true
-
-dex:
-  ingress:
-    enabled: false
-
-httpRoute:
-  domain: "kkp.example.com"
-  timeout: 3600s
-```
-
-When the top-level `httpRoute.gatewayName` and `httpRoute.gatewayNamespace` still point to the default `kubermatic/kubermatic` Gateway, the installer defaults them to `spec.ingress.gateway.externalGateway` for master-scoped charts such as Dex. Seed-scoped IAP and MLA charts in separate seed setups are not defaulted from the master `externalGateway`; configure their `httpRoute.gatewayName` and `httpRoute.gatewayNamespace` explicitly for the seed Gateway.
-
-You can also set them explicitly:
+Point the Helm values at the external Gateway:
 
 ```yaml
 httpRoute:
@@ -249,10 +218,12 @@ httpRoute:
   timeout: 3600s
 ```
 
-Run the installer with Gateway API migration enabled:
+If the top-level `httpRoute.gatewayName` and `httpRoute.gatewayNamespace` are omitted, the installer defaults them to `spec.ingress.gateway.externalGateway` for master-scoped charts such as Dex. Seed-scoped IAP and MLA charts in separate seed setups are not defaulted from the master `externalGateway`; configure their `httpRoute.gatewayName` and `httpRoute.gatewayNamespace` explicitly for the seed Gateway.
+
+Run the installer:
 
 ```bash
-kubermatic-installer deploy kubermatic-master --migrate-gateway-api [other options]
+kubermatic-installer deploy kubermatic-master [other options]
 ```
 
 ### Migration Behavior and Fallback
@@ -309,19 +280,21 @@ Use `http://` instead of `https://` if TLS is not configured yet.
 
 ## What You Need to Know
 
-### Two Controllers Will Run Temporarily
+### Two Controllers Run Temporarily During the Upgrade
 
-When you migrate with `--migrate-gateway-api` and use the KKP-managed Gateway, the `kubermatic-installer` deploys Envoy Gateway but does NOT remove `nginx-ingress-controller`. Both controllers will run in your cluster simultaneously.
+When you upgrade from KKP 2.30 with nginx-ingress-controller still installed, the 2.31 installer deploys Envoy Gateway but does not uninstall `nginx-ingress-controller` unless you pass `--clean-nginx-lb`. Both controllers remain in the cluster until that final run. The installer deletes the Kubermatic and Dex Ingress resources, so nginx has nothing left to serve and answers with a 404 for any request that still reaches its LoadBalancer.
 
-If `spec.ingress.gateway.externalGateway` is configured, the installer does not deploy the bundled Envoy Gateway controller. In that mode, any Gateway controller used by the external Gateway must already be installed and maintained outside of KKP.
-
-This is intentional. The installer removes the Kubermatic and Dex Ingress resources to prevent routing conflicts. The `nginx-ingress-controller` pods continue running, but they have no Ingress resources to process (except possibly non-KKP Ingress resources you may have).
-
-After you verify the migration is successful, you should manually uninstall `nginx-ingress-controller` to free up cluster resources:
+After you verify the migration and the DNS cutover, remove nginx with a final installer run:
 
 ```bash
-helm uninstall nginx-ingress-controller -n nginx-ingress-controller
+kubermatic-installer deploy kubermatic-master --clean-nginx-lb [other options]
 ```
+
+`--skip-ingress-cleanup` and `--clean-nginx-lb` cannot be combined; the installer rejects the combination. The staging flag keeps the legacy Ingresses alive, while the cleanup flag removes the controller that would serve them.
+
+If `spec.ingress.gateway.externalGateway` is configured, the installer does not deploy the bundled Envoy Gateway controller. In that mode, any Gateway controller used by the external Gateway must already be installed and maintained outside of KKP, and the legacy nginx release must be removed manually with `helm uninstall nginx-ingress-controller -n nginx-ingress-controller`.
+
+Separate seed clusters: the `kubermatic-seed` stack does not clean up a legacy nginx-ingress-controller installation. If nginx was deployed on separate seeds, remove it there manually.
 
 ### Cleanup of Old Resources
 
@@ -334,15 +307,17 @@ If the installer is not used to manage Kubermatic operations, old resources need
 
 By default, the installer performs the following cleanup steps:
 
-1. **Verifies Gateway readiness**: When migrating to Gateway API, the installer waits up to 10 minutes for the Gateway and relevant HTTPRoutes to become ready before removing old resources. This verification includes:
+1. **Verifies Gateway readiness**: The installer waits up to 10 minutes for the Gateway and relevant HTTPRoutes to become ready before removing old resources. This verification includes:
    - Gateway has valid addresses assigned for the operator-managed Gateway
    - Gateway is in `Programmed=True` status
    - Kubermatic and Dex HTTPRoutes are accepted by the active Gateway before their legacy Ingress resources are deleted
    - for `externalGateway`, the external Gateway is `Programmed=True`, the `kubermatic/kubermatic` HTTPRoute is accepted, and the `dex/dex` HTTPRoute is accepted unless the Dex chart is skipped; external Gateway addresses are not required
 
-2. **Deletes Ingress resources**: When migrating to Gateway API, the installer deletes the following Ingress resources:
+2. **Deletes Ingress resources**: The installer deletes the following Ingress resources:
    - Kubermatic Ingress (`kubermatic/kubermatic`)
    - Dex Ingress (`dex/dex`)
+
+3. **Uninstalls the legacy nginx release**: only when run with `--clean-nginx-lb`. Without the flag the installer logs a warning that the legacy release is still installed and that nginx answers with a 404, and it asks you to check whether DNS still points at the nginx LoadBalancer.
 
 This cleanup prevents routing conflicts between old and new resources.
 
@@ -363,70 +338,35 @@ kubectl delete ingress -n dex dex
 
 ## Migration Steps
 
-To migrate from nginx-ingress-controller to Gateway API:
+These steps upgrade a KKP 2.30 installation that still uses nginx-ingress-controller to KKP 2.31. If you already migrated to Gateway API on 2.30, only the verification steps and the final nginx cleanup apply to you.
 
-### Update Helm values file and KubermaticConfiguration
+### Update the Helm values file
 
 ```yaml
-migrateGatewayAPI: true
-
-# Dex configurations for Gateway API mode
-# When migrateGatewayAPI is true, ingress must be disabled
-# and httpRoute must be configured with your domain
-dex:
-  ingress:
-    enabled: false  # MUST be false when using Gateway API
 httpRoute:
   gatewayName: kubermatic
   gatewayNamespace: kubermatic
-  domain: "kkp.example.com"  # Replace with your domain
+  domain: "kkp.example.com"  # replace with your domain
   timeout: 3600s
-
-# cert-manager helm chart needs to be configured to work
-# with Gateway API resources.
-# Note: this is only needed if cert-manager is being used.
-cert-manager:
-  config:
-    apiVersion: controller.config.cert-manager.io/v1alpha1
-    kind: ControllerConfiguration
-    enableGatewayAPI: true
 ```
 
-{{% notice note %}}
+`httpRoute.domain` must be set to your `spec.ingress.domain`. Nothing defaults it, and with an empty value the Dex chart renders an HTTPRoute with an empty hostname, which fails Gateway API validation at the API server and aborts the dex Helm upgrade in the middle of the installer run.
 
-If *cert-manager* is being used to provision certificates, a new feature gate, `HTTPRouteGatewaySync` is needed to allow
-cert-manager to provision certificates.
+The `HTTPRouteGatewaySync` feature gate and the cert-manager `enableGatewayAPI` option are enabled by default and no longer need to be set.
 
-The `HTTPRouteGatewaySync` feature gate is only needed if the cert-manager is in use in order to manage TLS certificates.
+If you run external-dns, switch its sources from `ingress` to `gateway-httproute` so DNS records follow the Gateway instead of Ingress resources.
 
-```yaml
-apiVersion: kubermatic.k8c.io/v1
-kind: KubermaticConfiguration
-metadata:
-  name: kubermatic
-  namespace: kubermatic
-spec:
-  # simplified for brevity
-  #
-  # *add* the following feature gate to KubermaticConfiguration
-  featureGates:
-    HTTPRouteGatewaySync: true
-```
-
-> Please check [Automatic Certificate Provisioning](#automatic-certificate-provisioning) section for details about cert-manager migration.
-
-{{% /notice %}}
-
-### Run the kubermatic-installer with the migration flag
+### Run the kubermatic-installer
 ```bash
-kubermatic-installer deploy kubermatic-master --migrate-gateway-api [other options]
+kubermatic-installer deploy kubermatic-master [other options]
 ```
 
-_Conditional step_, by default, `kubermatic-installer` automatically deletes the old Ingress resource after migration to prevent conflicts.
-If you want to skip this automatic cleanup (for example, to manually verify before cleanup), use the `--skip-ingress-cleanup` flag:
+The installer deploys envoy-gateway-controller, waits up to 10 minutes for the Gateway and the Kubermatic and Dex HTTPRoutes to become ready, and then deletes the legacy Ingress resources.
+
+For a staged DNS cutover, keep the legacy Ingresses alive during the first pass so nginx keeps serving while Envoy stands up:
 
 ```bash
-kubermatic-installer deploy kubermatic-master --migrate-gateway-api --skip-ingress-cleanup [other options]
+kubermatic-installer deploy kubermatic-master --skip-ingress-cleanup [other options]
 ```
 
 When cleanup is skipped, both Ingress and Gateway resources will coexist.
@@ -452,28 +392,35 @@ The HTTPRoute should display:
 
 These confirm that the Gateway is operational and actively routing traffic through the defined HTTPRoutes.
 
-**Step 4: Update DNS records**
+**Next: update DNS records**
 
-After verifying the Gateway is operational, update your DNS records to ensure that the Gateway's IP is available.
+After verifying the Gateway is operational, update your DNS records so your KKP domain points to the Envoy Gateway address.
 
-**Step 5: Test access to the Kubermatic dashboard and API**
+**Next: test access to the Kubermatic dashboard and API**
 
 Verify that everything works as before with the new DNS resolution.
 
-**Step 6: Uninstall `nginx-ingress-controller` (optional but recommended)**
+**Next: remove `nginx-ingress-controller`**
+
+Run the installer once more with the cleanup flag. It deletes the nginx Helm release and frees its LoadBalancer:
 
 ```bash
-helm uninstall nginx-ingress-controller -n nginx-ingress-controller
+kubermatic-installer deploy kubermatic-master --clean-nginx-lb [other options]
 ```
 
 ## DNS and IP Considerations
 
-During migration, your cluster will have two LoadBalancer Services:
+During the upgrade from KKP 2.30, your cluster has two LoadBalancer Services:
 
-- **nginx-ingress-controller**: Service in `nginx-ingress-controller` namespace with IP like `203.0.113.50`
-- **envoy-gateway-controller**: Service in `envoy-gateway-controller` namespace with a **different IP** like `203.0.113.51`
+- **nginx-ingress-controller**: Service in the `nginx-ingress-controller` namespace with an IP like `203.0.113.50`
+- **Envoy Gateway**: Service in the `envoy-gateway-controller` namespace with a **different IP** like `203.0.113.51`. The service belongs to the Envoy data plane and its name follows the pattern `envoy-kubermatic-kubermatic-<suffix>`. The Gateway status also carries the address:
 
-The Envoy Gateway creates a NEW LoadBalancer with a different IP address. This means:
+```bash
+kubectl -n envoy-gateway-controller get svc
+kubectl -n kubermatic get gateway kubermatic -o jsonpath='{.status.addresses}'
+```
+
+The Envoy Gateway creates a new LoadBalancer with a different IP address. This means:
 
 1. **DNS must be updated** to point to the new Envoy Gateway IP
 2. **There is a downtime window** during DNS propagation if not planned carefully
@@ -496,11 +443,14 @@ To minimize or eliminate downtime, we suggest following DNS cutover strategies:
 - Increase TTL after stabilization
 
 For example, if your LoadBalancer IP changes between nginx and Envoy Gateway, or you want a gradual cutover with automatic fallback, the following explains a sample migration approach:
-1. Run migration with `--skip-ingress-cleanup`
-2. Verify Gateway is programmed and HTTPRoutes are accepted ( see [Verify the migration](#verify-the-migration) below)
+1. Run the installer with `--skip-ingress-cleanup`
+2. Verify Gateway is programmed and HTTPRoutes are accepted ( see [Verify the migration](#verify-the-migration))
 3. If LoadBalancer IP changed: Update DNS records to point to the new IP
 4. Wait for DNS propagation and verify end-to-end traffic through Gateway
-5. Once verified, delete old Ingress resources
+5. Re-run the installer without `--skip-ingress-cleanup` to delete the legacy Ingress resources
+6. Run the installer with `--clean-nginx-lb` to uninstall nginx-ingress-controller and release its LoadBalancer
+
+If you use external-dns, switch its sources from `ingress` to `gateway-httproute` before the cutover, so records are created from the Gateway and its HTTPRoutes automatically.
 
 ### Preserving Your LoadBalancer IP
 
@@ -698,42 +648,22 @@ The migration affects the following Ingress resources during migration:
 Components that use HTTPRoute resources (such as MLA monitoring components and IAP components) can leverage the HTTPRoute-Gateway sync controller for automatic certificate provisioning when the `HTTPRouteGatewaySync` feature gate is enabled.
 These components create HTTPRoute resources that attach to the shared Gateway, and the sync controller ensures the Gateway has the necessary HTTPS listeners for cert-manager.
 
-**Note**: Dex authentication is automatically migrated when you enable Gateway API mode.
-The Dex Helm chart creates an HTTPRoute resource instead of an Ingress resource when `migrateGatewayAPI: true` is set in the Helm values.
+**Note**: Dex authentication is migrated automatically.
+The Dex Helm chart creates an HTTPRoute resource instead of an Ingress resource.
 This HTTPRoute references the configured Gateway, allowing Dex to remain accessible through the same domain. By default this is the Kubermatic-managed Gateway, but when `spec.ingress.gateway.externalGateway` is configured the installer points Dex at that external Gateway unless you explicitly override the Helm values.
 
 Ensure your Dex deployment includes the following configuration:
 
-- `migrateGatewayAPI: true` in Dex Helm values
-- `ingress.enabled: false` (to avoid creating a conflicting Ingress)
 - `httpRoute.gatewayName` and `httpRoute.gatewayNamespace` correctly reference the active Gateway
+- `httpRoute.domain` is set to your domain
 
 ## Rolling Back
 
-To rollback to `nginx-ingress-controller`:
+There is no rollback to nginx-ingress-controller on KKP 2.31. The path no longer exists in the source code.
 
-1. Update Helm values
-```yaml
-# kubermatic-operator/values.yaml
-migrateGatewayAPI: false
+If the upgrade fails before it completes, you are still on KKP 2.30: restore the previous values file and re-run the 2.30 installer. Plan the upgrade so that a failed run leaves you on 2.30 rather than in a half-upgraded state, and keep the legacy nginx release until the Gateway serves traffic and DNS has been flipped.
 
-# for dex, also enable ingress
-dex:
-  ingress:
-    enabled: true
-```
-
-2. Run installer without the migration flag
-```bash
-kubermatic-installer deploy kubermatic-master [other options]
-```
-
-This will deploy `nginx-ingress-controller` (if it was uninstalled) and the operator will recreate the Ingress resource.
-
-Note: Uninstall `envoy-gateway-controller` if you no longer need it:
-```bash
-helm uninstall envoy-gateway-controller -n envoy-gateway-controller
-```
+If you migrate to a user-managed Gateway and later want to return to the KKP-managed Gateway, remove `spec.ingress.gateway.externalGateway` from the `KubermaticConfiguration` and re-run the installer. See the troubleshooting section below for CRD and admission policy leftovers that can block this switch.
 
 ## Troubleshooting
 
@@ -745,7 +675,7 @@ The HTTPRoute resource should also be checked to ensure it is properly attached 
 Use `kubectl get httproute -n kubermatic` to verify its status.
 
 If the KKP-managed Gateway shows as not ready, verify that the GatewayClass resource exists and that the Envoy Gateway controller pods are running.
-The GatewayClass should be named `kubermatic-envoy-gateway` and should exist in the `envoy-gateway-controller` namespace.
+The GatewayClass should be named `kubermatic-envoy-gateway`. It is a cluster-scoped resource, so check it with `kubectl get gatewayclass`.
 
 For an external Gateway, check the Gateway in the namespace configured by `spec.ingress.gateway.externalGateway` instead of `kubermatic/kubermatic`:
 
@@ -805,11 +735,11 @@ You should also verify that the backend services exist and are healthy. The kube
 
 If automatic certificate provisioning is not working, check the following:
 
-1. **Verify the feature gate is enabled**:
+1. **Verify the feature gate is enabled** (it is enabled by default in KKP 2.31):
 ```bash
 kubectl get deployment -n kubermatic kubermatic-master-controller-manager -o jsonpath='{.spec.template.spec.containers[0].args}' | grep HTTPRouteGatewaySync
 ```
-Should show `--feature-gates=HTTPRouteGatewaySync=true`.
+Should show `-feature-gates=HTTPRouteGatewaySync=true`.
 
 2. **Check watched namespaces**:
 ```bash
@@ -831,14 +761,14 @@ Verify that `spec.parentRefs` correctly references the active Gateway.
 
 5. **Check controller logs**:
 ```bash
-kubectl logs -n kubermatic -l app.kubermatic.io/component=master-controller-manager | grep -i kkp-httproute-gateway-sync
+kubectl logs -n kubermatic -l app.kubernetes.io/name=kubermatic-master-controller-manager | grep -i kkp-httproute-gateway-sync
 ```
 
 6. **Verify listener limit**: If you have many HTTPRoutes with unique hostnames, you may reach the 64 listener limit. Check the controller logs for "listener limit reached" errors.
 
 ## Quick Verification Commands
 
-After migration, you can use these commands to verify your installation. To check Gateway API resources for the operator-managed Gateway, run `kubectl get gateway,httproute,gatewayclass -n kubermatic`. This should show one Gateway, one HTTPRoute, and the GatewayClass.
+After migration, you can use these commands to verify your installation. To check Gateway API resources for the operator-managed Gateway, run `kubectl get gateway,httproute -n kubermatic`. This should show one Gateway and one HTTPRoute; the cluster-scoped GatewayClass is listed by `kubectl get gatewayclass`.
 
 For an external Gateway, check both the Gateway namespace and the namespaces that contain HTTPRoutes:
 

--- a/content/kubermatic/main/tutorials-howtos/networking/proxy-whitelisting/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/networking/proxy-whitelisting/_index.en.md
@@ -68,9 +68,6 @@ registry.k8s.io/provider-os/openstack-cloud-controller-manager
 registry.k8s.io/provider-os/cinder-csi-plugin
 registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
 
-# Ingress
-registry.k8s.io/ingress-nginx/controller
-registry.k8s.io/ingress-nginx/kube-webhook-certgen
 ```
 
 **`gcr.io`:**
@@ -95,8 +92,11 @@ docker.io/digitalocean/digitalocean-cloud-controller-manager
 
 #Helper
 docker.io/d3fk/s3cmd
+
+# Gateway API (Envoy Gateway controller)
 docker.io/envoyproxy/envoy
 docker.io/envoyproxy/envoy-distroless
+docker.io/envoyproxy/gateway
 docker.io/fluent/fluent-bit
 docker.io/library/alpine
 docker.io/library/busybox

--- a/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/web-terminal/_index.en.md
+++ b/content/kubermatic/main/tutorials-howtos/project-and-cluster-management/web-terminal/_index.en.md
@@ -51,12 +51,7 @@ spec:
 
 ### Connection being closed after some time
 
-KKP nginx ingress controller is configured with 1 hour proxy timeout to support long-lasting connections of webterminal. In case that you use a different ingress controller in your setup, you may need to extend the timeouts for the `kubermatic` ingress - e.g. in case of nginx ingress controller, you can add these annotations to have a 1 hour "read" and "send" timeouts:
-
-```yaml
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-```
+KKP sets a fixed 1 hour timeout on the `kubermatic` HTTPRoute to support long-lasting connections of the web terminal. If you route through a user-managed external Gateway instead, make sure its timeouts allow connections to stay open for an hour. The `httpRoute.timeout` value in your `values.yaml` applies to the Dex and IAP routes, not to the `kubermatic` HTTPRoute.
 
 ### Cannot connect to other pods or internet from the web terminal pod
 

--- a/content/kubermatic/v2.30/tutorials-howtos/networking/gateway-api-migration/_index.en.md
+++ b/content/kubermatic/v2.30/tutorials-howtos/networking/gateway-api-migration/_index.en.md
@@ -11,6 +11,10 @@ weight = 155
 
 Kubermatic Kubernetes Platform is transitioning from the nginx-ingress-controller to the Gateway API with Envoy Gateway. This document explains what this means for your deployment, why we are making this change, and how to migrate when you are ready.
 
+{{% notice note %}}
+KKP 2.31 enforces Gateway API: the nginx-ingress-controller path is removed and the migration described here happens during the upgrade to 2.31, where the `migrateGatewayAPI` value and the `--migrate-gateway-api` flag are accepted but ignored. Migrating on 2.30 first gives you full control over the timing and the DNS cutover. See the [2.30 to 2.31 upgrade guide](https://docs.kubermatic.com/kubermatic/main/installation/upgrading/upgrade-from-2.30-to-2.31/) for the upgrade-side changes.
+{{% /notice %}}
+
 This migration affects how traffic reaches the Kubermatic dashboard and API. The external behavior remains the same, but the underlying implementation changes to use modern Kubernetes standards.
 
 ## What is Changing
@@ -432,6 +436,19 @@ kubermatic-installer deploy kubermatic-master --migrate-gateway-api --skip-ingre
 When cleanup is skipped, both Ingress and Gateway resources will coexist.
 This is useful for zero-downtime migration with automatic fallback during DNS propagation.
 
+The following staged sequence keeps nginx serving while Envoy stands up and gives you a controlled DNS cutover:
+
+1. Run the installer with `--migrate-gateway-api --skip-ingress-cleanup`. Keep `dex.ingress.enabled: true` in this pass so the Dex chart does not remove the legacy Dex Ingress while Envoy stands up. This requires the Ingress hosts in your values to stay populated; a fresh config with empty hosts must keep the Ingress disabled.
+2. Verify the Gateway is programmed and the HTTPRoutes are accepted (see [Verify the migration](#verify-the-migration)).
+3. If you use external-dns, switch its sources from `ingress` to `gateway-httproute`, so records follow the Gateway instead of Ingress resources.
+4. Update your DNS records to point at the Envoy Gateway address and wait for propagation. Both paths keep working during the switch because the legacy Ingress resources still exist.
+5. Set `dex.ingress.enabled: false` and re-run the installer again with `--migrate-gateway-api` (and `migrateGatewayAPI: true` still in the values), this time without `--skip-ingress-cleanup`, to delete the legacy Ingress resources. Keep the flag and the value set on every run until you are on KKP 2.31: without them, the 2.30 installer redeploys nginx-ingress-controller and removes the Gateway resources.
+6. Uninstall `nginx-ingress-controller` manually:
+
+```bash
+helm uninstall nginx-ingress-controller -n nginx-ingress-controller
+```
+
 #### Verify the migration
 
 ```bash
@@ -745,7 +762,7 @@ The HTTPRoute resource should also be checked to ensure it is properly attached 
 Use `kubectl get httproute -n kubermatic` to verify its status.
 
 If the KKP-managed Gateway shows as not ready, verify that the GatewayClass resource exists and that the Envoy Gateway controller pods are running.
-The GatewayClass should be named `kubermatic-envoy-gateway` and should exist in the `envoy-gateway-controller` namespace.
+The GatewayClass should be named `kubermatic-envoy-gateway`. It is a cluster-scoped resource, so check it with `kubectl get gatewayclass`.
 
 For an external Gateway, check the Gateway in the namespace configured by `spec.ingress.gateway.externalGateway` instead of `kubermatic/kubermatic`:
 
@@ -809,7 +826,7 @@ If automatic certificate provisioning is not working, check the following:
 ```bash
 kubectl get deployment -n kubermatic kubermatic-master-controller-manager -o jsonpath='{.spec.template.spec.containers[0].args}' | grep HTTPRouteGatewaySync
 ```
-Should show `--feature-gates=HTTPRouteGatewaySync=true`.
+Should show `-feature-gates=HTTPRouteGatewaySync=true`.
 
 2. **Check watched namespaces**:
 ```bash
@@ -831,14 +848,14 @@ Verify that `spec.parentRefs` correctly references the active Gateway.
 
 5. **Check controller logs**:
 ```bash
-kubectl logs -n kubermatic -l app.kubermatic.io/component=master-controller-manager | grep -i kkp-httproute-gateway-sync
+kubectl logs -n kubermatic -l app.kubernetes.io/name=kubermatic-master-controller-manager | grep -i kkp-httproute-gateway-sync
 ```
 
 6. **Verify listener limit**: If you have many HTTPRoutes with unique hostnames, you may reach the 64 listener limit. Check the controller logs for "listener limit reached" errors.
 
 ## Quick Verification Commands
 
-After migration, you can use these commands to verify your installation. To check Gateway API resources for the operator-managed Gateway, run `kubectl get gateway,httproute,gatewayclass -n kubermatic`. This should show one Gateway, one HTTPRoute, and the GatewayClass.
+After migration, you can use these commands to verify your installation. To check Gateway API resources for the operator-managed Gateway, run `kubectl get gateway,httproute -n kubermatic`. This should show one Gateway and one HTTPRoute; the cluster-scoped GatewayClass is listed by `kubectl get gatewayclass`.
 
 For an external Gateway, check both the Gateway namespace and the namespaces that contain HTTPRoutes:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP 2.31 enforces Gateway API with Envoy Gateway and removes the nginx-ingress-controller path, but the docs still described nginx as the way in. This updates the affected pages in the `main` tree and the migration guide in the `v2.30` tree: the CE install guide now walks through the Gateway API flow (httpRoute values, Envoy NodePort setup, gatewayHTTPRoute ClusterIssuer, DNS against the Envoy service), the migration guide is reframed from the 2.30 opt-in flow to the enforced 2.31 upgrade with the staged DNS cutover and nginx cleanup flags, and the setup checklist, custom certificates, IAP, MLA and monitoring pages no longer reference nginx or Ingress resources. The 2.30 to 2.31 upgrade guide gains a pre-upgrade section covering the required values changes, including `httpRoute.domain`, which aborts the dex chart upgrade when left empty.

**Which issue(s) this PR fixes**:
Fixes #2140

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
```
