### PR TITLE
Note fixed OSM versions in the Flatcar known issue

### DIFF
--- a/content/kubermatic/main/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/main/architecture/known-issues/_index.en.md
@@ -41,9 +41,9 @@ When provisioning Flatcar nodes on Stable 4593.2.0 or newer, nodes may fail to j
                disableAutoUpdate: true
    ```
 
-### Planned resolution
+### Resolution
 
-A fix in Operating System Manager ([kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589)) is in progress.
+Fixed in Operating System Manager v1.9.1, v1.10.5 and newer (including all v1.11.x releases); see [kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589). KKP 2.31 ships Operating System Manager v1.11.3 and is not affected.
 
 ## Cilium 1.18 fails installation on older Ubuntu 22.04 kernels
 

--- a/content/kubermatic/v2.29/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.29/architecture/known-issues/_index.en.md
@@ -41,9 +41,9 @@ When provisioning Flatcar nodes on Stable 4593.2.0 or newer, nodes may fail to j
                disableAutoUpdate: true
    ```
 
-### Planned resolution
+### Resolution
 
-A fix in Operating System Manager ([kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589)) is in progress.
+Fixed in Operating System Manager v1.9.1, v1.10.5 and newer (including all v1.11.x releases); see [kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589). The fix was not backported to the v1.8 release line that KKP 2.29 pins, so the workarounds above remain necessary on KKP 2.29, or the Operating System Manager image tag can be overridden on the seed to a fixed version.
 
 ## Cilium 1.18 fails installation on older Ubuntu 22.04 kernels
 

--- a/content/kubermatic/v2.29/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.29/architecture/known-issues/_index.en.md
@@ -43,7 +43,7 @@ When provisioning Flatcar nodes on Stable 4593.2.0 or newer, nodes may fail to j
 
 ### Resolution
 
-Fixed in Operating System Manager v1.9.1, v1.10.5 and newer (including all v1.11.x releases); see [kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589). The fix was not backported to the v1.8 release line that KKP 2.29 pins, so the workarounds above remain necessary on KKP 2.29, or the Operating System Manager image tag can be overridden on the seed to a fixed version.
+Fixed in Operating System Manager v1.9.1, v1.10.5 and newer (including all v1.11.x releases); see [kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589).
 
 ## Cilium 1.18 fails installation on older Ubuntu 22.04 kernels
 

--- a/content/kubermatic/v2.30/architecture/known-issues/_index.en.md
+++ b/content/kubermatic/v2.30/architecture/known-issues/_index.en.md
@@ -41,9 +41,9 @@ When provisioning Flatcar nodes on Stable 4593.2.0 or newer, nodes may fail to j
                disableAutoUpdate: true
    ```
 
-### Planned resolution
+### Resolution
 
-A fix in Operating System Manager ([kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589)) is in progress.
+Fixed in Operating System Manager v1.9.1, v1.10.5 and newer (including all v1.11.x releases); see [kubermatic/operating-system-manager#589](https://github.com/kubermatic/operating-system-manager/issues/589). KKP 2.30.x patch releases from v2.30.4 pin Operating System Manager v1.10.6 or newer and are not affected; older 2.30.x patch releases pin unfixed versions, so upgrade to the latest 2.30.x patch release.
 
 ## Cilium 1.18 fails installation on older Ubuntu 22.04 kernels
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Flatcar Stable 4593.2.0 known issue (kubermatic/operating-system-manager#589) in the main, v2.30 and v2.29 trees: the fix landed in OSM v1.9.1, v1.10.5 and newer (including all v1.11.x), so the "fix is in progress" note is replaced

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
