### PR TITLE
Fix component versions for Kubermatic Virtualization

### DIFF
--- a/content/kubermatic-virtualization/main/architecture/compatibility/kubev-components-versioning/_index.en.md
+++ b/content/kubermatic-virtualization/main/architecture/compatibility/kubev-components-versioning/_index.en.md
@@ -8,15 +8,15 @@ The following list is only applicable for the Kubermatic-Virtualization version 
 on security and reliability of provided software and therefore releases updates regularly that also include component updates.
 
 
-|Kubermatic-Virtualization Component| Version |
-|:---------------------------------:|:-------:|
-|            Kubernetes             | v1.34.7 |
-|             KubeVirt              | v1.5.3  |
-| Containerized Data Importer (CDI) | v1.64.0 |
-|              KubeOVN              | v1.14.35 |
-|              KubeOne              | v1.11.1 |
-|              Kyverno              | v1.14.4 |
-|           Cert Manager            | v1.18.5 |
-|              MetalLB              | v0.15.3 |
-|             Multus CNI            | v4.2.3  |
-|             Longhorn              | v1.9.1  |
+| Kubermatic-Virtualization Component | Version  |
+|:-----------------------------------:|:--------:|
+|             Kubernetes              | v1.34.7  |
+|              KubeVirt               |  v1.6.5  |
+|  Containerized Data Importer (CDI)  | v1.64.0  |
+|               KubeOVN               | v1.15.16 |
+|              KubeOne                | v1.13.4  |
+|               Kyverno               | v1.15.3  |
+|            Cert Manager             | v1.18.5  |
+|               MetalLB               | v0.15.3  |
+|              Multus CNI             | v4.2.3   |
+|              Longhorn               | v1.9.1   |

--- a/content/kubermatic-virtualization/v1.1.0/architecture/compatibility/kubev-components-versioning/_index.en.md
+++ b/content/kubermatic-virtualization/v1.1.0/architecture/compatibility/kubev-components-versioning/_index.en.md
@@ -8,15 +8,15 @@ The following list is only applicable for the Kubermatic-Virtualization version 
 on security and reliability of provided software and therefore releases updates regularly that also include component updates.
 
 
-|Kubermatic-Virtualization Component| Version |
-|:---------------------------------:|:-------:|
-|            Kubernetes             | v1.34.7 |
-|             KubeVirt              | v1.5.3  |
-| Containerized Data Importer (CDI) | v1.64.0 |
-|              KubeOVN              | v1.14.35 |
-|              KubeOne              | v1.11.1 |
-|              Kyverno              | v1.14.4 |
-|           Cert Manager            | v1.18.5 |
-|              MetalLB              | v0.15.3 |
-|             Multus CNI            | v4.2.3  |
-|             Longhorn              | v1.9.1  |
+| Kubermatic-Virtualization Component | Version  |
+|:-----------------------------------:|:--------:|
+|             Kubernetes              | v1.34.7  |
+|              KubeVirt               |  v1.5.3  |
+|  Containerized Data Importer (CDI)  | v1.64.0  |
+|               KubeOVN               | v1.14.35 |
+|              KubeOne                | v1.12.0  |
+|               Kyverno               | v1.15.3  |
+|            Cert Manager             | v1.18.5  |
+|               MetalLB               | v0.15.3  |
+|              Multus CNI             | v4.2.3   |
+|              Longhorn               | v1.9.1   |

--- a/content/kubermatic-virtualization/v1.2.0/architecture/compatibility/kubev-components-versioning/_index.en.md
+++ b/content/kubermatic-virtualization/v1.2.0/architecture/compatibility/kubev-components-versioning/_index.en.md
@@ -8,15 +8,15 @@ The following list is only applicable for the Kubermatic-Virtualization version 
 on security and reliability of provided software and therefore releases updates regularly that also include component updates.
 
 
-|Kubermatic-Virtualization Component| Version |
-|:---------------------------------:|:-------:|
-|            Kubernetes             | v1.33.0 |
-|             KubeVirt              | v1.5.2  |
-| Containerized Data Importer (CDI) | v1.62.0 |
-|              KubeOVN              | v1.13.2 |
-|              KubeOne              | v1.11.1 |
-|              Kyverno              | v1.14.4 |
-|           Cert Manager            | v1.18.2 |
-|              MetalLB              | v0.15.2 |
-|             Multus CNI            | v4.2.2  |
-|             Longhorn              | v1.9.1  |
+| Kubermatic-Virtualization Component | Version  |
+|:-----------------------------------:|:--------:|
+|             Kubernetes              | v1.34.7  |
+|              KubeVirt               |  v1.6.5  |
+|  Containerized Data Importer (CDI)  | v1.64.0  |
+|               KubeOVN               | v1.15.16 |
+|              KubeOne                | v1.13.4  |
+|               Kyverno               | v1.15.3  |
+|            Cert Manager             | v1.18.5  |
+|               MetalLB               | v0.15.3  |
+|              Multus CNI             | v4.2.3   |
+|              Longhorn               | v1.9.1   |


### PR DESCRIPTION
Fix component versions for Kubermatic Virtualization

The v1.2.0 component table was a stale copy of an earlier release; the v1.1.0
and main tables were only partially updated. Correct all three against the
versions pinned in pkg/kubeone/types.go at the matching release tag, verified
against a running cluster where the component is actually deployed.